### PR TITLE
Fix "exactly" grammar on previews docs

### DIFF
--- a/src/content/cloud/preview-environments/overview.mdx
+++ b/src/content/cloud/preview-environments/overview.mdx
@@ -21,6 +21,6 @@ Okteto's preview environments are powered by Kubernetes and easily integrate wit
 
 ## Prerequisites
 
-Preview environments deploy the code in a pull request to [Okteto Cloud](/docs/cloud/) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using [Okteto Pipelines](/docs/cloud/okteto-pipeline/). This is exactly the same to using Okteto Pipelines to do custom builds when using [Dev Environments](/docs/reference/development-environment/). 
+Preview environments deploy the code in a pull request to [Okteto Cloud](/docs/cloud/) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using [Okteto Pipelines](/docs/cloud/okteto-pipeline/). This is exactly the same as using Okteto Pipelines to do custom builds when using [Dev Environments](/docs/reference/development-environment/). 
 
 If you choose not to set up an Okteto Pipeline, Okteto Cloud will analyze the source code of your repository, looking for clues on how to deploy your application. You can read more about this [here](/docs/cloud/deploy-from-git/#prerequisites).


### PR DESCRIPTION
Nitpick; The current wording here sounds off. I believe it should either be:
1. _"This is **exactly the same to** …"_ (this PR)
2. _"This is **similar to**  …"_. 

I opted for 1 since the word exactly was already there.