### PR TITLE
Added pipeline relative path note

### DIFF
--- a/src/content/cloud/okteto-pipeline.mdx
+++ b/src/content/cloud/okteto-pipeline.mdx
@@ -7,6 +7,8 @@ id: okteto-pipeline
 
 Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto Cloud](/docs/cloud/). You might want to use them if Okteto Cloud cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
 
+The okteto pipeline is executed relative to the path where the manifest is located. This means, if the manifest is at any subfolder, the pipeline will use the context of the subfolder where the manifest is defined.
+
 ### Example okteto-pipeline.yml
 
 ```yaml

--- a/src/content/cloud/okteto-pipeline.mdx
+++ b/src/content/cloud/okteto-pipeline.mdx
@@ -7,7 +7,7 @@ id: okteto-pipeline
 
 Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto Cloud](/docs/cloud/). You might want to use them if Okteto Cloud cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
 
-The okteto pipeline is executed relative to the path where the manifest is located. This means, if the manifest is at any subfolder, the pipeline will use the context of the subfolder where the manifest is defined.
+The Okteto Pipeline is executed relative to the path where the manifest is located. This means, if the manifest is at any subfolder, the pipeline will use the context of the subfolder where the manifest is defined.
 
 ### Example okteto-pipeline.yml
 

--- a/src/content/enterprise/install/releases.mdx
+++ b/src/content/enterprise/install/releases.mdx
@@ -31,7 +31,7 @@ May 19, 2022
 
 ### Breaking changes
 - Ingresses using the `kubernetes.io/ingress.class` annotation will be automatically updated by the okteto webhook and saved as `spec.ingressClassName` with the annotation removed
-- Okteto Pipelines are executed relative to the path where manifest is located.
+- Okteto Pipelines are executed relative to the path where manifest is located, all relative paths at the manifest will refer to this location.
 
 ## 0.11.1
 May 6, 2022

--- a/src/content/enterprise/install/releases.mdx
+++ b/src/content/enterprise/install/releases.mdx
@@ -31,7 +31,7 @@ May 19, 2022
 
 ### Breaking changes
 - Ingresses using the `kubernetes.io/ingress.class` annotation will be automatically updated by the okteto webhook and saved as `spec.ingressClassName` with the annotation removed
-- Okteto Pipelines are executed relative to the path where manifest is located, all relative paths at the manifest will refer to this location.
+- Okteto Pipelines are executed relative to the path where manifest is located. All relative paths in the manifest will use the context of the subfolder where the manifest is defined
 
 ## 0.11.1
 May 6, 2022

--- a/src/content/enterprise/install/releases.mdx
+++ b/src/content/enterprise/install/releases.mdx
@@ -31,6 +31,7 @@ May 19, 2022
 
 ### Breaking changes
 - Ingresses using the `kubernetes.io/ingress.class` annotation will be automatically updated by the okteto webhook and saved as `spec.ingressClassName` with the annotation removed
+- Okteto Pipelines are executed relative to the path where manifest is located.
 
 ## 0.11.1
 May 6, 2022

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -195,6 +195,8 @@ Deploy your development environment by running the commands specified in the `de
 If the images in the `build` section don't exist, `okteto deploy` automatically builds and pushes all these images.
 If the repositories in the `dependencies` section haven't been deployed yet, `okteto deploy` deploys these dependencies automatically.
 
+The command is executed relative to the path where the manifest is located. This means, that if the manifest is at any subfolder, the pipeline will use the context of the subfolder where the manifest is defined.
+
 ```console
 $ okteto deploy
 ```

--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -114,6 +114,8 @@ dependencies:
     wait: true
 ```
 
+When specifying the manifest path, the dependency deployment will use as context this path where the manifest is defined.
+
 ### deploy ([string], optional)
 
 A list of commands to deploy your development environment.

--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -114,7 +114,7 @@ dependencies:
     wait: true
 ```
 
-When specifying the manifest path, the dependency deployment will use as context this path where the manifest is defined.
+When specifying the manifest path, the dependency deployment will use this path where the manifest is defined as the context.
 
 ### deploy ([string], optional)
 


### PR DESCRIPTION
When deploying a pipeline, now the file path is relative to the manifest folder

Fix https://github.com/okteto/app/issues/3901 