### PR TITLE
Add Okteto CLI redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,9 @@
 [[redirects]]
+  from = "/docs/getting-started/installation"
+  to = "/docs/cloud/okteto-cli"
+  status = 301
+  
+[[redirects]]
   from = "/*"
   to = "/docs/404.html"
   status = 404


### PR DESCRIPTION
### Test plan

Visit https://deploy-preview-58--okteto-docs.netlify.app/docs/getting-started/installation/ and it should redirect to https://deploy-preview-58--okteto-docs.netlify.app/docs/cloud/okteto-cli/