### PR TITLE
fix: wrong env_file to environment link

### DIFF
--- a/src/content/reference/stacks.mdx
+++ b/src/content/reference/stacks.mdx
@@ -161,7 +161,7 @@ entrypoint: ["yarn", "start"]
 #### env_file (string, optional)
 
 Add environment variables from a file to the containers of a service.
-Environment variables declared in the [environment section](/docs/reference/stacks/#environment-string-required) override these values. This also holds true if those values are empty or undefined.
+Environment variables declared in the [environment section](/docs/reference/stacks/#environment-string-optional) override these values. This also holds true if those values are empty or undefined.
 
 ```yaml
 env_file: .env


### PR DESCRIPTION
This PR fixes a tiny error at a link within `env_file` Okteto Stacks documentation.

1. Go to https://www.okteto.com/docs/reference/stacks/#env_file-string-optional
2. Click on `environment section`.