### PR TITLE
Okteto Enterprise 0.13.0 release notes

### DIFF
--- a/src/content/enterprise/install/releases.mdx
+++ b/src/content/enterprise/install/releases.mdx
@@ -10,13 +10,13 @@ TBD
 
 ### Features
 - Add Access Control to [Volume Snapshots](/docs/enterprise/administration/volume-snapshots/)
-- Add link to Community [Community](https://community.okteto.com) in help menu.
-- Inject OKTETO_NAMESPACE and OKTETO_DOMAIN environment variables in every pod
+- Add link to the [Community website](https://community.okteto.com) in the help menu.
+- Inject `OKTETO_NAMESPACE` and `OKTETO_DOMAIN` environment variables in every pod
 - Remove Namespace limit on licenses
 
 ### Improvements
 - Upgrade Okteto CLI to [2.3.3](https://github.com/okteto/okteto/releases/tag/2.3.3)
-- Upgrade registry to [2.8.1](https://github.com/distribution/distribution/releases/tag/v2.8.1)
+- Upgrade Okteto registry to [2.8.1](https://github.com/distribution/distribution/releases/tag/v2.8.1)
 - Better deduplication in secrets query. Prioritize user secrets over cluster secrets.
 - Handle PVC update in the mutating webhook. Fixes Okteto CLI issue [#2599](https://github.com/okteto/okteto/issues/2599)
 - Upgrade crypto package. Fixes [CVE-2022-27191](https://access.redhat.com/security/cve/CVE-2022-27191)

--- a/src/content/enterprise/install/releases.mdx
+++ b/src/content/enterprise/install/releases.mdx
@@ -5,6 +5,28 @@ sidebar_label: Release Notes
 id: releases
 ---
 
+## 0.13.0
+TBD
+
+### Features
+- Add Access Control to [Volume Snapshots](/docs/enterprise/administration/volume-snapshots/)
+- Add link to Community [Community](https://community.okteto.com) in help menu.
+- Inject OKTETO_NAMESPACE and OKTETO_DOMAIN environment variables in every pod
+- Remove Namespace limit on licenses
+
+### Improvements
+- Upgrade Okteto CLI to [2.3.3](https://github.com/okteto/okteto/releases/tag/2.3.3)
+- Upgrade registry to [2.8.1](https://github.com/distribution/distribution/releases/tag/v2.8.1)
+- Better deduplication in secrets query. Prioritize user secrets over cluster secrets.
+- Handle PVC update in the mutating webhook. Fixes Okteto CLI issue [#2599](https://github.com/okteto/okteto/issues/2599)
+- Upgrade crypto package. Fixes [CVE-2022-27191](https://access.redhat.com/security/cve/CVE-2022-27191)
+- Upgrade frontend nginx server to alpine 1.22. Fixes [CVE-2022-27405](https://access.redhat.com/security/cve/CVE-2022-27405)
+
+### Bugfixes
+- Fix panic in Preview Environment query for repos with invalid format
+- Fix component running state calculation for pods with many retries. They previously stayed in the error state.
+- Fix UI bug with Pull Request names in Preview environment list for non github URLs.
+
 ## 0.12.0
 May 19, 2022
 

--- a/src/content/enterprise/install/releases.mdx
+++ b/src/content/enterprise/install/releases.mdx
@@ -6,7 +6,7 @@ id: releases
 ---
 
 ## 0.13.0
-TBD
+Jun 16, 2022
 
 ### Features
 - Add Access Control to [Volume Snapshots](/docs/enterprise/administration/volume-snapshots/)


### PR DESCRIPTION
Okteto Enterprise 0.13 Release Notes. Reviewers taken from the changelog between 0.12 and 0.13. Please review in case there's something missing about your changes that should be added (or removed)