### PR TITLE
docs: add note regarding the use of CNAME records

### DIFF
--- a/src/content/enterprise/eks.mdx
+++ b/src/content/enterprise/eks.mdx
@@ -257,6 +257,8 @@ okteto-ingress-nginx-controller  LoadBalancer   10.0.7.73    a519c8b3b27f94...el
 
 You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. In Route 53, this is done by creating an `A` record with the name  `*`, pointing to the alias of the Elastic Load Balancer.
 
+> Note: avoid using a `CNAME` record for `*` pointing to the public hostname of the Elastic Load Balancer, as it will block the cert-manager default capability for issuing/renewing certificates via ACME dns01.
+
 ### Retrieve the Buildkit IP address
 
 You can use `kubectl` to fetch the address that has been dynamically allocated by EKS to the Buildkit instance you've just installed and configured as a part of Okteto Enterprise:

--- a/versioned_docs/version-0.10/enterprise/eks.mdx
+++ b/versioned_docs/version-0.10/enterprise/eks.mdx
@@ -257,6 +257,8 @@ okteto-ingress-nginx-controller  LoadBalancer   10.0.7.73    a519c8b3b27f94...el
 
 You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. In Route 53, this is done by creating an `A` record with the name  `*`, pointing to the alias of the Elastic Load Balancer.
 
+> Note: avoid using a `CNAME` record for `*` pointing to the public hostname of the Elastic Load Balancer, as it will block the cert-manager default capability for issuing/renewing certificates via ACME dns01.
+
 ### Retrieve the Buildkit IP address
 
 You can use `kubectl` to fetch the address that has been dynamically allocated by EKS to the Buildkit instance you've just installed and configured as a part of Okteto Enterprise:

--- a/versioned_docs/version-0.11/enterprise/eks.mdx
+++ b/versioned_docs/version-0.11/enterprise/eks.mdx
@@ -257,6 +257,8 @@ okteto-ingress-nginx-controller  LoadBalancer   10.0.7.73    a519c8b3b27f94...el
 
 You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. In Route 53, this is done by creating an `A` record with the name  `*`, pointing to the alias of the Elastic Load Balancer.
 
+> Note: avoid using a `CNAME` record for `*` pointing to the public hostname of the Elastic Load Balancer, as it will block the cert-manager default capability for issuing/renewing certificates via ACME dns01.
+
 ### Retrieve the Buildkit IP address
 
 You can use `kubectl` to fetch the address that has been dynamically allocated by EKS to the Buildkit instance you've just installed and configured as a part of Okteto Enterprise:


### PR DESCRIPTION
This PR adds a note discouraging the use of `CNAME` records for `*` that point to the public hostname of AWS Elastic Load Balancers.

Okteto Enterprise automatic certificate management uses cert-manager to issue the wildcard certificate used by the deployment. This certificate is issued by Let's Encrypt as default and uses ACME dns01 verification challenge, which consists of creating a `TXT` dns record for the Okteto domain.

If the user creates a `CNAME` dns record for `*`, it will shadow any other dns records, including `TXT`. This blocks the issue/renewal process as the verification can no longer be achieved.

Reasons why a user may set a `CNAME` record include the scenario where they manage DNS from a different AWS account, making it impossible to set an `A` dns record with an alias, or where they manage DNS with a different service/software rather than AWS Route53.

The best way to solve the issue for these scenarios would be to use AWS Network Load Balancers, which expose a public static IP.