### PR TITLE
Fix deploy previews 404s

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,11 @@
   from = "/docs/getting-started/installation"
   to = "/docs/cloud/okteto-cli"
   status = 301
+
+[[redirects]]
+  from = "/"
+  to = "/docs/welcome/overview/"
+  status = 301
   
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Fix https://okteto.slack.com/archives/C02SX9665RP/p1649869339218189

### Test plan

https://deploy-preview-68--okteto-docs.netlify.app/ should redirect to https://deploy-preview-68--okteto-docs.netlify.app/docs/welcome/overview/ removing the annoying 404!