### PR TITLE
update docs header to remove options

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,7 +56,7 @@ module.exports = {
           target: '_self'
         },
         {
-          href: 'https://okteto.com/community/',
+          href: 'https://community.okteto.com',
           label: 'Community',
           position: 'left',
           target: '_self'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,6 +48,12 @@ module.exports = {
           position: 'right',
           dropdownActiveClassDisabled: true,
         },
+        {
+          href: 'https://okteto.com/free-trial',
+          label: 'Get Free Trial',
+          position: 'right',
+          target: '_self'
+        },
       ],
     },
     footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,7 +31,8 @@ module.exports = {
       appId: 'RS9BKUCQCT',
       apiKey: 'ac5c1ba5f3d4e8eceb4ce860d568da39',
       indexName: 'okteto',
-      algoliaOptions: {}
+      algoliaOptions: {},
+      position: 'left',
     },
     navbar: {
       title: 'Okteto',
@@ -62,6 +63,10 @@ module.exports = {
           target: '_self'
         },
         {
+          type: 'search',
+          position: 'left',
+        },
+        {
           type: 'docsVersionDropdown',
           position: 'right',
           dropdownActiveClassDisabled: true,
@@ -70,7 +75,8 @@ module.exports = {
           href: 'https://okteto.com/free-trial',
           label: 'Get Free Trial',
           position: 'right',
-          target: '_self'
+          target: '_self',
+          className: "Button teal"
         },
       ],
     },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,6 +45,10 @@ module.exports = {
       },
       items: [
         {
+          type: 'search',
+          position: 'left',
+        },
+        {
           href: 'https://okteto.com',
           label: 'Product',
           position: 'left',
@@ -61,10 +65,6 @@ module.exports = {
           label: 'Community',
           position: 'left',
           target: '_self'
-        },
-        {
-          type: 'search',
-          position: 'left',
         },
         {
           type: 'docsVersionDropdown',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,37 +45,9 @@ module.exports = {
       items: [
         {
           type: 'docsVersionDropdown',
-          position: 'left',
+          position: 'right',
           dropdownActiveClassDisabled: true,
         },
-        {
-          to: 'getting-started/',
-          activeBasePath: 'nothing',
-          label: 'Documentation',
-          position: 'right',
-        },
-        {
-          href: 'https://okteto.com/pricing/',
-          label: 'Pricing',
-          position: 'right',
-          target: '_self'
-        },
-        {
-          href: 'https://okteto.com/blog/',
-          label: 'Blog',
-          position: 'right',
-          target: '_self'
-        },
-        {
-          href: 'https://kubernetes.slack.com/?redir=%2Fmessages%2FCM1QMQGS0%2F',
-          label: 'Slack',
-          position: 'right',
-        },
-        {
-          href: 'https://github.com/okteto/okteto',
-          label: 'GitHub',
-          position: 'right',
-        }
       ],
     },
     footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,6 +44,24 @@ module.exports = {
       },
       items: [
         {
+          href: 'https://okteto.com',
+          label: 'Product',
+          position: 'left',
+          target: '_self'
+        },
+        {
+          href: 'https://okteto.com/blog/',
+          label: 'Blog',
+          position: 'left',
+          target: '_self'
+        },
+        {
+          href: 'https://okteto.com/community/',
+          label: 'Community',
+          position: 'left',
+          target: '_self'
+        },
+        {
           type: 'docsVersionDropdown',
           position: 'right',
           dropdownActiveClassDisabled: true,

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,11 +1,12 @@
 $light-green: #25f5ee;
 $green: #00D1CA;
+$green-hover: #20b8c9;
 $secondary-green: #1CA8B8;
 $dark-green: #1CA8B8;
 
 $navy: #1a263e;
 $light-navy: #27304B;
-$dark-navy: #1E222B;
+$dark-navy: #0e203d;
 
 $cyan: #3d6bc7;
 

--- a/src/theme/Button/styles.scss
+++ b/src/theme/Button/styles.scss
@@ -68,4 +68,18 @@ a.Button,
   svg {
     margin-left: 0.5em;
   }
+
+  &.teal {
+    background-color: $green;
+    color: $dark-navy;
+
+    &:hover {
+      background-color: $green-hover;
+    }
+  }
+}
+
+/* Weird Docusaurus default styling overwrite */
+.navbar__items--right > .Button {
+  padding-right: 28px;
 }


### PR DESCRIPTION
I like the aesthetic of Gitlab docs. I think is clean and less distracting.
![image](https://user-images.githubusercontent.com/475313/167741298-7d1599b0-82ea-428b-8d2f-6818fc56c3bb.png)

@huguestennier would it be possible to copy their layout, and have the search on the left (so it's more obvious). And a more noticeable button for the free trial link?