### PR TITLE
Fix heading level for `endpoints`

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -268,7 +268,7 @@ The `down` command should be run from the same location as `okteto up`.
 | <em className="no-wrap">--context</em>   | (string) | The context to use (defaults to the current okteto context)             |
 | _--volumes_                              |  (bool)  | Remove persistent volumes where your local folder is synched on remote  |
 
-#### endpoints
+### endpoints
 
 List the public endpoints of your development environment.
 


### PR DESCRIPTION
`endpoints` should be an h3, not an h4

### Test plan

https://deploy-preview-82--okteto-docs.netlify.app/docs/reference/cli/#endpoints