### PR TITLE
Fix 404

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,3 @@
   from = "/*"
   to = "/docs/404.html"
   status = 404
-
-[[redirects]]
-  from = "/docs/*"
-  to = "/docs/404.html"
-  status = 404


### PR DESCRIPTION
Fix https://github.com/okteto/docs/issues/25

### Test plan

❌ This shows the default Netlify 404:
https://www.okteto.com/docs/welcome/overview/fea

✅ This should show the default Docusaurus 404:
https://deploy-preview-26--okteto-docs.netlify.app/docs/welcome/overview/fea 