### PR TITLE
Revert the removing dollar sign in clipboard

### DIFF
--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, {isValidElement, useEffect, useState} from 'react';
+import clsx from 'clsx';
+import Highlight, {defaultProps} from 'prism-react-renderer';
+import copy from 'copy-text-to-clipboard';
+import Translate, {translate} from '@docusaurus/Translate';
+import {
+  useThemeConfig,
+  parseCodeBlockTitle,
+  parseLanguage,
+  parseLines,
+  ThemeClassNames,
+  usePrismTheme,
+} from '@docusaurus/theme-common';
+import styles from './styles.module.css';
+export default function CodeBlock({
+  children,
+  className: blockClassName = '',
+  metastring,
+  title,
+  language: languageProp,
+}) {
+  const {prism} = useThemeConfig();
+  const [showCopied, setShowCopied] = useState(false);
+  const [mounted, setMounted] = useState(false); // The Prism theme on SSR is always the default theme but the site theme
+  // can be in a different mode. React hydration doesn't update DOM styles
+  // that come from SSR. Hence force a re-render after mounting to apply the
+  // current relevant styles. There will be a flash seen of the original
+  // styles seen using this current approach but that's probably ok. Fixing
+  // the flash will require changing the theming approach and is not worth it
+  // at this point.
+
+  useEffect(() => {
+    setMounted(true);
+  }, []); // We still parse the metastring in case we want to support more syntax in the
+  // future. Note that MDX doesn't strip quotes when parsing metastring:
+  // "title=\"xyz\"" => title: "\"xyz\""
+
+  const codeBlockTitle = parseCodeBlockTitle(metastring) || title;
+  const prismTheme = usePrismTheme(); // <pre> tags in markdown map to CodeBlocks and they may contain JSX children.
+  // When the children is not a simple string, we just return a styled block
+  // without actually highlighting.
+
+  if (React.Children.toArray(children).some((el) => isValidElement(el))) {
+    return (
+      <Highlight
+        {...defaultProps}
+        key={String(mounted)}
+        theme={prismTheme}
+        code=""
+        language={'text'}>
+        {({className, style}) => (
+          <pre
+            /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+            tabIndex={0}
+            className={clsx(
+              className,
+              styles.codeBlockStandalone,
+              'thin-scrollbar',
+              styles.codeBlockContainer,
+              blockClassName,
+              ThemeClassNames.common.codeBlock,
+            )}
+            style={style}>
+            <code className={styles.codeBlockLines}>{children}</code>
+          </pre>
+        )}
+      </Highlight>
+    );
+  } // The children is now guaranteed to be one/more plain strings
+
+  const content = Array.isArray(children) ? children.join('') : children;
+  const language =
+    languageProp ?? parseLanguage(blockClassName) ?? prism.defaultLanguage;
+  const {highlightLines, code} = parseLines(content, metastring, language);
+
+  const handleCopyCode = () => {
+    // If the code starts with "$", remove it from the clipboard
+    const formattedCode = code.split('\n').map(line => line.charAt(0) === "$" ? line.substring(1).trim() : line).join('\n');
+    
+    copy(formattedCode);
+    setShowCopied(true);
+    setTimeout(() => setShowCopied(false), 2000);
+  };
+
+  return (
+    <Highlight
+      {...defaultProps}
+      key={String(mounted)}
+      theme={prismTheme}
+      code={code}
+      language={language ?? 'text'}>
+      {({className, style, tokens, getLineProps, getTokenProps}) => (
+        <div
+          className={clsx(
+            styles.codeBlockContainer,
+            blockClassName,
+            {
+              [`language-${language}`]:
+                language && !blockClassName.includes(`language-${language}`),
+            },
+            ThemeClassNames.common.codeBlock,
+          )}>
+          {codeBlockTitle && (
+            <div style={style} className={styles.codeBlockTitle}>
+              {codeBlockTitle}
+            </div>
+          )}
+          <div className={clsx(styles.codeBlockContent, language)}>
+            <pre
+              /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+              tabIndex={0}
+              className={clsx(className, styles.codeBlock, 'thin-scrollbar')}
+              style={style}>
+              <code className={styles.codeBlockLines}>
+                {tokens.map((line, i) => {
+                  if (line.length === 1 && line[0].content === '\n') {
+                    line[0].content = '';
+                  }
+
+                  const lineProps = getLineProps({
+                    line,
+                    key: i,
+                  });
+
+                  if (highlightLines.includes(i)) {
+                    lineProps.className += ' docusaurus-highlight-code-line';
+                  }
+
+                  return (
+                    <span key={i} {...lineProps}>
+                      {line.map((token, key) => (
+                        <span
+                          key={key}
+                          {...getTokenProps({
+                            token,
+                            key,
+                          })}
+                        />
+                      ))}
+                      <br />
+                    </span>
+                  );
+                })}
+              </code>
+            </pre>
+
+            <button
+              type="button"
+              aria-label={translate({
+                id: 'theme.CodeBlock.copyButtonAriaLabel',
+                message: 'Copy code to clipboard',
+                description: 'The ARIA label for copy code blocks button',
+              })}
+              className={clsx(styles.copyButton, 'clean-btn')}
+              onClick={handleCopyCode}>
+              {showCopied ? (
+                <Translate
+                  id="theme.CodeBlock.copied"
+                  description="The copied button label on code blocks">
+                  Copied
+                </Translate>
+              ) : (
+                <Translate
+                  id="theme.CodeBlock.copy"
+                  description="The copy button label on code blocks">
+                  Copy
+                </Translate>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+    </Highlight>
+  );
+}

--- a/src/theme/CodeBlock/styles.module.css
+++ b/src/theme/CodeBlock/styles.module.css
@@ -1,57 +1,69 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .codeBlockContainer {
   margin-bottom: var(--ifm-leading);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-lw);
 }
 
 .codeBlockContent {
   position: relative;
-  /*rtl:ignore*/
+  /* rtl:ignore */
   direction: ltr;
 }
 
 .codeBlockTitle {
-  border-top-left-radius: var(--ifm-global-radius);
-  border-top-right-radius: var(--ifm-global-radius);
   border-bottom: 1px solid var(--ifm-color-emphasis-300);
   font-size: var(--ifm-code-font-size);
   font-weight: 500;
   padding: 0.75rem var(--ifm-pre-padding);
+  border-top-left-radius: var(--ifm-global-radius);
+  border-top-right-radius: var(--ifm-global-radius);
 }
 
 .codeBlock {
-  overflow: auto;
+  margin: 0;
+  padding: 0;
   border-radius: var(--ifm-global-radius);
 }
 
-.codeBlockWithTitle {
+.codeBlockTitle + .codeBlockContent .codeBlock {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
 
+.codeBlockStandalone {
+  padding: 0;
+  border-radius: var(--ifm-global-radius);
+}
+
 .copyButton {
-  background:#191d25;
-  border: 1px solid var(--ifm-color-white);
+  background: rgb(0 0 0 / 30%);
   border-radius: var(--ifm-global-radius);
   color: var(--ifm-color-white);
-  cursor: pointer;
   opacity: 0;
   user-select: none;
   padding: 0.4rem 0.5rem;
   position: absolute;
-  right: calc(var(--ifm-pre-padding) - 2px);
-  top: calc(var(--ifm-pre-padding) - 2px);
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
   transition: opacity 200ms ease-in-out;
 }
 
-.codeBlockTitle:hover + .codeBlockContent .copyButton,
+.copyButton:focus,
 .codeBlockContent:hover > .copyButton,
-.copyButton:focus {
+.codeBlockTitle:hover + .codeBlockContent .copyButton {
   opacity: 1;
 }
 
 .codeBlockLines {
-  font: var(--ifm-code-font-size) / var(--ifm-pre-line-height)
-    var(--ifm-font-family-monospace);
-  white-space: pre;
+  font: inherit;
+  /* rtl:ignore */
   float: left;
   min-width: 100%;
   padding: var(--ifm-pre-padding);


### PR DESCRIPTION
Fix regression reported by @rberrelleza on Slack: https://okteto.slack.com/archives/C02ML9B0V7U/p1647976714726709

### Test plan

😢 
1. Go here: https://www.okteto.com/docs/getting-started/#step-3-configure-access-to-your-okteto-cloud-namespace
2. Copy the code block using the `Copy` button
3. `$` at the start of the line

😎  
1. Go here: https://deploy-preview-43--okteto-docs.netlify.app/docs/getting-started/#step-3-configure-access-to-your-okteto-cloud-namespace
2. Copy the code block using the `Copy` button
3. No `$` at the start of the line! 

### Note

Open question - but makes me wonder if we really need the `$` sign in these code blocks. The issue is that we have to `eject` the provided Docusaurus component to modify it to fits our needs. We get taken off the upgrade path and likely need to re-apply this change every time we update Docusaurus version.

Just a thought! 