### PR TITLE
Renaming Gitlab > GitLab in all docs

### DIFF
--- a/src/content/cloud/preview-environments/gitlab.mdx
+++ b/src/content/cloud/preview-environments/gitlab.mdx
@@ -1,17 +1,17 @@
 ---
-title: Preview Environments Using Gitlab CI/CD
-description: Create a preview environment for your application using Okteto Cloud and Gitlab
-sidebar_label: For Gitlab
+title: Preview Environments Using GitLab CI/CD
+description: Create a preview environment for your application using Okteto Cloud and GitLab
+sidebar_label: For GitLab
 id: preview-environments-gitlab
 ---
 
 import Image from '@theme/Image';
 
-This section will show you how to automatically create a preview environment for your applications using Okteto and Gitlab's preview apps.
+This section will show you how to automatically create a preview environment for your applications using Okteto and GitLab's preview apps.
 
 ## Pre-Requisites
 - An [Okteto Cloud account](https://cloud.okteto.com)
-- A [Gitlab Account](https://gitlab.com)
+- A [GitLab Account](https://gitlab.com)
 
 ## Step 1: Fork the Sample Repository
 
@@ -27,12 +27,12 @@ To deploy a preview environment with Okteto, you need to define the following en
 
 To add the environment variables:
 
-1. Navigate to your Gitlab repository.
+1. Navigate to your GitLab repository.
 1. Go to the **Settings** menu on the left, and click on the **CI/CD** entry.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="Gitlab settings, CI/CD" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="GitLab settings, CI/CD" /></p>
 1. Expand the **Variables** section, and click on the **Add Variable** button.
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-add-variables.png" alt="Gitlab settings, add variables" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-add-variables.png" alt="GitLab settings, add variables" /></p>
 
 1. Add *OKTETO_TOKEN* as the key, and your personal access token as the value, and press the *Add Variable* button.
 <p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-add-variables-okteto-token.png" alt="update variable with Okteto Token" /></p>
@@ -41,7 +41,7 @@ To add the environment variables:
 
 ## Step 3: Configure the Preview Environment on the Repository
 
-To tell Gitlab how to deploy our preview environment, you need to create a file named [`.gitlab-ci.yml`](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) file at the root of the repository.
+To tell GitLab how to deploy our preview environment, you need to create a file named [`.gitlab-ci.yml`](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) file at the root of the repository.
 
 In this file, we'll define two jobs. The `review` creates a preview environment for every branch and a `stop-review` job to destroy it when merging or deleting the branch.
 
@@ -101,7 +101,7 @@ There are two scopes for preview environments, `personal`, where the only one wh
 
 A few recommendations when creating your preview environment:
 - Create a preview environment per branch/merge request to keep things isolated. We use both `$CI_BUILD_REF_NAME` and `$OKTETO_USERNAME` in the name to ensure the namespace is unique and that we only create one per branch.
-- Pass the URL of your preview environment using the `environment.url` key. That way, the reviewers can directly go to the preview environment from Gitlab.
+- Pass the URL of your preview environment using the `environment.url` key. That way, the reviewers can directly go to the preview environment from GitLab.
 - Delete both the preview environment, and the namespace when the branch is deleted to cut down on manual deletion.
 
 > Learn more about [the okteto CLI here](/docs/reference/cli/).
@@ -112,41 +112,41 @@ Once your changes are in your repository, make a small code change and create a 
 
 After a few seconds, the workflow will update the pull request with the URL of your preview environment. Click on the *View App* button, access it, and see your changes running.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-merge-request.png" alt="Gitlab merge request" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-merge-request.png" alt="GitLab merge request" /></p>
 
 ## Step 5: Cleanup
 
 Merging the merge request or deleting the branch automatically triggers the `stop-review` job we defined in the `.gitlab-ci.yml` file. The `stop-review` job will destroy the preview environment automatically for you.
 
-##  Configure your Gitlab Runner in Okteto
+##  Configure your GitLab Runner in Okteto
 
-Okteto makes it easy to deploy your own [Gitlab Runner](https://docs.gitlab.com/runner/) from the [Okteto Catalog](/docs/cloud/deploy-from-helm/). Running your runners is useful if you find yourself constantly waiting for shared runners to be available or want to run more complex configurations.
+Okteto makes it easy to deploy your own [GitLab Runner](https://docs.gitlab.com/runner/) from the [Okteto Catalog](/docs/cloud/deploy-from-helm/). Running your runners is useful if you find yourself constantly waiting for shared runners to be available or want to run more complex configurations.
 
 ### Retrieve the Registration Information
 
-1. Navigate to your Gitlab repository.
+1. Navigate to your GitLab repository.
 1. Go to the **Settings** menu on the left, and click on the **CI/CD** entry.
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="settings for Gitlab" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="settings for GitLab" /></p>
 1. Expand the **Runners** section, and copy the URL and registration tokens.
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-registration.png" alt="Gitlab specific runners" width="650" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-registration.png" alt="GitLab specific runners" width="650" /></p>
 
-### Deploy your Gitlab Runner
+### Deploy your GitLab Runner
 
 1. Log into [Okteto Cloud](https://cloud.okteto.com).
 1. Click on the **Deploy** button on the top.
 1. Choose **Catalog** as the source, select **gitlab-runner** from the options below, and click **Deploy**.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner.png" width="600" alt="Gitlab deploy runner" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner.png" width="600" alt="GitLab deploy runner" /></p>
 
 1. On the **configuration** section, add your runner registration token to the `runnerRegistrationToken` key.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-configuration.png" width="500" alt="Gitlab deploy runner configuration" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-configuration.png" width="500" alt="GitLab deploy runner configuration" /></p>
 
-1. [Optional] If you're running your own Gitlab instance, also update the value of `gitlabUrl`.
+1. [Optional] If you're running your own GitLab instance, also update the value of `gitlabUrl`.
 1. Press the **Deploy** button.
 
-In a few seconds, your Gitlab Runner will be deployed and registered with your repository. To validate this, go back to the **Runners** section on your repository's settings, and validate that the runner is available there.
+In a few seconds, your GitLab Runner will be deployed and registered with your repository. To validate this, go back to the **Runners** section on your repository's settings, and validate that the runner is available there.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-registered.png" alt="Gitlab runner registered" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-registered.png" alt="GitLab runner registered" /></p>
 
 > To learn more about GitLab Runners, we recommend you check [their official documentation](https://docs.gitlab.com/runner/).

--- a/src/content/cloud/preview-environments/overview.mdx
+++ b/src/content/cloud/preview-environments/overview.mdx
@@ -15,7 +15,7 @@ Okteto's preview environments are powered by Kubernetes and easily integrate wit
 You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with [Okteto Self-Hosted](/docs/enterprise) if you want to run them on your Kubernetes infrastructure.
 
 - [GitHub](/docs/cloud/preview-environments/preview-environments-github/)
-- [Gitlab](/docs/cloud/preview-environments/preview-environments-gitlab/)
+- [GitLab](/docs/cloud/preview-environments/preview-environments-gitlab/)
 - Circle CI (coming soon!)
 - Bitbucket Pipelines (coming soon!)
 - CodeFresh (coming soon!)

--- a/src/content/enterprise/administration/configuration.mdx
+++ b/src/content/enterprise/administration/configuration.mdx
@@ -115,7 +115,7 @@ The `issuer` and `authorization` endpoints must match the value returned in the 
 
 The `mapping` fields are optional. Use them to configure the mapping between Okteto's user attributes and the claim coming from your authentication provider.
 
-> Your provider needs to support the [UserInfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) in order to be used with Okteto Enterprise. This authentication option follows the OpenID standard, and it has been validated with Okta, PingIdentity, and Gitlab.
+> Your provider needs to support the [UserInfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) in order to be used with Okteto Enterprise. This authentication option follows the OpenID standard, and it has been validated with Okta, PingIdentity, and GitLab.
 
 ### cloud
 
@@ -672,7 +672,7 @@ quickstarts:
         options: ["dark", "light"]
   - name: "GitHub"
     url: https://github.com/
-  - name: "Gitlab"
+  - name: "GitLab"
     url: https://gitlab.com/
   - name: "Bitbucket"
     url: https://bitbucket.org/

--- a/src/content/enterprise/digitalocean.mdx
+++ b/src/content/enterprise/digitalocean.mdx
@@ -14,7 +14,7 @@ In order to fully install Okteto Enterprise, you'll need the following:
 - A Kubernetes cluster
 - A working installation of kubectl
 - A working installation of Helm v3
-- A Gitlab OAuth application
+- A GitLab OAuth application
 - A DigitalOcean personal access token
 - A DigitalOcean space and access key
 - An Okteto Enterprise License (optional)
@@ -45,13 +45,13 @@ Follow the official documentation for [installing kubectl](https://kubernetes.io
 
 Follow the official documentation for [installing the latest release of Helm v3](https://helm.sh/docs/intro/install/).
 
-### Creating the Gitlab OAuth application
+### Creating the GitLab OAuth application
 
 Okteto Enterprise supports OAuth providers like Google, Bitbucket, GitHub, or OpenID Connect to handle user authentication. All the supported configuration settings [are described here](/docs/enterprise/administration/configuration/#auth).
 
-For this guide, we will focus on using Gitlab OpenID Connect.
+For this guide, we will focus on using GitLab OpenID Connect.
 
-Follow Gitlab's official documentation on [how to create an OAuth Client](https://docs.gitlab.com/ee/integration/oauth_provider.html).
+Follow GitLab's official documentation on [how to create an OAuth Client](https://docs.gitlab.com/ee/integration/oauth_provider.html).
 
 When creating the OAuth Application, you will need to provide the following values:
 
@@ -115,7 +115,7 @@ Using these values:
 - Your license (optional): `$LICENSE`
 - Your subdomain: `$SUBDOMAIN`
 - You Kubernetes cluster endpoint: `$KUBERNETES_ENDPOINT`. You can get it from the `server` field of your cluster kubeconfig file
-- The URL of your Gitlab instance: `$GITLAB_URL`. Use https://gitlab.com if your are using Gitlab SaaS
+- The URL of your GitLab instance: `$GITLAB_URL`. Use https://gitlab.com if your are using GitLab SaaS
 - Application ID: `$OAUTH_APPLICATION_ID` and Secret: `$OAUTH_APPLICATION_SECRET` of the OAuth 2.0 Client you created
 - The ID of the DigitalOcean region of your Kubernetes cluster: `$REGION`
 - Your space name: `$SPACE_NAME` and access key ID : `$SPACE_ACCESS_KEY_ID`

--- a/src/content/enterprise/install/releases.mdx
+++ b/src/content/enterprise/install/releases.mdx
@@ -509,7 +509,7 @@ January 30, 2021
 - The dashboard now supports running `okteto down` directly from there
 - The dashboard now gives you an option to destroy attached volumes together with the application
 - Support for Azure Storage for the Okteto Registry
-- Login with Okta, Gitlab, Ping, Dex, or any other OpenID provider
+- Login with Okta, GitLab, Ping, Dex, or any other OpenID provider
 - You can now enable/disable the cluster-wide changes that the daemon set applies
 - Dev environments will automatically use the internal network when connecting to the build and registry services
 - Upgraded to cert-manager v1.1.0

--- a/versioned_docs/version-0.10/cloud/preview-environments/gitlab.mdx
+++ b/versioned_docs/version-0.10/cloud/preview-environments/gitlab.mdx
@@ -1,17 +1,17 @@
 ---
-title: Preview Environments Using Gitlab CI/CD
-description: Create a preview environment for your application using Okteto Cloud and Gitlab
-sidebar_label: For Gitlab
+title: Preview Environments Using GitLab CI/CD
+description: Create a preview environment for your application using Okteto Cloud and GitLab
+sidebar_label: For GitLab
 id: preview-environments-gitlab
 ---
 
 import Image from '@theme/Image';
 
-This section will show you how to automatically create a preview environment for your applications using Okteto and Gitlab's preview apps.
+This section will show you how to automatically create a preview environment for your applications using Okteto and GitLab's preview apps.
 
 ## Pre-Requisites
 - An [Okteto Cloud account](https://cloud.okteto.com)
-- A [Gitlab Account](https://gitlab.com)
+- A [GitLab Account](https://gitlab.com)
 
 ## Step 1: Fork the Sample Repository
 
@@ -27,12 +27,12 @@ To deploy a preview environment with Okteto, you need to define the following en
 
 To add the environment variables:
 
-1. Navigate to your Gitlab repository.
+1. Navigate to your GitLab repository.
 1. Go to the **Settings** menu on the left, and click on the **CI/CD** entry.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="Gitlab settings, CI/CD" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="GitLab settings, CI/CD" /></p>
 1. Expand the **Variables** section, and click on the **Add Variable** button.
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-add-variables.png" alt="Gitlab settings, add variables" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-add-variables.png" alt="GitLab settings, add variables" /></p>
 
 1. Add *OKTETO_TOKEN* as the key, and your personal access token as the value, and press the *Add Variable* button.
 <p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-add-variables-okteto-token.png" alt="update variable with Okteto Token" /></p>
@@ -41,7 +41,7 @@ To add the environment variables:
 
 ## Step 3: Configure the Preview Environment on the Repository
 
-To tell Gitlab how to deploy our preview environment, you need to create a file named [`.gitlab-ci.yml`](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) file at the root of the repository.
+To tell GitLab how to deploy our preview environment, you need to create a file named [`.gitlab-ci.yml`](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) file at the root of the repository.
 
 In this file, we'll define two jobs. The `review` creates a preview environment for every branch and a `stop-review` job to destroy it when merging or deleting the branch.
 
@@ -101,7 +101,7 @@ There are two scopes for preview environments, `personal`, where the only one wh
 
 A few recommendations when creating your preview environment:
 - Create a preview environment per branch/merge request to keep things isolated. We use both `$CI_BUILD_REF_NAME` and `$OKTETO_USERNAME` in the name to ensure the namespace is unique and that we only create one per branch.
-- Pass the URL of your preview environment using the `environment.url` key. That way, the reviewers can directly go to the preview environment from Gitlab.
+- Pass the URL of your preview environment using the `environment.url` key. That way, the reviewers can directly go to the preview environment from GitLab.
 - Delete both the preview environment, and the namespace when the branch is deleted to cut down on manual deletion.
 
 > Learn more about [the okteto CLI here](/docs/0.10/reference/cli/).
@@ -112,41 +112,41 @@ Once your changes are in your repository, make a small code change and create a 
 
 After a few seconds, the workflow will update the pull request with the URL of your preview environment. Click on the *View App* button, access it, and see your changes running.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-merge-request.png" alt="Gitlab merge request" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-merge-request.png" alt="GitLab merge request" /></p>
 
 ## Step 5: Cleanup
 
 Merging the merge request or deleting the branch automatically triggers the `stop-review` job we defined in the `.gitlab-ci.yml` file. The `stop-review` job will destroy the preview environment automatically for you.
 
-##  Configure your Gitlab Runner in Okteto
+##  Configure your GitLab Runner in Okteto
 
-Okteto makes it easy to deploy your own [Gitlab Runner](https://docs.gitlab.com/runner/) from the [Okteto Catalog](/docs/0.10/cloud/deploy-from-helm/). Running your runners is useful if you find yourself constantly waiting for shared runners to be available or want to run more complex configurations.
+Okteto makes it easy to deploy your own [GitLab Runner](https://docs.gitlab.com/runner/) from the [Okteto Catalog](/docs/0.10/cloud/deploy-from-helm/). Running your runners is useful if you find yourself constantly waiting for shared runners to be available or want to run more complex configurations.
 
 ### Retrieve the Registration Information
 
-1. Navigate to your Gitlab repository.
+1. Navigate to your GitLab repository.
 1. Go to the **Settings** menu on the left, and click on the **CI/CD** entry.
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="settings for Gitlab" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd.png" alt="settings for GitLab" /></p>
 1. Expand the **Runners** section, and copy the URL and registration tokens.
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-registration.png" alt="Gitlab specific runners" width="650" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-settings-cicd-registration.png" alt="GitLab specific runners" width="650" /></p>
 
-### Deploy your Gitlab Runner
+### Deploy your GitLab Runner
 
 1. Log into [Okteto Cloud](https://cloud.okteto.com).
 1. Click on the **Deploy** button on the top.
 1. Choose **Catalog** as the source, select **gitlab-runner** from the options below, and click **Deploy**.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner.png" width="600" alt="Gitlab deploy runner" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner.png" width="600" alt="GitLab deploy runner" /></p>
 
 1. On the **configuration** section, add your runner registration token to the `runnerRegistrationToken` key.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-configuration.png" width="500" alt="Gitlab deploy runner configuration" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-configuration.png" width="500" alt="GitLab deploy runner configuration" /></p>
 
-1. [Optional] If you're running your own Gitlab instance, also update the value of `gitlabUrl`.
+1. [Optional] If you're running your own GitLab instance, also update the value of `gitlabUrl`.
 1. Press the **Deploy** button.
 
-In a few seconds, your Gitlab Runner will be deployed and registered with your repository. To validate this, go back to the **Runners** section on your repository's settings, and validate that the runner is available there.
+In a few seconds, your GitLab Runner will be deployed and registered with your repository. To validate this, go back to the **Runners** section on your repository's settings, and validate that the runner is available there.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-registered.png" alt="Gitlab runner registered" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/gitlab-deploy-runner-registered.png" alt="GitLab runner registered" /></p>
 
 > To learn more about GitLab Runners, we recommend you check [their official documentation](https://docs.gitlab.com/runner/).

--- a/versioned_docs/version-0.10/cloud/preview-environments/overview.mdx
+++ b/versioned_docs/version-0.10/cloud/preview-environments/overview.mdx
@@ -14,7 +14,7 @@ Preview environments allow you to include a live preview of your changes on ever
 Okteto's preview environments are powered by Kubernetes and easily integrate with your favorite source control and CI/CD provider. And they use [the same pipelines](/docs/0.10/cloud/okteto-pipeline/) that you already use as part of your development workflow, so it's simple to get started. You can use Preview Environments with either [Okteto Cloud](/docs/0.10/cloud) or with [Okteto Self-Hosted](/docs/0.10/enterprise) if you want to run them on your Kubernetes infrastructure.
 
 - [GitHub](/docs/0.10/cloud/preview-environments/preview-environments-github/)
-- [Gitlab](/docs/0.10/cloud/preview-environments/preview-environments-gitlab/)
+- [GitLab](/docs/0.10/cloud/preview-environments/preview-environments-gitlab/)
 - Circle CI (coming soon!)
 - Bitbucket Pipelines (coming soon!)
 - CodeFresh (coming soon!)

--- a/versioned_docs/version-0.10/enterprise/administration/configuration.mdx
+++ b/versioned_docs/version-0.10/enterprise/administration/configuration.mdx
@@ -115,7 +115,7 @@ The `issuer` and `authorization` endpoints must match the value returned in the 
 
 The `mapping` fields are optional. Use them to configure the mapping between Okteto's user attributes and the claim coming from your authentication provider.
 
-> Your provider needs to support the [UserInfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) in order to be used with Okteto Enterprise. This authentication option follows the OpenID standard, and it has been validated with Okta, PingIdentity, and Gitlab.
+> Your provider needs to support the [UserInfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) in order to be used with Okteto Enterprise. This authentication option follows the OpenID standard, and it has been validated with Okta, PingIdentity, and GitLab.
 
 ### cloud
 
@@ -697,7 +697,7 @@ quickstarts:
         options: ["dark", "light"]
   - name: "GitHub"
     url: https://github.com/
-  - name: "Gitlab"
+  - name: "GitLab"
     url: https://gitlab.com/
   - name: "Bitbucket"
     url: https://bitbucket.org/

--- a/versioned_docs/version-0.10/enterprise/digitalocean.mdx
+++ b/versioned_docs/version-0.10/enterprise/digitalocean.mdx
@@ -14,7 +14,7 @@ In order to fully install Okteto Enterprise, you'll need the following:
 - A Kubernetes cluster
 - A working installation of kubectl
 - A working installation of Helm v3
-- A Gitlab OAuth application
+- A GitLab OAuth application
 - A DigitalOcean personal access token
 - A DigitalOcean space and access key
 - An Okteto Enterprise License (optional)
@@ -45,13 +45,13 @@ Follow the official documentation for [installing kubectl](https://kubernetes.io
 
 Follow the official documentation for [installing the latest release of Helm v3](https://helm.sh/docs/intro/install/).
 
-### Creating the Gitlab OAuth application
+### Creating the GitLab OAuth application
 
 Okteto Enterprise supports OAuth providers like Google, Bitbucket, GitHub, or OpenID Connect to handle user authentication. All the supported configuration settings [are described here](/docs/0.10/enterprise/administration/configuration/#auth).
 
-For this guide, we will focus on using Gitlab OpenID Connect.
+For this guide, we will focus on using GitLab OpenID Connect.
 
-Follow Gitlab's official documentation on [how to create an OAuth Client](https://docs.gitlab.com/ee/integration/oauth_provider.html).
+Follow GitLab's official documentation on [how to create an OAuth Client](https://docs.gitlab.com/ee/integration/oauth_provider.html).
 
 When creating the OAuth Application, you will need to provide the following values:
 
@@ -115,7 +115,7 @@ Using these values:
 - Your license (optional): `$LICENSE`
 - Your subdomain: `$SUBDOMAIN`
 - You Kubernetes cluster endpoint: `$KUBERNETES_ENDPOINT`. You can get it from the `server` field of your cluster kubeconfig file
-- The URL of your Gitlab instance: `$GITLAB_URL`. Use https://gitlab.com if your are using Gitlab SaaS
+- The URL of your GitLab instance: `$GITLAB_URL`. Use https://gitlab.com if your are using GitLab SaaS
 - Application ID: `$OAUTH_APPLICATION_ID` and Secret: `$OAUTH_APPLICATION_SECRET` of the OAuth 2.0 Client you created
 - The ID of the DigitalOcean region of your Kubernetes cluster: `$REGION`
 - Your space name: `$SPACE_NAME` and access key ID : `$SPACE_ACCESS_KEY_ID`

--- a/versioned_docs/version-0.10/enterprise/install/releases.mdx
+++ b/versioned_docs/version-0.10/enterprise/install/releases.mdx
@@ -482,7 +482,7 @@ January 30, 2021
 - The dashboard now supports running `okteto down` directly from there
 - The dashboard now gives you an option to destroy attached volumes together with the application
 - Support for Azure Storage for the Okteto Registry
-- Login with Okta, Gitlab, Ping, Dex, or any other OpenID provider
+- Login with Okta, GitLab, Ping, Dex, or any other OpenID provider
 - You can now enable/disable the cluster-wide changes that the daemon set applies
 - Dev environments will automatically use the internal network when connecting to the build and registry services
 - Upgraded to cert-manager v1.1.0


### PR DESCRIPTION
Fixing a typo in doc repo.

dt-work:okteto-docs dt$ for i in $(find . -type f | xargs grep "Gitlab" |  awk -F: '{print $1}' | uniq); do sed -e 's/Gitlab/GitLab/g' $i > $i.sed && mv $i.sed $i;  done;

Signed-off-by: David 'DT' Thomas <dt@okteto.com>