### PR TITLE
Add Tiers badge to headings

### DIFF
--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -5,8 +5,9 @@ sidebar_label: Okteto CLI
 id: okteto-cli
 ---
 
-[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto Cloud](/docs/cloud), or [Okteto Self-Hosted](/docs/enterprise).
+import TiersList from '@theme/TiersList'
 
+[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto Cloud](/docs/cloud), or [Okteto Self-Hosted](/docs/enterprise).
 
 Learn more about the Okteto CLI
 
@@ -99,3 +100,10 @@ The installation job will run in a Debian Linux container with the following too
 The installation job is automatically configured with your Okteto and Kubernetes credentials.
 
 > Are we missing any binaries you use? [Join our community and let us know!](https://community.okteto.com/c/feature-requests).
+
+# Heading 1 <TiersList tiers="Starter Scale" />
+## Heading 2 <TiersList tiers="Starter Scale" />
+### Heading 3 <TiersList tiers="Starter Scale" />
+#### Heading 4 <TiersList tiers="Starter Scale" />
+##### Heading 5 <TiersList tiers="Starter Scale" />
+###### Heading 6 <TiersList tiers="Starter Scale" />

--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -5,8 +5,6 @@ sidebar_label: Okteto CLI
 id: okteto-cli
 ---
 
-import TiersList from '@theme/TiersList'
-
 [Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto Cloud](/docs/cloud), or [Okteto Self-Hosted](/docs/enterprise).
 
 Learn more about the Okteto CLI
@@ -100,27 +98,3 @@ The installation job will run in a Debian Linux container with the following too
 The installation job is automatically configured with your Okteto and Kubernetes credentials.
 
 > Are we missing any binaries you use? [Join our community and let us know!](https://community.okteto.com/c/feature-requests).
-
-# Heading 1<TiersList tiers="Starter Scale" />
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
-
-## Heading 2<TiersList tiers="Self-Hosted Enterprise" />
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
-
-### Heading 3<TiersList tiers="Scale" />
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
-
-#### Heading 4<TiersList tiers="All" />
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
-
-##### Heading 5<TiersList tiers="Cloud" />
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
-
-###### Heading 6<TiersList tiers="Starter Scale" />
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.

--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -101,9 +101,26 @@ The installation job is automatically configured with your Okteto and Kubernetes
 
 > Are we missing any binaries you use? [Join our community and let us know!](https://community.okteto.com/c/feature-requests).
 
-# Heading 1 <TiersList tiers="Starter Scale" />
-## Heading 2 <TiersList tiers="Starter Scale" />
-### Heading 3 <TiersList tiers="Starter Scale" />
-#### Heading 4 <TiersList tiers="Starter Scale" />
-##### Heading 5 <TiersList tiers="Starter Scale" />
-###### Heading 6 <TiersList tiers="Starter Scale" />
+# Heading 1<TiersList tiers="Starter Scale" />
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
+
+## Heading 2<TiersList tiers="Self-Hosted Enterprise" />
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
+
+### Heading 3<TiersList tiers="Scale" />
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
+
+#### Heading 4<TiersList tiers="All" />
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
+
+##### Heading 5<TiersList tiers="Cloud" />
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.
+
+###### Heading 6<TiersList tiers="Starter Scale" />
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas efficitur lectus dolor, nec sollicitudin mauris bibendum sit amet. Fusce posuere auctor orci ut mattis.

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -252,6 +252,9 @@ h1, h2, h3, h4, h5, h6 {
     margin-top: calc(2 * var(--ifm-leading));
     line-height: normal;
     letter-spacing: -.08rem;
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5em;
   }
 
   h1:first-child {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -252,9 +252,6 @@ h1, h2, h3, h4, h5, h6 {
     margin-top: calc(2 * var(--ifm-leading));
     line-height: normal;
     letter-spacing: -.08rem;
-    display: flex;
-    align-items: flex-end;
-    gap: 0.5em;
   }
 
   h1:first-child {

--- a/src/theme/TiersList/index.js
+++ b/src/theme/TiersList/index.js
@@ -1,19 +1,25 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 import "./styles.scss";
 
-function TiersList({tiers}) {
+const TiersList = ({tiers}) => {
+
+  if(typeof tiers !== 'string') return null;
 
   const tiersArray = tiers.split(" ");
 
-  console.log(tiersArray);
   return (
     <div className="TiersList">
-    {tiersArray.map(tier => (
-      <span className="Tier">{tier}</span>
-    ))}
+      {tiersArray.length > 0 && tiersArray.map((tier, index) => (
+        <span className="Tier" key={`${tier}-${index}`}>{tier}</span>
+      ))}
     </div>
   );
 }
+
+TiersList.propTypes = {
+  tiers: PropTypes.string.isRequired
+};
 
 export default TiersList;

--- a/src/theme/TiersList/index.js
+++ b/src/theme/TiersList/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+import "./styles.scss";
+
+function TiersList({tiers}) {
+
+  const tiersArray = tiers.split(" ");
+
+  console.log(tiersArray);
+  return (
+    <div className="TiersList">
+    {tiersArray.map(tier => (
+      <span className="Tier">{tier}</span>
+    ))}
+    </div>
+  );
+}
+
+export default TiersList;

--- a/src/theme/TiersList/styles.scss
+++ b/src/theme/TiersList/styles.scss
@@ -1,8 +1,9 @@
 .TiersList {
   display: inline-flex;
   gap: 0.5rem;
-  margin-bottom: 0.15em;
   line-height: 1;
+  vertical-align: middle;
+  margin-left: 0.5em;
 }
 
 .TiersList .Tier {

--- a/src/theme/TiersList/styles.scss
+++ b/src/theme/TiersList/styles.scss
@@ -1,0 +1,17 @@
+.TiersList {
+  display: inline-flex;
+  gap: 0.5rem;
+  margin-bottom: 0.15em;
+  line-height: 1;
+}
+
+.TiersList .Tier {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  padding: 0.25em 0.5em;
+  background-color: #00d1ca17;
+  border-radius: 6px;
+  display: inline-block;
+  font-weight: bold;
+  letter-spacing: -0.04em;
+}


### PR DESCRIPTION
Add the ability to show tiers badge next to headings

### Usage

```js
<TiersList tiers="Starter Scale Self-host" />
```

### Test plan

https://deploy-preview-99--okteto-docs.netlify.app/docs/cloud/okteto-cli/#heading-2 (will remove before we merge)