### PR TITLE
Fix the extended notation at dependencies in manifest

### DIFF
--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -103,7 +103,8 @@ There is also an extended notation to configure how to deploy your dependency:
 
 ```yaml
 dependencies:
-  - repository: https://github.com/okteto/movies-frontend
+  frontend:
+    repository: https://github.com/okteto/movies-frontend
     manifest: okteto.yml
     branch: main
     variables:


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Documented extended notation for dependencies at manifest 2.0 was not correct.