### PR TITLE
removed references of Okteto Cloud

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -21,7 +21,6 @@ module.exports = {
     "Dev Environments": [
       "reference/development-environments",
       "cloud/okteto-cli",
-      "cloud",
       {
         "type": "category",
         "label": "Deploying",

--- a/src/content/api.mdx
+++ b/src/content/api.mdx
@@ -11,7 +11,7 @@ import Image from '@theme/Image';
 
 ## The GraphQL API endpoint
 
-If you using Okteto Cloud, the endpoint is available at:
+If you using Okteto, the endpoint is available at:
 ```
 https://cloud.okteto.com/graphql
 ```

--- a/src/content/cloud.mdx
+++ b/src/content/cloud.mdx
@@ -1,14 +1,14 @@
 ---
-title: Okteto Cloud
-description: Okteto Cloud gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
-sidebar_label: Okteto Cloud
+title: Okteto
+description: Okteto gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
+sidebar_label: Okteto
 id: cloud
 ---
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
-Develop your applications in Okteto Cloud and forget about slow and tedious local development forever.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
+Develop your applications in Okteto and forget about slow and tedious local development forever.
 
-With Okteto Cloud you can:
+With Okteto you can:
 
 - Deploy your development environments with the [Okteto CLI](/docs/cloud/okteto-cli/) or from your [Git Repositories](/docs/cloud/deploy-from-git/).
 - Configure [Secrets](/docs/cloud/secrets/) and prevent secure credentials from being stored in version control.
@@ -19,10 +19,10 @@ With Okteto Cloud you can:
 - Download your [Kubernetes Credentials](/docs/cloud/credentials/) to access your namespaces with `kubectl`, `helm`, or any other CLI tool.
 - Visualize your workloads in a Developer-focused Kubernetes dashboard.
 
-Head over to our [5 minutes getting started guide](/docs/cloud/okteto-cli/) and see how you can use Okteto Cloud and Okteto CLI to start developing applications the cloud-native way!
+Head over to our [5 minutes getting started guide](/docs/cloud/okteto-cli/) and see how you can use Okteto and Okteto CLI to start developing applications the cloud-native way!
 
-The [FAQs](/docs/reference/faqs) section also covers some common questions you might have regarding Okteto Cloud.
+The [FAQs](/docs/reference/faqs) section also covers some common questions you might have regarding Okteto.
 
-## Okteto Cloud in your own infrastructure
+## Okteto in your own infrastructure
 
-Interested in running Okteto Cloud in your own infrastructure? [Okteto Enterprise](/docs/enterprise/) allows you to run and host Okteto Cloud on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).
+Interested in running Okteto in your own infrastructure? [Okteto Enterprise](/docs/enterprise/) allows you to run and host Okteto on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).

--- a/src/content/cloud/build.mdx
+++ b/src/content/cloud/build.mdx
@@ -1,19 +1,19 @@
 ---
 title: Okteto Build Service
-description: The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure
+description: The Okteto Build service allows you to build your development images directly in the Okteto infrastructure
 sidebar_label: Build Service
 id: build
 ---
 
 import Image from '@theme/Image';
 
-The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto Cloud.
+The Okteto Build service allows you to build your development images directly in the Okteto infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto.
 
 ## Build images
 
 You'll need the [okteto CLI](/docs/cloud/okteto-cli/) in order to access the Okteto Build Service.
 
-Once the Okteto CLI is installed, run `okteto context` and select the Okteto Cloud option to download the credentials and certificates required to access the Okteto Build service.
+Once the Okteto CLI is installed, run `okteto context` and select the Okteto option to download the credentials and certificates required to access the Okteto Build service.
 
 After that, run the `okteto build` command to build and push your images.
 
@@ -27,4 +27,4 @@ You can build and push images to any available docker registry. If you're not us
 
 ## Quotas
 
-Access to the Okteto Registry is included with all Okteto Cloud accounts. Developer accounts get 15 builds per day for free.
+Access to the Okteto Registry is included with all Okteto accounts. Developer accounts get 15 builds per day for free.

--- a/src/content/cloud/credentials.mdx
+++ b/src/content/cloud/credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: Download your Kubernetes credentials
-description: Download your Kubernetes credentials and start developing your applications in Okteto Cloud
+description: Download your Kubernetes credentials and start developing your applications in Okteto
 sidebar_label: Kubernetes Credentials
 id: credentials
 ---
@@ -10,18 +10,18 @@ import Button from '@theme/Button';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Download your Kubernetes credentials and start developing your applications in Okteto Cloud with your favorite CLI tools.
+Download your Kubernetes credentials and start developing your applications in Okteto with your favorite CLI tools.
 There are two different ways of downloading your Kubernetes credentials:
 
 - Download your Kubernetes credentials [using the Okteto CLI](#download-your-kubernetes-credentials-using-the-okteto-cli).
 
-- Download your Kubernetes credentials [from the Okteto Cloud UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Download your Kubernetes credentials [from the Okteto UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Download your Kubernetes credentials using the Okteto CLI
 
 If this is your first time using the Okteto CLI, install it following [this guide](/docs/cloud/okteto-cli/).
 
-The Okteto CLI can download your Kubernetes credentials from Okteto Cloud. To do this, run the `okteto context` command:
+The Okteto CLI can download your Kubernetes credentials from Okteto. To do this, run the `okteto context` command:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -32,9 +32,9 @@ Authentication will continue in your default browser
  ✓  Context 'cloud.okteto.com' created
 ```
 
-If you're not logged into Okteto Cloud yet, it will also run the login sequence.
+If you're not logged into Okteto yet, it will also run the login sequence.
 
-Once your okteto context is configured to access Okteto Cloud, run the following command:
+Once your okteto context is configured to access Okteto, run the following command:
 
 ```console
 $ okteto kubeconfig
@@ -47,7 +47,7 @@ Updated kubernetes context 'cloud_okteto_com/cindy' in '/Users/cindy/.kube/confi
 The `okteto kubeconfig` command adds your Kubernetes credentials to your kubeconfig file, and sets it as the current Kubernetes context.
 Once you do this, you'll have full access to your Kubernetes namespace with `kubectl`, `helm` or any other CLI tool.
 
-## Download your Kubernetes credentials from the Okteto Cloud UI
+## Download your Kubernetes credentials from the Okteto UI
 
 Download your Kubernetes credentials and save them in a well-known location:
 
@@ -57,7 +57,7 @@ Download your Kubernetes credentials and save them in a well-known location:
   </Button>
 </p>
 
-From the Okteto Cloud UI you should also find your credentials in the `Settings > Setup` section.
+From the Okteto UI you should also find your credentials in the `Settings > Setup` section.
 
 Once downloaded, point your `KUBECONFIG` environment variable to the credentials file:
 
@@ -97,7 +97,7 @@ No resources found.
 
 ## Using your Kubernetes credentials
 
-Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 For example, you could use `kubectl` to deploy our `hello-world` application:
 
@@ -105,5 +105,5 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-[Okteto Cloud](/docs/cloud) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-Take a look at the [FAQs](/docs/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+[Okteto](/docs/reference/development-environments) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+Take a look at the [FAQs](/docs/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/src/content/cloud/custom-domains.mdx
+++ b/src/content/cloud/custom-domains.mdx
@@ -1,38 +1,38 @@
 ---
 title: Custom Domain Names for your Applications
-description: Use a custom domain name for your applications with Okteto Cloud
+description: Use a custom domain name for your applications with Okteto
 sidebar_label: Custom Domain Names
 id: custom-domains
 ---
 
 import Image from '@theme/Image';
 
-By default, an application deployed in Okteto Cloud will be available at its Okteto Cloud domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
+By default, an application deployed in Okteto will be available at its Okteto domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
 
 For example, an application called `hello` deployed in the namespace `cindylopez` will be available at `https://hello-cindylopez.cloud.okteto.net`.
 
-To make your applications available on a non-Okteto Cloud domain (for example: `myapp.com`), you can add a **custom domain to your Okteto Cloud namespace**.
+To make your applications available on a non-Okteto domain (for example: `myapp.com`), you can add a **custom domain to your Okteto namespace**.
 This feature is part of the Okteto Developer Pro plan. If you haven't tried it yet, [start your 14-day free trial here](https://cloud.okteto.com/#/settings/plans/pro-upgrade).
 
-Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto Cloud endpoints.
+Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto endpoints.
 
 > Okteto does not provide a domain registration service (for registering a custom domain name) or a DNS provider service.
 
 ## Add a Custom Domain Name to your Application.
 
-Perform the following tasks to register your custom domain in your Okteto Cloud account:
+Perform the following tasks to register your custom domain in your Okteto account:
 
 1. Confirm that you own the custom domain name. Need a custom domain name? You can buy one with a domain registration service.
 
-2. Register your custom domain with Okteto Cloud by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
+2. Register your custom domain with Okteto by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
 
-3. Update your DNS configuration so your custom domain points to Okteto Cloud's DNS target.
+3. Update your DNS configuration so your custom domain points to Okteto's DNS target.
 
 ## Configure your Application to use your Custom Domain
 
-Once your domain has been registered with your Okteto Cloud account, it's time to put it to use.
+Once your domain has been registered with your Okteto account, it's time to put it to use.
 
-If you're using Okteto Cloud's [auto-ingress](/docs/cloud/ssl/) or [generate the host](/docs/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
+If you're using Okteto's [auto-ingress](/docs/cloud/ssl/) or [generate the host](/docs/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
 
 For example, if your application's endpoint was `https://hello-cindylopez.cloud.okteto.net` and you added the custom domain `myapp.com`, after redeployment your application's endpoint will be `https://hello.myapp.com`.
 
@@ -40,7 +40,7 @@ For example, if your application's endpoint was `https://hello-cindylopez.cloud.
 
 If you want to make your application available in the root domain you provided, you'll need to make a small change to your manifests.
 
-If you're using Okteto Cloud's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
+If you're using Okteto's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
 
 ```yaml
 apiVersion: v1

--- a/src/content/cloud/deploy-from-git.mdx
+++ b/src/content/cloud/deploy-from-git.mdx
@@ -17,13 +17,13 @@ Please make sure to configure your Git repositories with the [appropriate manife
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
 A dialog will open asking for a Git repository to deploy. Make sure that "**Git URL**" is selected as the source.
 Type the URL for the Movies App repo (https://github.com/okteto/movies), pick a branch, and click **Launch**:
 
 <p align="center"><Image src="/docs/cloud/images/deploy-git.png" alt="deploy from git" width="650" /></p>
 
-When you launch a dev environment using a Git repository, Okteto Cloud will analyze your repo and automatically deploy it running `okteto deploy --build`.
+When you launch a dev environment using a Git repository, Okteto will analyze your repo and automatically deploy it running `okteto deploy --build`.
 In the example above, Okteto will install the chart of the Movies App with Helm.
 
 > Check the [Okteto Manifest](/docs/reference/manifest/) to learn more about how to configure your development environment deployment with an `okteto.yml` file.
@@ -65,7 +65,7 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in GitHub README files, documentation sites, or pretty much anywhere that renders an HTML file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 

--- a/src/content/cloud/deploy-from-helm.mdx
+++ b/src/content/cloud/deploy-from-helm.mdx
@@ -7,12 +7,12 @@ id: deploy-from-helm
 
 import Image from '@theme/Image';
 
-You can launch additional services for your development environments on Okteto Cloud using Helm repositories.
+You can launch additional services for your development environments on Okteto using Helm repositories.
 Okteto automates all the processes needed to deploy, configure, upgrade, and destroy your Helm releases, so you can focus on building amazing applications.
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
 Switch to the *From Chart* tab and a list of available services to deploy on your namespace will be shown.
 The list will look something like this:
 
@@ -22,7 +22,7 @@ Click on the service you want to deploy (we'll be using **Redis** in this exampl
 
 <p align="center"><Image src="/docs/cloud/images/deploy-redis.png" alt="deploy redis" width="650" /></p>
 
-When you click on **Launch**, Okteto Cloud will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
+When you click on **Launch**, Okteto will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
 
 As soon as your Helm release is deployed, you'll see its state in the UI. The UI will automatically update as the different components are created. Your Helm release will be ready to go once it reaches the `Success` state.
 
@@ -30,7 +30,7 @@ As soon as your Helm release is deployed, you'll see its state in the UI. The UI
 
 ## Redeploy
 
-You can also redeploy your Helm releases from Okteto Cloud. This is useful when you want to upgrade or redeploy your services.
+You can also redeploy your Helm releases from Okteto. This is useful when you want to upgrade or redeploy your services.
 
 Click on **Redeploy** on the right of your Helm release.
 The *Redeploy Helm Chart* dialog shows you the available versions, as well as the configuration used to deploy the current version of the Helm release.
@@ -48,10 +48,10 @@ A confirmation dialog will pop up. Click on the **Destroy** button to confirm yo
 <p align="center"><Image src="/docs/cloud/images/destroy-helm.png" alt="Destroy Helm releases" width="450" /></p>
 
 In this case, the persistent volume created by Redis won't be deleted to avoid losing any sensitive data.
-You can delete it manually from the Okteto Cloud UI if you want.
+You can delete it manually from the Okteto UI if you want.
 
 ## Application Catalog
 
-The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto Cloud.
+The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto.
 
 You can also [bring your own Helm repository](/docs/tutorials/repos/) to the catalog and get the same one-click deployment experience for your own services.

--- a/src/content/cloud/deploy-from-terminal.mdx
+++ b/src/content/cloud/deploy-from-terminal.mdx
@@ -7,11 +7,11 @@ id: deploy-from-terminal
 
 import Image from '@theme/Image';
 
-You have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+You have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 ## Download your Kubernetes credentials
 
-In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto Cloud.
+In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto.
 [This document](/docs/cloud/credentials/) will walk you through the necessary steps for this.
 
 You can also use the `okteto kubeconfig` command to download your Kubernetes credentials. This will let you interact with your Okteto Namespaces using Kubernetes-native tools like `kubectl` or `helm`.
@@ -25,6 +25,6 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-Okteto Cloud is a multi-tenant environment.
-A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-[Take a look at this document](/docs/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+Okteto is a multi-tenant environment.
+A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+[Take a look at this document](/docs/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/src/content/cloud/develop-on-okteto-button.mdx
+++ b/src/content/cloud/develop-on-okteto-button.mdx
@@ -12,14 +12,14 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in Git `README` files, documentation sites, or pretty much anywhere that renders an html file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements
 
-The basic requirements for creating the button are that your application can be deployed in Okteto Cloud, and that the application's source code is hosted in a public Git repository.
+The basic requirements for creating the button are that your application can be deployed in Okteto, and that the application's source code is hosted in a public Git repository.
 
 The easiest way to validate this is to follow the instructions in the [Deploy from Git](/docs/cloud/deploy-from-git/) document.
 

--- a/src/content/cloud/github-actions.mdx
+++ b/src/content/cloud/github-actions.mdx
@@ -1,17 +1,17 @@
 ---
 title: GitHub Actions
-description: Automate your development workflows using GitHub Actions and Okteto Cloud
+description: Automate your development workflows using GitHub Actions and Okteto
 sidebar_label: GitHub Actions
 id: github-actions
 ---
 
-Automate your development workflows using GitHub Actions and Okteto Cloud.
+Automate your development workflows using GitHub Actions and Okteto.
 
-GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto Cloud, you can create workflows to build, deploy, and update your applications in Okteto Cloud.
+GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto, you can create workflows to build, deploy, and update your applications in Okteto.
 
 ## Available Actions
 
-The GitHub Actions for Okteto Cloud are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
+The GitHub Actions for Okteto are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
 
 - [Activate Namespace](https://github.com/marketplace/actions/activate-namespace)
 - [Apply](https://github.com/marketplace/actions/kubectl-apply)

--- a/src/content/cloud/multitenancy.mdx
+++ b/src/content/cloud/multitenancy.mdx
@@ -1,25 +1,25 @@
 ---
-title: Default Settings for Okteto Cloud
-description: Okteto Cloud gives you access to a Kubernetes namespace in a multi-tenant environment
+title: Default Settings for Okteto
+description: Okteto gives you access to a Kubernetes namespace in a multi-tenant environment
 sidebar_label: Default Settings
 id: multitenancy
 ---
 
-Okteto Cloud gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
+Okteto gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
 
-This document explains the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+This document explains the limitations and restrictions most likely to affect your applications in Okteto.
 
 ## Exposing services
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
 
 ## Pod Security Policies
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
 ## Resource quotas
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -56,11 +56,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 
 ## Network policies
 
-Okteto Cloud configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+Okteto configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
 ## RBAC
 
-Okteto Cloud uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Okteto uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/src/content/cloud/namespaces.mdx
+++ b/src/content/cloud/namespaces.mdx
@@ -7,13 +7,13 @@ id: namespaces
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can create and manage secure and isolated Kubernetes namespaces for you and your team.
+With Okteto you can create and manage secure and isolated Kubernetes namespaces for you and your team.
 
-Okteto Cloud will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
+Okteto will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
 
 ## Manage your namespaces
 
-You can create up to five namespaces per account. Go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
+You can create up to five namespaces per account. Go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
 
 <p align="center"><Image src="/docs/cloud/images/new-dialog.png" alt="new namespace dialog" width="650" /></p>
 
@@ -27,8 +27,8 @@ Once you're done, you can also delete your namespace via the UI, or with the `ok
 
 By default, you'll be the only person with access to your namespaces. Invite your teammates to enable true real-time collaboration.
 
-To share a namespace go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
+To share a namespace go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
 
 <p align="center"><Image src="/docs/cloud/images/share.png" alt="share a namespace" width="850" /></p>
 
-In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto Cloud will update the necessary permissions and notify your teammates via email.
+In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto will update the necessary permissions and notify your teammates via email.

--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -5,7 +5,7 @@ sidebar_label: Okteto CLI
 id: okteto-cli
 ---
 
-[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto Cloud](/docs/cloud), or [Okteto Self-Hosted](/docs/enterprise).
+[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto](/docs/reference/development-environments), or [Okteto Self-Hosted](/docs/enterprise).
 
 Learn more about the Okteto CLI
 
@@ -68,7 +68,7 @@ The installation job also populates the following environment variables. You can
 - `OKTETO_GIT_BRANCH`: the name of the Git branch currently being deployed.
 - `OKTETO_GIT_COMMIT`: the SHA1 hash of the last commit of the branch.
 - `OKTETO_REGISTRY_URL`: the url of the [Okteto Registry](/docs/cloud/registry/).
-- `BUILDKIT_HOST`: the address of the [Okteto Cloud buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
+- `BUILDKIT_HOST`: the address of the [Okteto buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
 
 In order to refer to images in the `build` section of the Okteto Manifest, you can use the following environment variables:
 - `${OKTETO_BUILD_<service>_TAG}`: SHA for the last image build at the registry
@@ -76,7 +76,7 @@ In order to refer to images in the `build` section of the Okteto Manifest, you c
 - `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)
 - `${OKTETO_BUILD_<service>_IMAGE}`: the full image reference (using its SHA)
 
-### Built-in Tools When Deploying To Okteto Cloud
+### Built-in Tools When Deploying To Okteto
 
 When launching a development environment [from a Git Repository](/docs/cloud/deploy-from-git/), Okteto will run an installation job that clones the Git repository, checks out the selected branch, builds the images defined in the `build` section of your Okteto Manifest, and executes the sequence of `deploy` commands. The job will fail if any of the commands in the `deploy` list fails.
 The installation job will run in a Debian Linux container with the following tools preinstalled:

--- a/src/content/cloud/okteto-pipeline.mdx
+++ b/src/content/cloud/okteto-pipeline.mdx
@@ -5,7 +5,7 @@ sidebar_label: Okteto Pipeline
 id: okteto-pipeline
 ---
 
-Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto Cloud](/docs/cloud/). You might want to use them if Okteto Cloud cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
+Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto](/docs/reference/development-environments). You might want to use them if Okteto cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
 
 The Okteto Pipeline is executed relative to the path where the manifest is located. This means, if the manifest is at any subfolder, the pipeline will use the context of the subfolder where the manifest is defined.
 
@@ -24,7 +24,7 @@ devs:
 
 ### Schema Reference
 
-- `icon`: the icon associated to your application in the Okteto Cloud Dashboard (optional).
+- `icon`: the icon associated to your application in the Okteto Dashboard (optional).
 - `deploy`: list of commands to deploy your application in your Kubernetes namespace. It is usually a combination of `helm`, `kubectl`, and `okteto` commands.
 - `destroy`: list of commands to be executed when the pipeline is destroyed. It can be used to release any resource created outside Okteto.
 - `devs`: the paths to the okteto manifests in your Git repository. This is used to fill the hints in the *Develop* dialog of each service (optional).
@@ -62,4 +62,4 @@ The installation job also populates the following environment variables. You can
 - `OKTETO_GIT_BRANCH`: the name of the Git branch currently being deployed.
 - `OKTETO_GIT_COMMIT`: the SHA1 hash of the last commit of the branch.
 - `OKTETO_REGISTRY_URL`: the url of the [Okteto Registry](/docs/cloud/registry/).
-- `BUILDKIT_HOST`: the address of the [Okteto Cloud buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
+- `BUILDKIT_HOST`: the address of the [Okteto buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.

--- a/src/content/cloud/permissions.mdx
+++ b/src/content/cloud/permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: GitHub Permissions for Okteto Cloud
-description: Details of permissions requested by Okteto Cloud when you login using your GitHub account
+title: GitHub Permissions for Okteto
+description: Details of permissions requested by Okteto when you login using your GitHub account
 sidebar_label: GitHub Permissions
 id: permissions
 ---
@@ -9,7 +9,7 @@ import Image from '@theme/Image';
 
 ## GitHub Permissions
 
-When using the Okteto Cloud Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
+When using the Okteto Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard-perms.png" alt="permissions requested on github for preview environments" width="650" /></p>
 
@@ -18,14 +18,14 @@ The reasons for requesting the above permissions are listed below.
 ### Repository Permissions
 
 - Contents: Needed to clone repositories for deploying Preview Environments
-- Metadata: Needed to list repositories a user has access to on the Okteto Cloud Dashboard
+- Metadata: Needed to list repositories a user has access to on the Okteto Dashboard
 - Pull Requests: Needed to comment on the pull requests with the deployed Preview Environment URL and to deploy/destroy a Preview Environment based on whether a PR has been opened/closed
 - Commit Statuses: Needed to change the status of a commit to show if the Preview Environment for it was deployed successfully or not
 
 ### Organization Permissions
 
-- Members: When an org admin installs Okteto Cloud for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto Cloud
+- Members: When an org admin installs Okteto for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto
 
 ### User Permissions
 
-- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto Cloud account.
+- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto account.

--- a/src/content/cloud/preview-environments/dashboard.mdx
+++ b/src/content/cloud/preview-environments/dashboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring Preview Environments
-description: Create preview environments for your application using the Okteto Cloud Dashboard
+description: Create preview environments for your application using the Okteto Dashboard
 sidebar_label: Configure
 id: dashboard
 ---
@@ -8,25 +8,25 @@ id: dashboard
 import Image from '@theme/Image';
 
 
-There are two ways to configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) using Okteto Cloud for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Cloud Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/cloud/preview-environments/preview-environments/#prerequisites) section.
+There are two ways to configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) using Okteto for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/cloud/preview-environments/preview-environments/#prerequisites) section.
 
 Note that this method is not applicable for users of [Okteto Self-Hosted](/docs/enterprise) or Okteto for Teams. Please checkout [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) for configuring Preview Environments in those cases.
 
-### Step 1: Log into Okteto Cloud
+### Step 1: Log into Okteto
 
-The first step is going to [Okteto Cloud](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
+The first step is going to [Okteto](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on okteto cloud" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on Okteto" /></p>
 
 In this guide, we will set up Preview Environments for a fork of the [movies-preview-environments](https://github.com/okteto/movies-preview-environments) repository. Head to that repository and [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of it under your GitHub account. Feel free to follow along with some other repository in your GitHub account once you've [configured](/docs/cloud/preview-environments/preview-environments/#prerequisites) it.
 
 ### Step 2: Add Your Repository
 
-Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto Cloud on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto Cloud requests and why over [here](/docs/cloud/permissions). 
+Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto requests and why over [here](/docs/cloud/permissions). 
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto Cloud on github account" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto on github account" /></p>
 
-Please note that you can only install Okteto Cloud for repositories belonging to your own GitHub account. Only org admins can install Okteto Cloud in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto Cloud to admins through GitHub.
+Please note that you can only install Okteto for repositories belonging to your own GitHub account. Only org admins can install Okteto in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto to admins through GitHub.
 
 Once you do that, you should see your repository appear in the list. 
 
@@ -42,7 +42,7 @@ That's right, this was all the configuration you needed to do! Head over to your
 
 Sharing this with team members is the best way to get their attention for reviews 😛
 
-You should also be able to see the pull request details along with the endpoints on the Okteto Cloud Dashboard.
+You should also be able to see the pull request details along with the endpoints on the Okteto Dashboard.
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/pr-in-dashboard.png" alt="endpoints for the pr" /></p>
 

--- a/src/content/cloud/preview-environments/github.mdx
+++ b/src/content/cloud/preview-environments/github.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments Using GitHub Actions
-description: Create a preview environment for your application using Okteto Cloud and GitHub Actions
+description: Create a preview environment for your application using Okteto and GitHub Actions
 sidebar_label: Using GitHub Actions
 id: preview-environments-github
 ---
 
 import Image from '@theme/Image';
 
-This section will show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+This section will show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/movies).
@@ -21,18 +21,18 @@ Start by forking the [movies](https://github.com/okteto/movies) repository with 
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we will use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we will use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Log into Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Log into Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/movies/blob/main/.github/workflows/preview.yaml).
 If you want to use this on for your repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.
 
-The workflow file to create the preview environments for Okteto Cloud users looks like this:
+The workflow file to create the preview environments for Okteto users looks like this:
 
 ```yaml
 # file: .github/workflows/preview.yaml

--- a/src/content/cloud/preview-environments/gitlab.mdx
+++ b/src/content/cloud/preview-environments/gitlab.mdx
@@ -1,6 +1,6 @@
 ---
 title: Preview Environments Using GitLab CI/CD
-description: Create a preview environment for your application using Okteto Cloud and GitLab
+description: Create a preview environment for your application using Okteto and GitLab
 sidebar_label: For GitLab
 id: preview-environments-gitlab
 ---
@@ -10,7 +10,7 @@ import Image from '@theme/Image';
 This section will show you how to automatically create a preview environment for your applications using Okteto and GitLab's preview apps.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitLab Account](https://gitlab.com)
 
 ## Step 1: Fork the Sample Repository
@@ -22,7 +22,7 @@ For this tutorial, we'll be using [this application](https://gitlab.com/okteto/p
 To deploy a preview environment with Okteto, you need to define the following environment variables:
 
 1. `OKTETO_TOKEN`: an Okteto [personal access token](/docs/cloud/personal-access-tokens/).
-1. `OKTETO_USERNAME`: your Okteto username (in Okteto Cloud, this is your GitHub Username).
+1. `OKTETO_USERNAME`: your Okteto username (in Okteto, this is your GitHub Username).
 1. [Optional] `OKTETO_URL`: if you are using [Okteto Enterprise](/enterprise/), specify the URL of your instance of Okteto Enterprise (e.g., https://okteto.dev.mycompany.com).
 
 To add the environment variables:
@@ -132,7 +132,7 @@ Okteto makes it easy to deploy your own [GitLab Runner](https://docs.gitlab.com/
 
 ### Deploy your GitLab Runner
 
-1. Log into [Okteto Cloud](https://cloud.okteto.com).
+1. Log into [Okteto](https://cloud.okteto.com).
 1. Click on the **Deploy** button on the top.
 1. Choose **Catalog** as the source, select **gitlab-runner** from the options below, and click **Deploy**.
 

--- a/src/content/cloud/preview-environments/overview.mdx
+++ b/src/content/cloud/preview-environments/overview.mdx
@@ -12,7 +12,7 @@ Preview environments allow you to include a live preview of your changes on ever
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-environments.png" alt="Preview Environments" /></p>
 
 Okteto's preview environments are powered by Kubernetes and easily integrate with your favorite source control and CI/CD provider. They work using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest), so are very simple to get started with.
-You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with [Okteto Self-Hosted](/docs/enterprise) if you want to run them on your Kubernetes infrastructure.
+You can use Preview Environments with either [Okteto](/docs/reference/development-environments) or with [Okteto Self-Hosted](/docs/enterprise) if you want to run them on your Kubernetes infrastructure.
 
 - [GitHub](/docs/cloud/preview-environments/preview-environments-github/)
 - [GitLab](/docs/cloud/preview-environments/preview-environments-gitlab/)
@@ -22,4 +22,4 @@ You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with
 
 ## Prerequisites
 
-Preview environments deploy the code in a pull request to [Okteto Cloud](/docs/cloud/) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest)'s `deploy` section.
+Preview environments deploy the code in a pull request to [Okteto](/docs/reference/development-environments) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest)'s `deploy` section.

--- a/src/content/cloud/private-endpoints.mdx
+++ b/src/content/cloud/private-endpoints.mdx
@@ -10,9 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-Okteto Cloud allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
+Okteto allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
 
-Private endpoints can be identified by the lock icon in the Okteto Cloud UI:
+Private endpoints can be identified by the lock icon in the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/private-endpoints.png" alt="private endpoints UI" width="850" /></p>
 
@@ -137,6 +137,6 @@ services:
 
 ## Restrictions
 
-Private Endpoints use your Okteto Cloud account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
+Private Endpoints use your Okteto account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
 
 Private Endpoints only restrict external access to your applications. Applications running in your namespace will be able to access your private endpoints without authentication by using the `service` name.

--- a/src/content/cloud/private-repositories.mdx
+++ b/src/content/cloud/private-repositories.mdx
@@ -15,13 +15,13 @@ Okteto integrates with GitHub and allows you to easily deploy any repository fro
 
 You'll need to perform the following steps the first time you grant GitHub permissions to Okteto:
 
-1. Log into Okteto Cloud
+1. Log into Okteto
 1. Click on the "**Launch Dev Environment**" button on the top
 1. Make sure "**GitHub**" is the selected source
 <p align="center"><Image src="/docs/cloud/images/private-repositories-deploy.png" alt="Launch private repository from git" width="650" /></p>
 
-1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto Cloud App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
-<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto Cloud" width="400" /></p>
+1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
+<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto" width="400" /></p>
 
 1. Finally click on the **Install & Authorize** button to proceed. If you're not the administrator of the organization, GitHub will send an email notification to your administrator and wait for their authorization to complete the installation and grant you access.
 <p align="center"><Image src="/docs/cloud/images/private-repositories-authorize.png" alt="install and authorize repositories" width="400" /></p>

--- a/src/content/cloud/registry.mdx
+++ b/src/content/cloud/registry.mdx
@@ -47,6 +47,6 @@ registry.cloud.okteto.net/<okteto-namespace>/<image>:<tag>
 
 Any image pushed into the Okteto Registry is private. You'll need to authenticate with the registry before pulling an image.
 
-Namespaces in Okteto Cloud are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
+Namespaces in Okteto are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
 
 To pull an image from a different namespace, you'll need to create and configure the required `imagePullSecrets` as outlined [here](/docs/reference/faqs/#how-to-use-private-images).

--- a/src/content/cloud/secrets.mdx
+++ b/src/content/cloud/secrets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Okteto Secrets
-description: Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject them during deployment time
+description: Okteto Secrets allows you to save application configuration in Okteto, and automatically inject them during deployment time
 sidebar_label: Okteto Secrets
 id: secrets
 ---
@@ -9,11 +9,11 @@ import Image from '@theme/Image';
 
 Application configuration should be passed at deployment time, not hardcoded in your code.
 
-Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject it during deployment time.
+Okteto Secrets allows you to save application configuration in Okteto, and automatically inject it during deployment time.
 
-## Manage Okteto Secrets from the Okteto Cloud UI
+## Manage Okteto Secrets from the Okteto UI
 
-You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto Cloud UI:
+You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/secrets.png" alt="Secrets in settings" width="650" /></p>
 

--- a/src/content/cloud/ssl.mdx
+++ b/src/content/cloud/ssl.mdx
@@ -5,7 +5,7 @@ sidebar_label: Automatic SSL
 id: ssl
 ---
 
-Okteto Cloud can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
+Okteto can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
 
 ```
   dev.okteto.com/auto-ingress: "true"
@@ -36,7 +36,7 @@ spec:
 
 Adding this annotation will tell Okteto to automatically create an https ingress rule for you that redirects to the first http port of your service. `NodePort` or `LoadBalancer` services are managed as if they had this annotation too.
 
-You can see the address of your endpoint by going to Okteto Cloud's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
+You can see the address of your endpoint by going to Okteto's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
 
 ## Bring your own ingress
 
@@ -46,7 +46,7 @@ Keep in mind that all the hosts you use in your ingress must end with`-$NAMESPAC
 
 ### Let Okteto generate the host
 
-Okteto Cloud can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
+Okteto can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
 
 ```
   dev.okteto.com/generate-host: "true"
@@ -71,4 +71,4 @@ spec:
         path: /
 ```
 
-We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto Cloud namespace.
+We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto namespace.

--- a/src/content/enterprise.mdx
+++ b/src/content/enterprise.mdx
@@ -5,7 +5,7 @@ sidebar_label: Intro
 id: enterprise
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/cloud/), with the control and flexibility of running in your Kubernetes infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/cloud/), with the control and flexibility of running in your Kubernetes infrastructure.
 
 With Okteto Enterprise your team can:
 

--- a/src/content/enterprise/install/overview.mdx
+++ b/src/content/enterprise/install/overview.mdx
@@ -5,7 +5,7 @@ sidebar_label: Overview
 id: overview
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/cloud/), with the control and flexibility of running in your own infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/reference/development-environments), with the control and flexibility of running in your own infrastructure.
 
 Okteto Enterprise is free for small teams.  You get all the features of [Okteto Enterprise](/docs/enterprise/) for up to 3 users with 3 namespaces each.
 

--- a/src/content/getting-started.mdx
+++ b/src/content/getting-started.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Okteto's Development Environments enable you to work directly with a deployed application and see your code changes live on the cloud as soon as you hit save.
 
-These Dev environments work using a combination of [Okteto Cloud](/docs/cloud), which is used to deploy your application, and [Okteto CLI](/docs/cloud/okteto-cli), which is used to launch the Dev Environment. This guide will teach how to get started with remote Development Environments.
+These Dev environments work using a combination of [Okteto](/docs/reference/development-environments), which is used to deploy your application, and [Okteto CLI](/docs/cloud/okteto-cli), which is used to launch the Dev Environment. This guide will teach how to get started with remote Development Environments.
 
 ## Installing Okteto CLI
 
@@ -49,11 +49,11 @@ $ scoop install okteto
 
 Alternatively, you can directly download the binary [from GitHub](https://github.com/okteto/okteto/releases) or build it directly from the source code.
 
-## Configuring Okteto CLI with Okteto Cloud
+## Configuring Okteto CLI with Okteto
 
-You can launch a remote Development Environment on [Okteto Cloud](https://cloud.okteto.com) or **any** Kubernetes cluster with the Okteto CLI. For this guide, we'll be using Okteto Cloud. 
+You can launch a remote Development Environment on [Okteto](https://cloud.okteto.com) or **any** Kubernetes cluster with the Okteto CLI. For this guide, we'll be using Okteto. 
 
-The first thing you need to do is configure Okteto CLI to use Okteto Cloud. To do this, run the command below:
+The first thing you need to do is configure Okteto CLI to use Okteto. To do this, run the command below:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -83,4 +83,4 @@ Once the Okteto manifest is created, we recommend that you review it and adjust 
 
 ## Next Steps
 
-In this section, we installed Okteto CLI on our machine and configured it to work with Okteto Cloud. [Next](/docs/using-dev-envs), we're going to launch our Dev Environment and fix a bug in a sample application.
+In this section, we installed Okteto CLI on our machine and configured it to work with Okteto. [Next](/docs/using-dev-envs), we're going to launch our Dev Environment and fix a bug in a sample application.

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -88,7 +88,7 @@ This will prompt you to select one of your existing contexts or to create a new 
 A context defines the default cluster/namespace for any Okteto CLI command.
 Select the context you want to use:
 Use the arrow keys to navigate: ↓ ↑ → ←
-  ▸ https://cloud.okteto.com (Okteto Cloud) *
+  ▸ https://cloud.okteto.com (Okteto) *
     minikube
     staging
     production
@@ -120,7 +120,7 @@ Available subcommands:
 
 Delete a context.
 
-For example, to delete the Okteto Cloud context, run:
+For example, to delete the Okteto context, run:
 
 ```console
 $ okteto context delete https://cloud.okteto.com

--- a/src/content/reference/development-containers.mdx
+++ b/src/content/reference/development-containers.mdx
@@ -20,9 +20,9 @@ For using `okteto up`, you will need to install the Okteto CLI. Okteto CLI is an
 
 Coming to the first step of deploying your application code, there are multiple options available for you to choose from. You can choose to deploy it on an existing cluster and use Okteto CLI to interact with this cluster. 
 
-A second option available is Okteto Cloud. Using Okteto Cloud, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto Cloud was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto Cloud [documentation](/docs/cloud). 
+A second option available is Okteto. Using Okteto, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto [documentation](/docs/cloud). 
 
-Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto Cloud - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto Cloud. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
+Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
 
 ## Getting started
 

--- a/src/content/reference/development-environments.mdx
+++ b/src/content/reference/development-environments.mdx
@@ -18,11 +18,25 @@ Setting up development environments using Okteto involves two main steps:
 
 For using `okteto up`, you will need to install the Okteto CLI. Okteto CLI is an [open-source](https://github.com/okteto/okteto) tool that helps spin up development containers regardless of where you choose to deploy your application code as part of the first step. You can learn more about it by heading to the documentation [here](/docs/cloud/okteto-cli/). 
 
-Coming to the first step of deploying your application code, there are multiple options available for you to choose from. You can choose to deploy it on an existing cluster and use Okteto CLI to interact with this cluster. 
+For the first step of deploying your application, there are multiple approaches for you to choose from. You can use Okteto for deploying your application. This way, you get a robust developer experience specially tailored by us, keeping Remote Development Environments in mind. Okteto comes with useful additional features you would not find in a traditional cluster.
 
-A second option available is Okteto Cloud. Using Okteto Cloud, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto Cloud was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto Cloud [documentation](/docs/cloud). 
+With Okteto you can:
 
-Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto Cloud - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto Cloud. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
+- Deploy your development environments with the [Okteto CLI](/docs/cloud/okteto-cli/) or from your [Git Repositories](/docs/cloud/deploy-from-git/).
+- Configure [Secrets](/docs/cloud/secrets/) and prevent secure credentials from being stored in version control.
+- Expose your development environments via [Automatic HTTPs Endpoints](/docs/cloud/ssl/) for your services, [Private Endpoints](/docs/cloud/private-endpoints/) to restrict access, and [Custom Domain Names](/docs/cloud/custom-domains/).
+- Build your images directly in the cloud using the [Okteto Build Service](/docs/cloud/build).
+- Push your container images in the [Okteto Registry](/docs/cloud/registry).
+- Create secure Kubernetes [Namespaces](/docs/cloud/namespaces/) with one click.
+- Download your [Kubernetes Credentials](/docs/cloud/credentials/) to access your namespaces with `kubectl`, `helm`, or any other CLI tool.
+- Visualize your workloads in a Developer-focused Kubernetes dashboard.
+
+If you want to try it out, head to our [Getting Started Guide](/docs/getting-started/) and see how you can use Okteto to simplify developing cloud-native applications. 
+
+With Okteto, you can also further choose between either hosting the infrastructure yourself or letting us take care of managing the cloud infrastructure for you. The former offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. You can learn more about the exact differences from the [pricing page](https://www.okteto.com/pricing/).
+
+Okteto CLI works out of the box with any Kubernetes cluster. This means that the other option available for you is to take care of creating a convenient developer experience around your dev environments yourself and then only relying on Okteto CLI to launch the Remote Development Environments. With this approach, you are also responsible for setting up and managing the Kubernetes cluster. This approach is completely independent of using the Okteto platform or any of its features.
+
 
 ## Getting started
 

--- a/src/content/reference/docker-compose.mdx
+++ b/src/content/reference/docker-compose.mdx
@@ -453,7 +453,7 @@ will use `change-me!` for the value of the `MYSQL_ROOT_PASSWORD` environment var
 
 > Values in the shell and/or the `.env` file take precedence over those specified in Okteto Secrets.
 
-## Okteto Cloud makes Docker Compose even more powerful!
+## Okteto makes Docker Compose even more powerful!
 
 Okteto extends the Compose Specification to make it even easier for you and your team to build cloud-native applications.
 

--- a/src/content/reference/faqs.mdx
+++ b/src/content/reference/faqs.mdx
@@ -70,13 +70,13 @@ $ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcr
 
 With this configuration, all the deployments, stateful sets, jobs, and development containers launched in your namespace will automatically use your registry credentials when pulling private images.
 
-## What types of Kubernetes services are supported in Okteto Cloud?
+## What types of Kubernetes services are supported in Okteto?
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/). Okteto Cloud also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/). Okteto also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
-## What resource quotas are present in Okteto Cloud Namespaces?
+## What resource quotas are present in Okteto Namespaces?
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -109,11 +109,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 | Persistent Volume Claims  | 10  |
 
 
-## Are there any restrictions on applications deployed on Okteto Cloud?
+## Are there any restrictions on applications deployed on Okteto?
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
-Apart from that, Okteto Cloud also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Apart from that, Okteto also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/src/content/reference/known-issues.mdx
+++ b/src/content/reference/known-issues.mdx
@@ -17,7 +17,7 @@ For example, you can do it by running this command on each node:
 $ sudo sysctl -w fs.inotify.max_user_watches=10048576
 ```
 
-Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
+Okteto and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
 
 ## *kubectl apply* changes are undone by *okteto up*
 
@@ -25,7 +25,7 @@ Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automat
 
 If you need to apply changes to your Kubernetes Deployment Manifest after running `okteto up`, note that **you need to run `okteto down` first** or `okteto up` will undo the changes you do to your Kubernetes Deployment Manifests. The reason is that `okteto up` records a copy of the deployment when `okteto up` is executed. This copy is used by `okteto down` to restore the original Kubernetes Deployment Manifest. But it is also used by `okteto up` as the original deployment to avoid ambiguities of "kubectl apply" concurrent changes.
 
-This issue does not apply if you're using Okteto Cloud or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
+This issue does not apply if you're using Okteto or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
 
 ## The okteto prompt doesn't look right in Windows
 

--- a/src/content/samples/aspnetcore.mdx
+++ b/src/content/samples/aspnetcore.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with ASP.NET
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application
+title: Getting Started on Okteto with ASP.NET
+description: This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application
 sidebar_label: ASP.NET
 id: aspnetcore
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application.
+This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the ASP.NET Sample App
 
@@ -36,11 +36,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI ASP.NET" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI ASP.NET" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Activate your development container
 
@@ -81,7 +81,7 @@ The `okteto up` command starts a [development container](/docs/reference/develop
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 3: Develop directly in Okteto Cloud
+## Step 3: Develop directly in Okteto
 
 Open the file `Controllers/HelloWorldController.cs` in your favorite local IDE and modify the response message on line 25 to be *Hello world from Okteto!*. Save your changes.
 
@@ -113,7 +113,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code using the VS dotnet debugger.
 
@@ -131,11 +131,11 @@ Go back to the browser and reload the page. As soon as the service receives the 
 
 <Image center borderless src="/docs/samples/images/aspnetcore-debug.png" alt="ASP.NET core debug" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -144,6 +144,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/src/content/samples/golang.mdx
+++ b/src/content/samples/golang.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Go
+title: Getting Started on Okteto with Go
 description: This tutorial will show you how to develop a Go sample application
 sidebar_label: Go
 id: golang
@@ -7,14 +7,14 @@ id: golang
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Go sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Go sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Go Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI golang" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI golang" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -139,7 +139,7 @@ Starting hello-world server...
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the file `main.go` in your favorite local IDE and modify the response message on line 17 to be *Hello world from Okteto!*. Save your changes.
 
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Go development.
@@ -210,18 +210,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/golang-debug.png" alt="debugging in Okteto with golang" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/src/content/samples/java.mdx
+++ b/src/content/samples/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Java
+title: Getting Started on Okteto with Java
 description: This tutorial will show you how to develop a Java sample application
 sidebar_label: Java
 id: java
@@ -7,14 +7,14 @@ id: java
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Java sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Java sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Java Sample App
 
@@ -46,11 +46,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Java" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Java" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -165,7 +165,7 @@ The first time you run the application, Maven/Gradle will compile your applicati
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open `src/main/java/com/okteto/helloworld/RestHelloWorld.java` in your favorite local IDE and modify the response message on line 11 to be *Hello world from Okteto!*. Save your changes.
 
@@ -185,13 +185,13 @@ public class RestHelloWorld {
 }
 ```
 
-Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto Cloud. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
+Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
 
 > Import the `spring-boot-devtools` dependency to automatically restart your Java application whenever a file is changed.
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in Eclipse, one of the most popular IDEs for Java development.
 
@@ -207,17 +207,17 @@ Click the Debug button to start a debugging session. Add a breakpoint on `src/ma
 
 <Image center src="/docs/samples/images/java-halt.png" alt="breakpoint in Java" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/src/content/samples/node.mdx
+++ b/src/content/samples/node.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Node.js
+title: Getting Started on Okteto with Node.js
 description: This tutorial will show you how to develop a Node.js sample application
 sidebar_label: Node.js
 id: node
@@ -7,14 +7,14 @@ id: node
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Node.js sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Node.js sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Node.js Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Node.js" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Node.js" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -135,7 +135,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `index.js` file in your favorite local IDE and modify the response message on line 5 to be *Hello world from the cluster!*. Save your changes.
 
@@ -154,7 +154,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Node development.
@@ -201,18 +201,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/node-halt.png" alt="breakpoint in Node.js" width="850" />
 
-Your code is running in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is running in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing on a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/src/content/samples/php.mdx
+++ b/src/content/samples/php.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with PHP
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application
+title: Getting Started on Okteto with PHP
+description: This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application
 sidebar_label: PHP
 id: php
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the PHP Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI PHP" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI PHP" width="850" />
 
-Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -134,7 +134,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `index.php` file in your favorite local IDE and modify the response message on line 2 to be *Hello world from the cluster!*. Save your changes.
 
@@ -146,7 +146,7 @@ echo($message);
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works with [PHPStorm](https://www.jetbrains.com/phpstorm/), one of the most popular IDEs for PHP development.
 
@@ -158,13 +158,13 @@ Go back to your browser and reload the page. The execution will automatically ha
 
 At this point, you're able to inspect the request object, the current values of everything, the contents of `$_SERVER` variable, etc.
 
-<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto Cloud with PHP" width="850" />
+<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto with PHP" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -173,6 +173,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/src/content/samples/python.mdx
+++ b/src/content/samples/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Python
+title: Getting Started on Okteto with Python
 description: This tutorial will show you how to develop a Python sample application
 sidebar_label: Python
 id: python
@@ -7,14 +7,14 @@ id: python
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Python sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Python sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Python Sample App
@@ -38,11 +38,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Python" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Python" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -138,7 +138,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `app.py` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*.
 Save your changes.
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in one of python's most popular IDE's, [PyCharm](https://www.jetbrains.com/pycharm/).
@@ -206,18 +206,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center borderless src="/docs/samples/images/python-debug.png" alt="breakpoint in Python" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/src/content/samples/ruby.mdx
+++ b/src/content/samples/ruby.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with Ruby
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application
+title: Getting Started on Okteto with Ruby
+description: This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application
 sidebar_label: Ruby
 id: ruby
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Ruby Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Ruby" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Ruby" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -132,7 +132,7 @@ cindy:hello-world app> ruby app.rb
 [2020-03-20 09:23:04] INFO  WEBrick::HTTPServer#start: pid=66 port=8080
 ```
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `app.rb` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*. Save your changes.
 
@@ -147,7 +147,7 @@ Okteto will synchronize your changes to your development container in Kubernetes
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code, one of the most popular IDEs for Ruby development. If you haven't done it yet, install the [Ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby) available from Visual Studio marketplace. This extension comes with debug definitions covering the default `ruby-debug-ide` client setup.
 
@@ -186,11 +186,11 @@ Add a breakpoint on `app.rb`, line 8. Go back to the browser and reload the page
 
 <Image center src="/docs/samples/images/ruby-halt.png" alt="debugging in Okteto with Ruby" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -199,6 +199,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/src/content/tutorials/compose-getting-started.mdx
+++ b/src/content/tutorials/compose-getting-started.mdx
@@ -14,7 +14,7 @@ Okteto implements and extends the [Compose Specification](https://github.com/com
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Launch your Development Environment
 
@@ -128,7 +128,7 @@ Your code changes were instantly applied. No commit, build, or push required!
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 Read the docs for the [Docker Compose](/docs/reference/compose/) and the [available Okteto CLI commands](/docs/reference/cli) to learn more about developing your Docker Compose application on Okteto.
 

--- a/src/content/tutorials/getting-started-with-okteto.mdx
+++ b/src/content/tutorials/getting-started-with-okteto.mdx
@@ -15,7 +15,7 @@ The tutorial is composed of the following steps:
 
 - Step 1: Code the Hello World application
 - Step 2: Define a Dockerfile for building the Docker image of the Hello World application
-- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 - Step 4: Generate your Okteto manifest
 - Step 5: Launch your Development Environment
 - Step 6: Configure a Remote Development Container
@@ -69,7 +69,7 @@ $ go mod init go-getting-started
 
 ## Step 2: Define a Dockerfile for building the Docker image of the Hello World application
 
-You need to build a Docker image and push it to a Docker registry before Okteto Cloud can run your application.
+You need to build a Docker image and push it to a Docker registry before Okteto can run your application.
 
 To do that, you need to define a `Dockerfile`.
 A `Dockerfile` file is a sequence of instructions to build the Docker image of your application.
@@ -88,9 +88,9 @@ EXPOSE 8080
 CMD ["./app"]
 ```
 
-## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 
-To deploy an application to Okteto Cloud, you need to define it using Kubernetes manifests.
+To deploy an application to Okteto, you need to define it using Kubernetes manifests.
 
 Let's start by creating a new folder for the Kubernetes manifests:
 
@@ -157,7 +157,7 @@ The service manifest has four main sections:
 
 You now have everything ready to define the Okteto Manifest of the Hello World application.
 
-> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto Cloud a secure environment to run your applications.
+> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto a secure environment to run your applications.
 
 ## Step 4: Generate your Okteto manifest
 
@@ -183,7 +183,7 @@ You can make use of tools such as `kubectl`, `helm`, `okteto`, and `kustomize` i
 
 ## Step 5: Deploy your Development Environment
 
-[Install](/docs/cloud/okteto-cli/) the Okteto CLI and configure access to Okteto Cloud:
+[Install](/docs/cloud/okteto-cli/) the Okteto CLI and configure access to Okteto:
 
 ```console
 $ okteto context use https://cloud.okteto.com

--- a/src/content/tutorials/getting-started-with-pipelines.mdx
+++ b/src/content/tutorials/getting-started-with-pipelines.mdx
@@ -8,7 +8,7 @@ id: getting-started-with-pipelines
 import Image from '@theme/Image';
 
 This tutorial provides a step by step guide to configure an [Okteto Pipeline](/docs/cloud/okteto-pipeline/).
-Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto Cloud in just one click.
+Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto in just one click.
 
 ## Overview
 
@@ -16,7 +16,7 @@ The tutorial is composed of the following steps:
 
 - Step 1: Code the Hello World application
 - Step 2: Define a Dockerfile for building the Docker image of the Hello World application
-- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 - Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 - Step 5: Deployment time!
 
@@ -68,7 +68,7 @@ $ go mod init go-getting-started
 
 ## Step 2: Define a Dockerfile for building the Docker image of the Hello World application
 
-You need to build a Docker image and push it to a Docker registry before Okteto Cloud can run your application.
+You need to build a Docker image and push it to a Docker registry before Okteto can run your application.
 
 To do that, you need to define a `Dockerfile`.
 A `Dockerfile` file is a sequence of instructions to build the Docker image of your application.
@@ -87,9 +87,9 @@ EXPOSE 8080
 CMD ["./app"]
 ```
 
-## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 
-To deploy an application to Okteto Cloud, you need to define it using Kubernetes manifests.
+To deploy an application to Okteto, you need to define it using Kubernetes manifests.
 
 Let's start by creating a new folder for the Kubernetes manifests:
 
@@ -156,7 +156,7 @@ The service manifest has four main sections:
 
 You now have everything ready to define the Okteto Pipeline of the Hello World application.
 
-> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto Cloud a secure environment to run your applications.
+> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto a secure environment to run your applications.
 
 ## Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 
@@ -181,21 +181,21 @@ Read the Okteto Pipeline [documentation](/docs/cloud/okteto-pipeline/) to learn 
 
 ## Step 5: Deployment time!
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs).
-Click on the **Deploy** button on the top left of the Okteto Cloud dashboard, select "**Git URL**" as the source
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs).
+Click on the **Deploy** button on the top left of the Okteto dashboard, select "**Git URL**" as the source
 and type the URL of your Git repository to deploy the Hello World application:
 
 <p align="center"><Image src="/docs/tutorials/images/deploy-from-git.png" alt="deploy a git repository" width="650" /></p>
 
 After a few seconds, your application will be ready. You can access the Hello World application by clicking its endpoint:
 
-<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto Cloud UI of Hello World app" width="850" />
+<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto UI of Hello World app" width="850" />
 
 > You can make the deployment experience even smoother by adding a [Develop on Okteto](/docs/cloud/develop-on-okteto-button/) button to the `README.md` file of your Git repository.
 
 ## Next steps
 
-Congratulations, you just configured **your first Okteto Pipeline on Okteto Cloud** 🚀.
+Congratulations, you just configured **your first Okteto Pipeline on Okteto** 🚀.
 
 We have covered how to deploy realistic environments for cloud-native applications in just one-click.
 The full source code used on this tutorial is available [here](https://github.com/okteto/pipeline-getting-started).

--- a/src/content/tutorials/preview-environments.mdx
+++ b/src/content/tutorials/preview-environments.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments for your Kubernetes Applications
-description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto Cloud and GitHub Actions
+description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto and GitHub Actions
 sidebar_label: Preview Environments for your Kubernetes Apps
 id: preview-environments
 ---
 
 import Image from '@theme/Image';
 
-In this section, we'll show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+In this section, we'll show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/kubernetes-preview-environment).
@@ -21,12 +21,12 @@ Start by forking the [kubernetes-preview-environment](https://github.com/okteto/
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we're going to use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we're going to use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Login to Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Login to Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/kubernetes-preview-environment/blob/master/.github/workflows/preview.yaml). If you want to use this one for your own repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.

--- a/src/content/tutorials/repos.mdx
+++ b/src/content/tutorials/repos.mdx
@@ -1,22 +1,22 @@
 ---
 title: How to Configure your Custom Helm Repository
-description: Tutorial on how to add your own Helm repository to Okteto Cloud
+description: Tutorial on how to add your own Helm repository to Okteto
 sidebar_label: Configure your Custom Helm Repository
 id: repos
 ---
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can deploy [Helm Charts with one click](/docs/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
+With Okteto you can deploy [Helm Charts with one click](/docs/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
 
-You can add your own Helm repositories to Okteto Cloud to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
+You can add your own Helm repositories to Okteto to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
 
 In order to add your Helm Charts, you'll need a Helm chart repository index with at least one published chart. [Follow this guide](https://helm.sh/docs/chart_repository/) to learn how to do it.
 
-## Add your repository to Okteto Cloud
+## Add your repository to Okteto
 
-On the left side of the Okteto Cloud UI click the **Settings** option. In the new window, click the **Integrations** tab.
-The Okteto Cloud UI will show you the Helm repositories you have configured in Okteto Cloud. Click the **Add Repository** button and put the address of your repository:
+On the left side of the Okteto UI click the **Settings** option. In the new window, click the **Integrations** tab.
+The Okteto UI will show you the Helm repositories you have configured in Okteto. Click the **Add Repository** button and put the address of your repository:
 
 <p align="center"><Image src="/docs/tutorials/images/helm-repos.png" alt="add a Helm repository" width="850" /></p>
 
@@ -31,12 +31,12 @@ Okteto will automatically load the `values-okteto.yaml` file and show it in the 
 
 ## Make your chart multi-tenant friendly.
 
-Okteto Cloud is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
+Okteto is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
 
-Your Helm chart will need to comply with these restrictions to function properly in Okteto Cloud:
+Your Helm chart will need to comply with these restrictions to function properly in Okteto:
 
 - Your chart cannot create `ClusterRole` or `ClusterRoleBinding` objects.
-- `NodePort` and `LoadBalancer` service types are not supported. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
+- `NodePort` and `LoadBalancer` service types are not supported. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
 - The following `Pod` options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Volume host paths are not allowed either.
 
 More information about our multi-tenant policies [is available here](/docs/cloud/multitenancy/).

--- a/src/content/using-dev-envs.mdx
+++ b/src/content/using-dev-envs.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-We set configured Okteto CLI with Okteto Cloud in the [previous section](/docs/getting-started). In this section, let's do the fun bits of developing our application in our Development Environment.
+We set configured Okteto CLI with Okteto in the [previous section](/docs/getting-started). In this section, let's do the fun bits of developing our application in our Development Environment.
 
 ## One Command To Rule Them All
 
@@ -53,7 +53,7 @@ Since we already have a [Docker compose file](/docs/cloud/okteto-cli/#okteto-man
 
 The Movies app only has the `api` and `frontent` microservices, which we see in the prompt. Let's go with `api` because we know there's a bug there we need to fix 🙂
 
-Once you do that, you should see Okteto CLI building the required Docker images for your microservices. When it is done building the images, it will start deploying your application to Okteto Cloud. You should see the deployed endpoints as part of the output in the CLI:
+Once you do that, you should see Okteto CLI building the required Docker images for your microservices. When it is done building the images, it will start deploying your application to Okteto. You should see the deployed endpoints as part of the output in the CLI:
 
 ```console
 Success! Your application will be available shortly.
@@ -62,7 +62,7 @@ i  Endpoints available:
   - https://movies-with-helm-cindylopez.cloud.okteto.net/api
 ```
 
-You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto Cloud dashboard:
+You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
 <Image
@@ -104,7 +104,7 @@ In case your application images aren't already built, you'll also have the optio
 
 The images for the Movies app haven't already been built, so let's select `api/Dockerfile` first and then `frontend/Dockerfile`.
 
-Once Okteto CLI is done building the images for you, it will start deploying your application to Okteto Cloud. You should see the deployed endpoints as part of the output in the CLI:
+Once Okteto CLI is done building the images for you, it will start deploying your application to Okteto. You should see the deployed endpoints as part of the output in the CLI:
 
 ```console
 Success! Your application will be available shortly.
@@ -113,7 +113,7 @@ i  Endpoints available:
   - https://movies-with-helm-cindylopez.cloud.okteto.net/api
 ```
 
-You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto Cloud dashboard:
+You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
 <Image
@@ -212,7 +212,7 @@ Okteto's Development Environment allowed the changes you made to your code local
 
 Congratulations! You successfully developed your first application in a Remote Development Environment. 
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
 
 From here, we recommend the following next steps:
 - Try launching a Dev Environment for your own application following similar steps to what we saw in this guide.

--- a/versioned_docs/version-0.10/api.mdx
+++ b/versioned_docs/version-0.10/api.mdx
@@ -11,7 +11,7 @@ import Image from '@theme/Image';
 
 ## The GraphQL API endpoint
 
-If you using Okteto Cloud, the endpoint is available at:
+If you using Okteto, the endpoint is available at:
 ```
 https://cloud.okteto.com/graphql
 ```

--- a/versioned_docs/version-0.10/cloud.mdx
+++ b/versioned_docs/version-0.10/cloud.mdx
@@ -1,14 +1,14 @@
 ---
-title: Okteto Cloud
-description: Okteto Cloud gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
-sidebar_label: Okteto Cloud
+title: Okteto
+description: Okteto gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
+sidebar_label: Okteto
 id: cloud
 ---
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
-Develop your Kubernetes applications in Okteto Cloud and forget about slow and tedious local development forever.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
+Develop your Kubernetes applications in Okteto and forget about slow and tedious local development forever.
 
-With Okteto Cloud you can:
+With Okteto you can:
 
 - Deploy your applications from [Git Repositories](/docs/0.10/cloud/deploy-from-git/), [Docker Compose](/docs/0.10/tutorials/stacks-getting-started/) files or [Helm Charts](/docs/0.10/cloud/deploy-from-helm/).
 - Configure how your application gets deployed using an [Okteto Pipeline](/docs/0.10/cloud/okteto-pipeline).
@@ -18,13 +18,13 @@ With Okteto Cloud you can:
 - Store your container images in [Okteto Registry](/docs/0.10/cloud/registry).
 - Create secure Kubernetes [Namespaces](/docs/0.10/cloud/namespaces/) with one click.
 - Download your [Kubernetes Credentials](/docs/0.10/cloud/credentials/) to access your namespaces with `kubectl`, `helm`, or any other CLI tool.
-- Set up [Personal Access Tokens](/docs/0.10/cloud/personal-access-tokens/) to interact with Okteto Cloud's API.
+- Set up [Personal Access Tokens](/docs/0.10/cloud/personal-access-tokens/) to interact with Okteto's API.
 - Visualize your workloads in a Developer-focused Kubernetes dashboard.
 
-Head over to our [5 minutes getting started guide](/docs/0.10/getting-started/) and see how you can use Okteto Cloud and Okteto CLI to start developing applications the cloud-native way!
+Head over to our [5 minutes getting started guide](/docs/0.10/getting-started/) and see how you can use Okteto and Okteto CLI to start developing applications the cloud-native way!
 
-The [FAQs](/docs/0.10/reference/faqs) section also covers some common questions you might have regarding Okteto Cloud.
+The [FAQs](/docs/0.10/reference/faqs) section also covers some common questions you might have regarding Okteto.
 
-## Okteto Cloud in your own infrastructure
+## Okteto in your own infrastructure
 
-Interested in running Okteto Cloud in your own infrastructure? [Okteto Enterprise](/docs/0.10/enterprise/) allows you to run and host Okteto Cloud on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).
+Interested in running Okteto in your own infrastructure? [Okteto Enterprise](/docs/0.10/enterprise/) allows you to run and host Okteto on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).

--- a/versioned_docs/version-0.10/cloud/build.mdx
+++ b/versioned_docs/version-0.10/cloud/build.mdx
@@ -1,19 +1,19 @@
 ---
 title: Okteto Build Service
-description: The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure
+description: The Okteto Build service allows you to build your development images directly in the Okteto infrastructure
 sidebar_label: Build Service
 id: build
 ---
 
 import Image from '@theme/Image';
 
-The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto Cloud.
+The Okteto Build service allows you to build your development images directly in the Okteto infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto.
 
 ## Build images
 
 You'll need the [okteto CLI](/docs/0.10/cloud/okteto-cli/) in order to access the Okteto Build Service.
 
-Once the Okteto CLI is installed, run `okteto context` and select the Okteto Cloud option to download the credentials and certificates required to access the Okteto Build service.
+Once the Okteto CLI is installed, run `okteto context` and select the Okteto option to download the credentials and certificates required to access the Okteto Build service.
 
 After that, run the `okteto build` command to build and push your images.
 
@@ -27,4 +27,4 @@ You can build and push images to any available docker registry. If you're not us
 
 ## Quotas
 
-Access to the Okteto Registry is included with all Okteto Cloud accounts. Developer accounts get 15 builds per day for free.
+Access to the Okteto Registry is included with all Okteto accounts. Developer accounts get 15 builds per day for free.

--- a/versioned_docs/version-0.10/cloud/credentials.mdx
+++ b/versioned_docs/version-0.10/cloud/credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: Download your Kubernetes credentials
-description: Download your Kubernetes credentials and start developing your applications in Okteto Cloud
+description: Download your Kubernetes credentials and start developing your applications in Okteto
 sidebar_label: Kubernetes Credentials
 id: credentials
 ---
@@ -10,18 +10,18 @@ import Button from '@theme/Button';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Download your Kubernetes credentials and start developing your applications in Okteto Cloud with your favorite CLI tools.
+Download your Kubernetes credentials and start developing your applications in Okteto with your favorite CLI tools.
 There are two different ways of downloading your Kubernetes credentials:
 
 - Download your Kubernetes credentials [using the Okteto CLI](#download-your-kubernetes-credentials-using-the-okteto-cli).
 
-- Download your Kubernetes credentials [from the Okteto Cloud UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Download your Kubernetes credentials [from the Okteto UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Download your Kubernetes credentials using the Okteto CLI
 
 If this is your first time using the Okteto CLI, install it following [this guide](/docs/0.10/cloud/okteto-cli/).
 
-The Okteto CLI can download your Kubernetes credentials from Okteto Cloud. To do this, run the `okteto context` command:
+The Okteto CLI can download your Kubernetes credentials from Okteto. To do this, run the `okteto context` command:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -32,9 +32,9 @@ Authentication will continue in your default browser
  ✓  Context 'cloud.okteto.com' created
 ```
 
-If you're not logged into Okteto Cloud yet, it will also run the login sequence.
+If you're not logged into Okteto yet, it will also run the login sequence.
 
-Once your okteto context is configured to access Okteto Cloud, run the following command:
+Once your okteto context is configured to access Okteto, run the following command:
 
 ```console
 $ okteto kubeconfig
@@ -47,7 +47,7 @@ Updated kubernetes context 'cloud_okteto_com/cindy' in '/Users/cindy/.kube/confi
 The `okteto kubeconfig` command adds your Kubernetes credentials to your kubeconfig file, and sets it as the current Kubernetes context.
 Once you do this, you'll have full access to your Kubernetes namespace with `kubectl`, `helm` or any other CLI tool.
 
-## Download your Kubernetes credentials from the Okteto Cloud UI
+## Download your Kubernetes credentials from the Okteto UI
 
 Download your Kubernetes credentials and save them in a well-known location:
 
@@ -57,7 +57,7 @@ Download your Kubernetes credentials and save them in a well-known location:
   </Button>
 </p>
 
-From the Okteto Cloud UI you should also find your credentials in the `Settings > Setup` section.
+From the Okteto UI you should also find your credentials in the `Settings > Setup` section.
 
 Once downloaded, point your `KUBECONFIG` environment variable to the credentials file:
 
@@ -97,7 +97,7 @@ No resources found.
 
 ## Using your Kubernetes credentials
 
-Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 For example, you could use `kubectl` to deploy our `hello-world` application:
 
@@ -105,5 +105,5 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-[Okteto Cloud](/docs/0.10/cloud) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-Take a look at the [FAQs](/docs/0.10/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+[Okteto](/docs/0.10/cloud) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+Take a look at the [FAQs](/docs/0.10/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/versioned_docs/version-0.10/cloud/custom-domains.mdx
+++ b/versioned_docs/version-0.10/cloud/custom-domains.mdx
@@ -1,38 +1,38 @@
 ---
 title: Custom Domain Names for your Applications
-description: Use a custom domain name for your applications with Okteto Cloud
+description: Use a custom domain name for your applications with Okteto
 sidebar_label: Custom Domain Names
 id: custom-domains
 ---
 
 import Image from '@theme/Image';
 
-By default, an application deployed in Okteto Cloud will be available at its Okteto Cloud domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
+By default, an application deployed in Okteto will be available at its Okteto domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
 
 For example, an application called `hello` deployed in the namespace `cindylopez` will be available at `https://hello-cindylopez.cloud.okteto.net`.
 
-To make your applications available on a non-Okteto Cloud domain (for example: `myapp.com`), you can add a **custom domain to your Okteto Cloud namespace**.
+To make your applications available on a non-Okteto domain (for example: `myapp.com`), you can add a **custom domain to your Okteto namespace**.
 This feature is part of the Okteto Developer Pro plan. If you haven't tried it yet, [start your 14-day free trial here](https://cloud.okteto.com/#/settings/plans/pro-upgrade).
 
-Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto Cloud endpoints.
+Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto endpoints.
 
 > Okteto does not provide a domain registration service (for registering a custom domain name) or a DNS provider service.
 
 ## Add a Custom Domain Name to your Application.
 
-Perform the following tasks to register your custom domain in your Okteto Cloud account:
+Perform the following tasks to register your custom domain in your Okteto account:
 
 1. Confirm that you own the custom domain name. Need a custom domain name? You can buy one with a domain registration service.
 
-2. Register your custom domain with Okteto Cloud by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
+2. Register your custom domain with Okteto by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
 
-3. Update your DNS configuration so your custom domain points to Okteto Cloud's DNS target.
+3. Update your DNS configuration so your custom domain points to Okteto's DNS target.
 
 ## Configure your Application to use your Custom Domain
 
-Once your domain has been registered with your Okteto Cloud account, it's time to put it to use.
+Once your domain has been registered with your Okteto account, it's time to put it to use.
 
-If you're using Okteto Cloud's [auto-ingress](/docs/0.10/cloud/ssl/) or [generate the host](/docs/0.10/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
+If you're using Okteto's [auto-ingress](/docs/0.10/cloud/ssl/) or [generate the host](/docs/0.10/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
 
 For example, if your application's endpoint was `https://hello-cindylopez.cloud.okteto.net` and you added the custom domain `myapp.com`, after redeployment your application's endpoint will be `https://hello.myapp.com`.
 
@@ -40,7 +40,7 @@ For example, if your application's endpoint was `https://hello-cindylopez.cloud.
 
 If you want to make your application available in the root domain you provided, you'll need to make a small change to your manifests.
 
-If you're using Okteto Cloud's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
+If you're using Okteto's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
 
 ```yaml
 apiVersion: v1

--- a/versioned_docs/version-0.10/cloud/deploy-from-git.mdx
+++ b/versioned_docs/version-0.10/cloud/deploy-from-git.mdx
@@ -12,7 +12,7 @@ Note that your Git repository needs to be configured with an [Okteto Pipeline](/
 Read the Okteto Pipeline [getting started guide](/docs/0.10/tutorials/getting-started-with-pipelines/) to learn how to create an Okteto Pipeline for your Git repository. -->
 
 ## Prerequisites
-When you deploy a Git repository, Okteto Cloud will analyze the source code of your Git repository, looking for clues on how to deploy your application.
+When you deploy a Git repository, Okteto will analyze the source code of your Git repository, looking for clues on how to deploy your application.
 
 Okteto will look for deployment manifests in the following order:
 
@@ -27,13 +27,13 @@ If Okteto is not able to detect how to deploy your application, or you want to h
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
 A dialog will open asking for a Git repository to deploy. Make sure that "**Git URL**" is selected as the source.
 Type the URL for the Movies App repo (https://github.com/okteto/movies), pick a branch, and click **Launch**:
 
 <p align="center"><Image src="/docs/cloud/images/deploy-git.png" alt="deploy from git" width="650" /></p>
 
-When you launch a dev environment using a Git repository, Okteto Cloud will analyze your repo and automatically deploy it.
+When you launch a dev environment using a Git repository, Okteto will analyze your repo and automatically deploy it.
 In the example above, Okteto will install the chart of the Movies App with Helm.
 
 > Check the [Configuration section](/docs/0.10/cloud/okteto-pipeline/) to learn more about Okteto's auto deployment capabilities, and how to customize this with a `okteto-pipeline.yml` file.
@@ -74,11 +74,11 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in GitHub README files, documentation sites, or pretty much anywhere that renders an HTML file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 
-The only requirements for creating the button are that your application be deployed in Okteto Cloud, and that the application's source code is hosted in a public Git repository.
+The only requirements for creating the button are that your application be deployed in Okteto, and that the application's source code is hosted in a public Git repository.
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-0.10/cloud/deploy-from-helm.mdx
+++ b/versioned_docs/version-0.10/cloud/deploy-from-helm.mdx
@@ -7,12 +7,12 @@ id: deploy-from-helm
 
 import Image from '@theme/Image';
 
-You can launch additional services for your development environments on Okteto Cloud using Helm repositories.
+You can launch additional services for your development environments on Okteto using Helm repositories.
 Okteto automates all the processes needed to deploy, configure, upgrade, and destroy your Helm releases, so you can focus on building amazing applications.
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
 Switch to the *From Chart* tab and a list of available services to deploy on your namespace will be shown.
 The list will look something like this:
 
@@ -22,7 +22,7 @@ Click on the service you want to deploy (we'll be using **Redis** in this exampl
 
 <p align="center"><Image src="/docs/cloud/images/deploy-redis.png" alt="deploy redis" width="650" /></p>
 
-When you click on **Launch**, Okteto Cloud will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
+When you click on **Launch**, Okteto will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
 
 As soon as your Helm release is deployed, you'll see its state in the UI. The UI will automatically update as the different components are created. Your Helm release will be ready to go once it reaches the `Success` state.
 
@@ -30,7 +30,7 @@ As soon as your Helm release is deployed, you'll see its state in the UI. The UI
 
 ## Redeploy
 
-You can also redeploy your Helm releases from Okteto Cloud. This is useful when you want to upgrade or redeploy your services.
+You can also redeploy your Helm releases from Okteto. This is useful when you want to upgrade or redeploy your services.
 
 Click on **Redeploy** on the right of your Helm release.
 The *Redeploy Helm Chart* dialog shows you the available versions, as well as the configuration used to deploy the current version of the Helm release.
@@ -48,10 +48,10 @@ A confirmation dialog will pop up. Click on the **Destroy** button to confirm yo
 <p align="center"><Image src="/docs/cloud/images/destroy-helm.png" alt="Destroy Helm releases" width="450" /></p>
 
 In this case, the persistent volume created by Redis won't be deleted to avoid losing any sensitive data.
-You can delete it manually from the Okteto Cloud UI if you want.
+You can delete it manually from the Okteto UI if you want.
 
 ## Application Catalog
 
-The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto Cloud.
+The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto.
 
 You can also [bring your own Helm repository](/docs/0.10/tutorials/repos/) to the catalog and get the same one-click deployment experience for your own services.

--- a/versioned_docs/version-0.10/cloud/deploy-from-terminal.mdx
+++ b/versioned_docs/version-0.10/cloud/deploy-from-terminal.mdx
@@ -7,11 +7,11 @@ id: deploy-from-terminal
 
 import Image from '@theme/Image';
 
-You have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+You have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 ## Download your Kubernetes credentials
 
-In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto Cloud.
+In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto.
 [This document](/docs/0.10/cloud/credentials/) will walk you through the necessary steps for this.
 
 ## Deploy your Application
@@ -23,6 +23,6 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-Okteto Cloud is a multi-tenant environment.
-A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-[Take a look at this document](/docs/0.10/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+Okteto is a multi-tenant environment.
+A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+[Take a look at this document](/docs/0.10/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/versioned_docs/version-0.10/cloud/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-0.10/cloud/develop-on-okteto-button.mdx
@@ -12,14 +12,14 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in Git `README` files, documentation sites, or pretty much anywhere that renders an html file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements
 
-The basic requirements for creating the button are that your application can be deployed in Okteto Cloud, and that the application's source code is hosted in a public Git repository.
+The basic requirements for creating the button are that your application can be deployed in Okteto, and that the application's source code is hosted in a public Git repository.
 
 The easiest way to validate this is to follow the instructions in the [Deploy from Git](/docs/0.10/cloud/deploy-from-git/) document.
 

--- a/versioned_docs/version-0.10/cloud/github-actions.mdx
+++ b/versioned_docs/version-0.10/cloud/github-actions.mdx
@@ -1,17 +1,17 @@
 ---
 title: GitHub Actions
-description: Automate your development workflows using GitHub Actions and Okteto Cloud
+description: Automate your development workflows using GitHub Actions and Okteto
 sidebar_label: GitHub Actions
 id: github-actions
 ---
 
-Automate your development workflows using GitHub Actions and Okteto Cloud.
+Automate your development workflows using GitHub Actions and Okteto.
 
-GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto Cloud, you can create workflows to build, deploy, and update your applications in Okteto Cloud.
+GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto, you can create workflows to build, deploy, and update your applications in Okteto.
 
 ## Available Actions
 
-The GitHub Actions for Okteto Cloud are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
+The GitHub Actions for Okteto are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
 
 - [Activate Namespace](https://github.com/marketplace/actions/activate-namespace)
 - [Apply](https://github.com/marketplace/actions/kubectl-apply)

--- a/versioned_docs/version-0.10/cloud/multitenancy.mdx
+++ b/versioned_docs/version-0.10/cloud/multitenancy.mdx
@@ -1,25 +1,25 @@
 ---
-title: Default Settings for Okteto Cloud
-description: Okteto Cloud gives you access to a Kubernetes namespace in a multi-tenant environment
+title: Default Settings for Okteto
+description: Okteto gives you access to a Kubernetes namespace in a multi-tenant environment
 sidebar_label: Default Settings
 id: multitenancy
 ---
 
-Okteto Cloud gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
+Okteto gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
 
-This document explains the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+This document explains the limitations and restrictions most likely to affect your applications in Okteto.
 
 ## Exposing services
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/0.10/cloud/ssl/).
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/0.10/cloud/ssl/).
 
 ## Pod Security Policies
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
 ## Resource quotas
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -62,11 +62,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 
 ## Network policies
 
-Okteto Cloud configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+Okteto configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
 ## RBAC
 
-Okteto Cloud uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Okteto uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/versioned_docs/version-0.10/cloud/namespaces.mdx
+++ b/versioned_docs/version-0.10/cloud/namespaces.mdx
@@ -7,13 +7,13 @@ id: namespaces
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can create and manage secure and isolated Kubernetes namespaces for you and your team.
+With Okteto you can create and manage secure and isolated Kubernetes namespaces for you and your team.
 
-Okteto Cloud will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
+Okteto will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
 
 ## Manage your namespaces
 
-You can create up to five namespaces per account. Go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
+You can create up to five namespaces per account. Go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
 
 <p align="center"><Image src="/docs/cloud/images/new-dialog.png" alt="new namespace dialog" width="650" /></p>
 
@@ -27,8 +27,8 @@ Once you're done, you can also delete your namespace via the UI, or with the `ok
 
 By default, you'll be the only person with access to your namespaces. Invite your teammates to enable true real-time collaboration.
 
-To share a namespace go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
+To share a namespace go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
 
 <p align="center"><Image src="/docs/cloud/images/share.png" alt="share a namespace" width="850" /></p>
 
-In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto Cloud will update the necessary permissions and notify your teammates via email.
+In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto will update the necessary permissions and notify your teammates via email.

--- a/versioned_docs/version-0.10/cloud/okteto-cli.md
+++ b/versioned_docs/version-0.10/cloud/okteto-cli.md
@@ -5,7 +5,7 @@ sidebar_label: Okteto CLI
 id: okteto-cli
 ---
 
-[Dev Environments](/docs/0.10/reference/development-environment) allow you to develop your deployed application locally. You continue coding  in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to set up Dev Environments with any Kubernetes cluster - your own, Okteto Cloud, or Okteto Self-Hosted.
+[Dev Environments](/docs/0.10/reference/development-environment) allow you to develop your deployed application locally. You continue coding  in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to set up Dev Environments with any Kubernetes cluster - your own, Okteto, or Okteto Self-Hosted.
 
 Below are instructions on how you can install Okteto CLI. Some other important topics related to the CLI are documented here:
 

--- a/versioned_docs/version-0.10/cloud/okteto-pipeline.mdx
+++ b/versioned_docs/version-0.10/cloud/okteto-pipeline.mdx
@@ -5,7 +5,7 @@ sidebar_label: Okteto Pipeline
 id: okteto-pipeline
 ---
 
-Okteto Pipelines allow you to configure how your [Git repositories](/docs/0.10/cloud/deploy-from-git) get deployed to [Okteto Cloud](/docs/0.10/cloud/). You might want to use them if Okteto Cloud cannot detect how to deploy your application from your [deployment manifests](/docs/0.10/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
+Okteto Pipelines allow you to configure how your [Git repositories](/docs/0.10/cloud/deploy-from-git) get deployed to [Okteto](/docs/0.10/cloud/). You might want to use them if Okteto cannot detect how to deploy your application from your [deployment manifests](/docs/0.10/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
 
 ### Example okteto-pipeline.yml
 
@@ -22,7 +22,7 @@ devs:
 
 ### Schema Reference
 
-- `icon`: the icon associated to your application in the Okteto Cloud Dashboard (optional).
+- `icon`: the icon associated to your application in the Okteto Dashboard (optional).
 - `deploy`: list of commands to deploy your application in your Kubernetes namespace. It is usually a combination of `helm`, `kubectl`, and `okteto` commands.
 - `destroy`: list of commands to be executed when the pipeline is destroyed. It can be used to release any resource created outside Okteto.
 - `devs`: the paths to the okteto manifests in your Git repository. This is used to fill the hints in the *Develop* dialog of each service (optional).
@@ -60,4 +60,4 @@ The installation job also populates the following environment variables. You can
 - `OKTETO_GIT_BRANCH`: the name of the Git branch currently being deployed.
 - `OKTETO_GIT_COMMIT`: the SHA1 hash of the last commit of the branch.
 - `OKTETO_REGISTRY_URL`: the url of the [Okteto Registry](/docs/0.10/cloud/registry/).
-- `BUILDKIT_HOST`: the address of the [Okteto Cloud buildkit instance](/docs/0.10/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
+- `BUILDKIT_HOST`: the address of the [Okteto buildkit instance](/docs/0.10/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.

--- a/versioned_docs/version-0.10/cloud/permissions.mdx
+++ b/versioned_docs/version-0.10/cloud/permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: GitHub Permissions for Okteto Cloud
-description: Details of permissions requested by Okteto Cloud when you login using your GitHub account
+title: GitHub Permissions for Okteto
+description: Details of permissions requested by Okteto when you login using your GitHub account
 sidebar_label: GitHub Permissions
 id: permissions
 ---
@@ -9,7 +9,7 @@ import Image from '@theme/Image';
 
 ## GitHub Permissions
 
-When using the Okteto Cloud Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
+When using the Okteto Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard-perms.png" alt="permissions requested on github for preview environments" width="650" /></p>
 
@@ -18,14 +18,14 @@ The reasons for requesting the above permissions are listed below.
 ### Repository Permissions
 
 - Contents: Needed to clone repositories for deploying Preview Environments
-- Metadata: Needed to list repositories a user has access to on the Okteto Cloud Dashboard
+- Metadata: Needed to list repositories a user has access to on the Okteto Dashboard
 - Pull Requests: Needed to comment on the pull requests with the deployed Preview Environment URL and to deploy/destroy a Preview Environment based on whether a PR has been opened/closed
 - Commit Statuses: Needed to change the status of a commit to show if the Preview Environment for it was deployed successfully or not
 
 ### Organization Permissions
 
-- Members: When an org admin installs Okteto Cloud for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto Cloud
+- Members: When an org admin installs Okteto for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto
 
 ### User Permissions
 
-- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto Cloud account.
+- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto account.

--- a/versioned_docs/version-0.10/cloud/preview-environments/dashboard.mdx
+++ b/versioned_docs/version-0.10/cloud/preview-environments/dashboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring Preview Environments
-description: Create preview environments for your application using the Okteto Cloud Dashboard
+description: Create preview environments for your application using the Okteto Dashboard
 sidebar_label: Configure
 id: dashboard
 ---
@@ -8,25 +8,25 @@ id: dashboard
 import Image from '@theme/Image';
 
 
-There are two ways to configure [Preview Environments](/docs/0.10/cloud/preview-environments/preview-environments) using Okteto Cloud for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Cloud Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/0.10/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/0.10/cloud/preview-environments/preview-environments/#prerequisites) section.
+There are two ways to configure [Preview Environments](/docs/0.10/cloud/preview-environments/preview-environments) using Okteto for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/0.10/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/0.10/cloud/preview-environments/preview-environments/#prerequisites) section.
 
 Note that this method is not applicable for users of [Okteto Self-Hosted](/docs/0.10/enterprise) or Okteto for Teams. Please checkout [GitHub Actions](/docs/0.10/cloud/preview-environments/preview-environments-github) for configuring Preview Environments in those cases.
 
-### Step 1: Log into Okteto Cloud
+### Step 1: Log into Okteto
 
-The first step is going to [Okteto Cloud](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
+The first step is going to [Okteto](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on okteto cloud" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on Okteto" /></p>
 
 In this guide, we will set up Preview Environments for a fork of the [movies-preview-environments](https://github.com/okteto/movies-preview-environments) repository. Head to that repository and [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of it under your GitHub account. Feel free to follow along with some other repository in your GitHub account once you've [configured](/docs/0.10/cloud/preview-environments/preview-environments/#prerequisites) it.
 
 ### Step 2: Add Your Repository
 
-Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto Cloud on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto Cloud requests and why over [here](/docs/0.10/cloud/permissions). 
+Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto requests and why over [here](/docs/0.10/cloud/permissions). 
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto Cloud on github account" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto on github account" /></p>
 
-Please note that you can only install Okteto Cloud for repositories belonging to your own GitHub account. Only org admins can install Okteto Cloud in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto Cloud to admins through GitHub.
+Please note that you can only install Okteto for repositories belonging to your own GitHub account. Only org admins can install Okteto in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto to admins through GitHub.
 
 Once you do that, you should see your repository appear in the list. 
 
@@ -42,7 +42,7 @@ That's right, this was all the configuration you needed to do! Head over to your
 
 Sharing this with team members is the best way to get their attention for reviews 😛
 
-You should also be able to see the pull request details along with the endpoints on the Okteto Cloud Dashboard.
+You should also be able to see the pull request details along with the endpoints on the Okteto Dashboard.
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/pr-in-dashboard.png" alt="endpoints for the pr" /></p>
 

--- a/versioned_docs/version-0.10/cloud/preview-environments/github.mdx
+++ b/versioned_docs/version-0.10/cloud/preview-environments/github.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments Using GitHub Actions
-description: Create a preview environment for your application using Okteto Cloud and GitHub Actions
+description: Create a preview environment for your application using Okteto and GitHub Actions
 sidebar_label: Using GitHub Actions
 id: preview-environments-github
 ---
 
 import Image from '@theme/Image';
 
-This section will show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+This section will show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/movies).
@@ -21,18 +21,18 @@ Start by forking the [movies](https://github.com/okteto/movies) repository with 
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we will use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we will use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Log into Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Log into Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/movies/blob/main/.github/workflows/preview.yaml).
 If you want to use this on for your repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.
 
-The workflow file to create the preview environments for Okteto Cloud users looks like this:
+The workflow file to create the preview environments for Okteto users looks like this:
 
 ```yaml
 # file: .github/workflows/preview.yaml

--- a/versioned_docs/version-0.10/cloud/preview-environments/gitlab.mdx
+++ b/versioned_docs/version-0.10/cloud/preview-environments/gitlab.mdx
@@ -1,6 +1,6 @@
 ---
 title: Preview Environments Using GitLab CI/CD
-description: Create a preview environment for your application using Okteto Cloud and GitLab
+description: Create a preview environment for your application using Okteto and GitLab
 sidebar_label: For GitLab
 id: preview-environments-gitlab
 ---
@@ -10,7 +10,7 @@ import Image from '@theme/Image';
 This section will show you how to automatically create a preview environment for your applications using Okteto and GitLab's preview apps.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitLab Account](https://gitlab.com)
 
 ## Step 1: Fork the Sample Repository
@@ -22,7 +22,7 @@ For this tutorial, we'll be using [this application](https://gitlab.com/okteto/p
 To deploy a preview environment with Okteto, you need to define the following environment variables:
 
 1. `OKTETO_TOKEN`: an Okteto [personal access token](/docs/0.10/cloud/personal-access-tokens/).
-1. `OKTETO_USERNAME`: your Okteto username (in Okteto Cloud, this is your GitHub Username).
+1. `OKTETO_USERNAME`: your Okteto username (in Okteto, this is your GitHub Username).
 1. [Optional] `OKTETO_URL`: if you are using [Okteto Enterprise](/enterprise/), specify the URL of your instance of Okteto Enterprise (e.g., https://okteto.dev.mycompany.com).
 
 To add the environment variables:
@@ -132,7 +132,7 @@ Okteto makes it easy to deploy your own [GitLab Runner](https://docs.gitlab.com/
 
 ### Deploy your GitLab Runner
 
-1. Log into [Okteto Cloud](https://cloud.okteto.com).
+1. Log into [Okteto](https://cloud.okteto.com).
 1. Click on the **Deploy** button on the top.
 1. Choose **Catalog** as the source, select **gitlab-runner** from the options below, and click **Deploy**.
 

--- a/versioned_docs/version-0.10/cloud/preview-environments/overview.mdx
+++ b/versioned_docs/version-0.10/cloud/preview-environments/overview.mdx
@@ -11,7 +11,7 @@ Preview environments allow you to include a live preview of your changes on ever
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-environments.png" alt="Preview Environments" /></p>
 
-Okteto's preview environments are powered by Kubernetes and easily integrate with your favorite source control and CI/CD provider. And they use [the same pipelines](/docs/0.10/cloud/okteto-pipeline/) that you already use as part of your development workflow, so it's simple to get started. You can use Preview Environments with either [Okteto Cloud](/docs/0.10/cloud) or with [Okteto Self-Hosted](/docs/0.10/enterprise) if you want to run them on your Kubernetes infrastructure.
+Okteto's preview environments are powered by Kubernetes and easily integrate with your favorite source control and CI/CD provider. And they use [the same pipelines](/docs/0.10/cloud/okteto-pipeline/) that you already use as part of your development workflow, so it's simple to get started. You can use Preview Environments with either [Okteto](/docs/0.10/cloud) or with [Okteto Self-Hosted](/docs/0.10/enterprise) if you want to run them on your Kubernetes infrastructure.
 
 - [GitHub](/docs/0.10/cloud/preview-environments/preview-environments-github/)
 - [GitLab](/docs/0.10/cloud/preview-environments/preview-environments-gitlab/)
@@ -21,6 +21,6 @@ Okteto's preview environments are powered by Kubernetes and easily integrate wit
 
 ## Prerequisites
 
-Preview environments deploy the code in a pull request to [Okteto Cloud](/docs/0.10/cloud/) or [Self-Hosted](/docs/0.10/enterprise/). You can configure the way your code gets deployed using [Okteto Pipelines](/docs/0.10/cloud/okteto-pipeline/). This is exactly the same as using Okteto Pipelines to do custom builds when using [Dev Environments](/docs/0.10/reference/development-environment/). 
+Preview environments deploy the code in a pull request to [Okteto](/docs/0.10/cloud/) or [Self-Hosted](/docs/0.10/enterprise/). You can configure the way your code gets deployed using [Okteto Pipelines](/docs/0.10/cloud/okteto-pipeline/). This is exactly the same as using Okteto Pipelines to do custom builds when using [Dev Environments](/docs/0.10/reference/development-environment/). 
 
-If you choose not to set up an Okteto Pipeline, Okteto Cloud will analyze the source code of your repository, looking for clues on how to deploy your application. You can read more about this [here](/docs/0.10/cloud/deploy-from-git/#prerequisites).
+If you choose not to set up an Okteto Pipeline, Okteto will analyze the source code of your repository, looking for clues on how to deploy your application. You can read more about this [here](/docs/0.10/cloud/deploy-from-git/#prerequisites).

--- a/versioned_docs/version-0.10/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.10/cloud/private-endpoints.mdx
@@ -10,9 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-Okteto Cloud allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
+Okteto allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
 
-Private endpoints can be identified by the lock icon in the Okteto Cloud UI:
+Private endpoints can be identified by the lock icon in the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/private-endpoints.png" alt="private endpoints UI" width="850" /></p>
 
@@ -165,6 +165,6 @@ services:
 
 ## Restrictions
 
-Private Endpoints use your Okteto Cloud account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
+Private Endpoints use your Okteto account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
 
 Private Endpoints only restrict external access to your applications. Applications running in your namespace will be able to access your private endpoints without authentication by using the `service` name.

--- a/versioned_docs/version-0.10/cloud/private-repositories.mdx
+++ b/versioned_docs/version-0.10/cloud/private-repositories.mdx
@@ -15,13 +15,13 @@ Okteto integrates with GitHub and allows you to easily deploy any repository fro
 
 You'll need to perform the following steps the first time you grant GitHub permissions to Okteto:
 
-1. Log into Okteto Cloud
+1. Log into Okteto
 1. Click on the "**Launch Dev Environment**" button on the top
 1. Make sure "**GitHub**" is the selected source
 <p align="center"><Image src="/docs/cloud/images/private-repositories-deploy.png" alt="Launch private repository from git" width="650" /></p>
 
-1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto Cloud App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
-<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto Cloud" width="400" /></p>
+1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
+<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto" width="400" /></p>
 
 1. Finally click on the **Install & Authorize** button to proceed. If you're not the administrator of the organization, GitHub will send an email notification to your administrator and wait for their authorization to complete the installation and grant you access.
 <p align="center"><Image src="/docs/cloud/images/private-repositories-authorize.png" alt="install and authorize repositories" width="400" /></p>

--- a/versioned_docs/version-0.10/cloud/registry.mdx
+++ b/versioned_docs/version-0.10/cloud/registry.mdx
@@ -47,6 +47,6 @@ registry.cloud.okteto.net/<okteto-namespace>/<image>:<tag>
 
 Any image pushed into the Okteto Registry is private. You'll need to authenticate with the registry before pulling an image.
 
-Namespaces in Okteto Cloud are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
+Namespaces in Okteto are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
 
 To pull an image from a different namespace, you'll need to create and configure the required `imagePullSecrets` as outlined [here](/docs/0.10/reference/faqs/#how-to-use-private-images).

--- a/versioned_docs/version-0.10/cloud/secrets.mdx
+++ b/versioned_docs/version-0.10/cloud/secrets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Okteto Secrets
-description: Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject them during deployment time
+description: Okteto Secrets allows you to save application configuration in Okteto, and automatically inject them during deployment time
 sidebar_label: Okteto Secrets
 id: secrets
 ---
@@ -9,11 +9,11 @@ import Image from '@theme/Image';
 
 Application configuration should be passed at deployment time, not hardcoded in your code.
 
-Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject it during deployment time.
+Okteto Secrets allows you to save application configuration in Okteto, and automatically inject it during deployment time.
 
-## Manage Okteto Secrets from the Okteto Cloud UI
+## Manage Okteto Secrets from the Okteto UI
 
-You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto Cloud UI:
+You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/secrets.png" alt="Secrets in settings" width="650" /></p>
 

--- a/versioned_docs/version-0.10/cloud/ssl.mdx
+++ b/versioned_docs/version-0.10/cloud/ssl.mdx
@@ -5,7 +5,7 @@ sidebar_label: Automatic SSL
 id: ssl
 ---
 
-Okteto Cloud can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
+Okteto can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
 
 ```
   dev.okteto.com/auto-ingress: "true"
@@ -36,7 +36,7 @@ spec:
 
 Adding this annotation will tell Okteto to automatically create an https ingress rule for you that redirects to the first http port of your service. `NodePort` or `LoadBalancer` services are managed as if they had this annotation too.
 
-You can see the address of your endpoint by going to Okteto Cloud's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
+You can see the address of your endpoint by going to Okteto's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
 
 ## Bring your own ingress
 
@@ -46,7 +46,7 @@ Keep in mind that all the hosts you use in your ingress must end with`-$NAMESPAC
 
 ### Let Okteto generate the host
 
-Okteto Cloud can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
+Okteto can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
 
 ```
   dev.okteto.com/generate-host: "true"
@@ -71,4 +71,4 @@ spec:
         path: /
 ```
 
-We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto Cloud namespace.
+We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto namespace.

--- a/versioned_docs/version-0.10/enterprise.mdx
+++ b/versioned_docs/version-0.10/enterprise.mdx
@@ -5,7 +5,7 @@ sidebar_label: Overview
 id: enterprise
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/0.10/cloud/), with the control and flexibility of running in your Kubernetes infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/0.10/cloud/), with the control and flexibility of running in your Kubernetes infrastructure.
 
 With Okteto Enterprise your team can:
 
@@ -17,7 +17,7 @@ With Okteto Enterprise your team can:
 - Get [automatic HTTPs endpoints](/docs/0.10/cloud/ssl/) for your services
 - Configure [secrets](/docs/0.10/cloud/secrets/) and prevent secure credentials from being stored in version control
 - [Download kubectl credentials](/docs/0.10/cloud/credentials/) to access your namespaces with `kubectl` or any other tool
-- Develop directly in Okteto Cloud with the [Okteto CLI](https://github.com/okteto/okteto)
+- Develop directly in Okteto with the [Okteto CLI](https://github.com/okteto/okteto)
 - Collaborate by [sharing](/docs/0.10/cloud/namespaces/#share-your-namespace) your namespaces with your teammates
 - Keep your infrastructure under control with the Okteto [Garbage Collector](/docs/0.10/enterprise/administration/cleanup/) and the [Okteto Autoscaler](/docs/0.10/enterprise/administration/configuration/#autoscaler)
 

--- a/versioned_docs/version-0.10/enterprise/install/overview.mdx
+++ b/versioned_docs/version-0.10/enterprise/install/overview.mdx
@@ -5,7 +5,7 @@ sidebar_label: Overview
 id: overview
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/0.10/cloud/), with the control and flexibility of running in your own infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/0.10/cloud/), with the control and flexibility of running in your own infrastructure.
 
 Okteto Enterprise is free for small teams.  You get all the features of [Okteto Enterprise](/docs/0.10/enterprise/) for up to 3 users with 3 namespaces each.
 

--- a/versioned_docs/version-0.10/getting-started.mdx
+++ b/versioned_docs/version-0.10/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
-title: Getting Started on Okteto Cloud in 5 minutes 
-description: Develop your Kubernetes applications in Okteto Cloud and forget about slow and tedious local development forever
+title: Getting Started on Okteto in 5 minutes 
+description: Develop your Kubernetes applications in Okteto and forget about slow and tedious local development forever
 sidebar_label: Quick Start Guide
 id: getting-started
 ---
@@ -9,28 +9,28 @@ import Image from '@theme/Image';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a sample application.
 
 ## Step 1: Launch the Movies App
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A dialog will open with different options to launch your new environment. Make sure that "**Git URL**" is selected as the source.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A dialog will open with different options to launch your new environment. Make sure that "**Git URL**" is selected as the source.
 Type the one for the Movies App repository (https://github.com/okteto/movies), pick a branch, and click **Launch**:
 
-<p align="center"><Image src="/docs/images/deploy.png" alt="Launch a development environment with Okteto Cloud" width="600" /></p>
+<p align="center"><Image src="/docs/images/deploy.png" alt="Launch a development environment with Okteto" width="600" /></p>
 
 The [Movies App](https://github.com/okteto/movies) is a simple web app composed of: a React frontend, a Node.js api, and a mongodb database.
-When you launch a dev environment for the Movies App repository, Okteto Cloud will run the deploy pipeline defined by the `okteto-pipeline.yml` of the repository.
+When you launch a dev environment for the Movies App repository, Okteto will run the deploy pipeline defined by the `okteto-pipeline.yml` of the repository.
 In this case, the pipeline deploys the chart of the Movies App with Helm.
 
 > Check the [docs](/docs/0.10/cloud/okteto-pipeline/) to learn more about how to configure your `okteto-pipeline.yml` file.
 
 At this point, your application is deploying. It will be ready to go once its components reach the `Running` state.
 
-<p align="center"><Image src="/docs/images/ui-cloud.png" alt="Okteto Cloud UI" width="850" /></p>
+<p align="center"><Image src="/docs/images/ui-cloud.png" alt="Okteto UI" width="850" /></p>
 
-The Okteto Cloud dashboard is designed to be developer friendly. It gives you instant feedback about your applications logs, errors, metrics, and more.
+The Okteto dashboard is designed to be developer friendly. It gives you instant feedback about your applications logs, errors, metrics, and more.
 
 Now click on the application's endpoint of the frontend component to access the Movies App. You should see something like this:
 
@@ -69,9 +69,9 @@ Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
 
 More installation options are documented [here](/docs/0.10/cloud/okteto-cli/).
 
-## Step 3: Configure access to your Okteto Cloud namespace
+## Step 3: Configure access to your Okteto namespace
 
-The Okteto CLI can download your Kubernetes credentials from Okteto Cloud. To do this, you just need to run the context command:
+The Okteto CLI can download your Kubernetes credentials from Okteto. To do this, you just need to run the context command:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -83,7 +83,7 @@ $ okteto context use https://cloud.okteto.com
 ```
 
 The `okteto context` configures the default context for any Okteto CLI command.
-If you're not logged into Okteto Cloud yet, it also runs the login sequence.
+If you're not logged into Okteto yet, it also runs the login sequence.
 
 ## Step 4: Activate your development container
 
@@ -114,7 +114,7 @@ Welcome to your development container. Happy coding!
 cindy:api src>
 ```
 
-The `okteto up` command starts a [development container](/docs/0.10/reference/development-environment/) in Okteto Cloud, which means:
+The `okteto up` command starts a [development container](/docs/0.10/reference/development-environment/) in Okteto, which means:
 
 - A [file synchronization service](/docs/0.10/reference/file-synchronization/) is created to keep your changes up-to-date between your local filesystem and your development container
 - Container ports 8080 (the application) and 9229 (the debugger) are forwarded to localhost
@@ -179,14 +179,14 @@ Go back to the browser and reload the Movies App. Your code fixes were instantly
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Head over to our samples for [Go](/docs/0.10/samples/golang/), [ASP.NET](/docs/0.10/samples/aspnetcore), [Java](/docs/0.10/samples/java/), [Node.js](/docs/0.10/samples/node), [PHP](/docs/0.10/samples/php/), [Python](/docs/0.10/samples/python/), or [Ruby](/docs/0.10/samples/ruby/) to see how to use Okteto to live-update your application with different programming languages and **debuggers**.
 

--- a/versioned_docs/version-0.10/reference/cli.mdx
+++ b/versioned_docs/version-0.10/reference/cli.mdx
@@ -56,7 +56,7 @@ Build an image from a Dockerfile and push it to a registry:
 $ okteto build [PATH]
 ```
 
-If your [okteto context](/docs/0.10/reference/cli/#context) points to Okteto Cloud or an Okteto Enterprise URL, images are built using the [Okteto Build Service](/docs/0.10/cloud/build/).
+If your [okteto context](/docs/0.10/reference/cli/#context) points to Okteto or an Okteto Enterprise URL, images are built using the [Okteto Build Service](/docs/0.10/cloud/build/).
 Otherwise, images are built using your local Docker daemon.
 
 The following flags can be used (very similar to `docker build`):
@@ -89,7 +89,7 @@ This will prompt you to select one of your existing contexts or to create a new 
 A context defines the default cluster/namespace for any Okteto CLI command.
 Select the context you want to use:
 Use the arrow keys to navigate: ↓ ↑ → ←
-  ▸ https://cloud.okteto.com (Okteto Cloud) *
+  ▸ https://cloud.okteto.com (Okteto) *
     minikube
     staging
     production
@@ -121,7 +121,7 @@ Available subcommands:
 
 Delete a context.
 
-For example, to delete the Okteto Cloud context, run:
+For example, to delete the Okteto context, run:
 
 ```console
 $ okteto context delete https://cloud.okteto.com
@@ -286,7 +286,7 @@ $ okteto kubeconfig
 ### login
 
 Log into Okteto, and download your API token and certificates required to interact with the Okteto Build Service.
-It defaults to [Okteto Cloud](https://cloud.okteto.com), but you can specify your own Okteto URL by specifying a `URL` argument.
+It defaults to [Okteto](https://cloud.okteto.com), but you can specify your own Okteto URL by specifying a `URL` argument.
 
 ```console
 $ okteto login [URL]
@@ -504,7 +504,7 @@ $ okteto push
 `okteto push` builds a new docker image, pushes it to the registry, and redeploys your containers.
 If you have an active development container created by `okteto up`, it is also deactivated as part of the *push* operation.
 
-If your [okteto context](/docs/0.10/reference/cli/#context) points to Okteto Cloud or an Okteto Enterprise URL, images are built using the [Okteto Build Service](/docs/0.10/cloud/build/).
+If your [okteto context](/docs/0.10/reference/cli/#context) points to Okteto or an Okteto Enterprise URL, images are built using the [Okteto Build Service](/docs/0.10/cloud/build/).
 Otherwise, images are built using your local Docker daemon.
 
 Options | Type | Description
@@ -575,7 +575,7 @@ By default, Okteto reads two files, an `okteto-stack.yml` and an optional `oktet
 If both files exist, or if `--file` refers to a list of stack manifests, stack manifests are merged.
 A manifest merge means any field defined in the second stack manifest replaces the value in the first stack manifest.
 
-If your [okteto context](/docs/0.10/reference/cli/#context) points to Okteto Cloud or an Okteto Enterprise URL, images are built using the [Okteto Build Service](/docs/0.10/cloud/build/).
+If your [okteto context](/docs/0.10/reference/cli/#context) points to Okteto or an Okteto Enterprise URL, images are built using the [Okteto Build Service](/docs/0.10/cloud/build/).
 Otherwise, images are built using your local Docker daemon.
 
 #### destroy

--- a/versioned_docs/version-0.10/reference/development-containers.mdx
+++ b/versioned_docs/version-0.10/reference/development-containers.mdx
@@ -20,9 +20,9 @@ For using `okteto up`, you will need to install the Okteto CLI. Okteto CLI is an
 
 Coming to the first step of deploying your application code, there are multiple options available for you to choose from. You can choose to deploy it on an existing cluster and use Okteto CLI to interact with this cluster. 
 
-A second option available is Okteto Cloud. Using Okteto Cloud, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto Cloud was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/0.10/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto Cloud [documentation](/docs/0.10/cloud). 
+A second option available is Okteto. Using Okteto, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/0.10/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto [documentation](/docs/0.10/cloud). 
 
-Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto Cloud - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto Cloud. The Okteto Self-Hosted [documentation](/docs/0.10/enterprise) covers how you can get started with it. 
+Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto. The Okteto Self-Hosted [documentation](/docs/0.10/enterprise) covers how you can get started with it. 
 
 ## Getting started
 

--- a/versioned_docs/version-0.10/reference/faqs.mdx
+++ b/versioned_docs/version-0.10/reference/faqs.mdx
@@ -70,13 +70,13 @@ $ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcr
 
 With this configuration, all the deployments, stateful sets, jobs, and development containers launched in your namespace will automatically use your registry credentials when pulling private images.
 
-## What types of Kubernetes services are supported in Okteto Cloud?
+## What types of Kubernetes services are supported in Okteto?
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/0.10/cloud/ssl/). Okteto Cloud also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/0.10/cloud/ssl/). Okteto also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
-## What resource quotas are present in Okteto Cloud Namespaces?
+## What resource quotas are present in Okteto Namespaces?
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -113,11 +113,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 | Requests accepted each second from the same IP | 40/ingress  |
 | Requests accepted each minute from the same IP | 400/ingress  |
 
-## Are there any restrictions on applications deployed on Okteto Cloud?
+## Are there any restrictions on applications deployed on Okteto?
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
-Apart from that, Okteto Cloud also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Apart from that, Okteto also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/versioned_docs/version-0.10/reference/known-issues.mdx
+++ b/versioned_docs/version-0.10/reference/known-issues.mdx
@@ -17,7 +17,7 @@ For example, you can do it by running this command on each node:
 $ sudo sysctl -w fs.inotify.max_user_watches=10048576
 ```
 
-Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
+Okteto and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
 
 ## *kubectl apply* changes are undone by *okteto up*
 
@@ -25,7 +25,7 @@ Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automat
 
 If you need to apply changes to your Kubernetes Deployment Manifest after running `okteto up`, note that **you need to run `okteto down` first** or `okteto up` will undo the changes you do to your Kubernetes Deployment Manifests. The reason is that `okteto up` records a copy of the deployment when `okteto up` is executed. This copy is used by `okteto down` to restore the original Kubernetes Deployment Manifest. But it is also used by `okteto up` as the original deployment to avoid ambiguities of "kubectl apply" concurrent changes.
 
-This issue does not apply if you're using Okteto Cloud or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
+This issue does not apply if you're using Okteto or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
 
 ## The okteto prompt doesn't look right in Windows
 

--- a/versioned_docs/version-0.10/reference/stacks.mdx
+++ b/versioned_docs/version-0.10/reference/stacks.mdx
@@ -444,7 +444,7 @@ will use `change-me!` for the value of the `MYSQL_ROOT_PASSWORD` environment var
 
 > Values in the shell and/or the `.env` file take precedence over those specified in Okteto Secrets.
 
-## Okteto Cloud makes Docker Compose even more powerful!
+## Okteto makes Docker Compose even more powerful!
 
 Okteto Stacks extends the Compose Specification to make it even easier for you and your team to build cloud-native applications.
 

--- a/versioned_docs/version-0.10/samples/aspnetcore.mdx
+++ b/versioned_docs/version-0.10/samples/aspnetcore.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with ASP.NET
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application
+title: Getting Started on Okteto with ASP.NET
+description: This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application
 sidebar_label: ASP.NET
 id: aspnetcore
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application.
+This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the ASP.NET Sample App
 
@@ -36,11 +36,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI ASP.NET" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI ASP.NET" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Activate your development container
 
@@ -81,7 +81,7 @@ The `okteto up` command starts a [development container](/docs/0.10/reference/de
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 3: Develop directly in Okteto Cloud
+## Step 3: Develop directly in Okteto
 
 Open the file `Controllers/HelloWorldController.cs` in your favorite local IDE and modify the response message on line 25 to be *Hello world from Okteto!*. Save your changes.
 
@@ -113,7 +113,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code using the VS dotnet debugger.
 
@@ -131,11 +131,11 @@ Go back to the browser and reload the page. As soon as the service receives the 
 
 <Image center borderless src="/docs/samples/images/aspnetcore-debug.png" alt="ASP.NET core debug" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -144,6 +144,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](/docs/0.10/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.10/samples/golang.mdx
+++ b/versioned_docs/version-0.10/samples/golang.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Go
+title: Getting Started on Okteto with Go
 description: This tutorial will show you how to develop a Go sample application
 sidebar_label: Go
 id: golang
@@ -7,14 +7,14 @@ id: golang
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Go sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Go sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Go Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI golang" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI golang" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -139,7 +139,7 @@ Starting hello-world server...
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the file `main.go` in your favorite local IDE and modify the response message on line 17 to be *Hello world from Okteto!*. Save your changes.
 
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Go development.
@@ -210,18 +210,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/golang-debug.png" alt="debugging in Okteto with golang" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.10/samples/java.mdx
+++ b/versioned_docs/version-0.10/samples/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Java
+title: Getting Started on Okteto with Java
 description: This tutorial will show you how to develop a Java sample application
 sidebar_label: Java
 id: java
@@ -7,14 +7,14 @@ id: java
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Java sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Java sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Java Sample App
 
@@ -46,11 +46,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Java" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Java" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -165,7 +165,7 @@ The first time you run the application, Maven/Gradle will compile your applicati
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open `src/main/java/com/okteto/helloworld/RestHelloWorld.java` in your favorite local IDE and modify the response message on line 11 to be *Hello world from Okteto!*. Save your changes.
 
@@ -185,13 +185,13 @@ public class RestHelloWorld {
 }
 ```
 
-Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto Cloud. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
+Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
 
 > Import the `spring-boot-devtools` dependency to automatically restart your Java application whenever a file is changed.
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in Eclipse, one of the most popular IDEs for Java development.
 
@@ -207,17 +207,17 @@ Click the Debug button to start a debugging session. Add a breakpoint on `src/ma
 
 <Image center src="/docs/samples/images/java-halt.png" alt="breakpoint in Java" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.10/samples/node.mdx
+++ b/versioned_docs/version-0.10/samples/node.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Node.js
+title: Getting Started on Okteto with Node.js
 description: This tutorial will show you how to develop a Node.js sample application
 sidebar_label: Node.js
 id: node
@@ -7,14 +7,14 @@ id: node
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Node.js sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Node.js sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Node.js Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Node.js" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Node.js" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -135,7 +135,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `index.js` file in your favorite local IDE and modify the response message on line 5 to be *Hello world from the cluster!*. Save your changes.
 
@@ -154,7 +154,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Node development.
@@ -201,18 +201,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/node-halt.png" alt="breakpoint in Node.js" width="850" />
 
-Your code is running in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is running in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing on a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.10/samples/php.mdx
+++ b/versioned_docs/version-0.10/samples/php.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with PHP
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application
+title: Getting Started on Okteto with PHP
+description: This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application
 sidebar_label: PHP
 id: php
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the PHP Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI PHP" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI PHP" width="850" />
 
-Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto Cloud will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -134,7 +134,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `index.php` file in your favorite local IDE and modify the response message on line 2 to be *Hello world from the cluster!*. Save your changes.
 
@@ -146,7 +146,7 @@ echo($message);
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works with [PHPStorm](https://www.jetbrains.com/phpstorm/), one of the most popular IDEs for PHP development.
 
@@ -158,13 +158,13 @@ Go back to your browser and reload the page. The execution will automatically ha
 
 At this point, you're able to inspect the request object, the current values of everything, the contents of `$_SERVER` variable, etc.
 
-<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto Cloud with PHP" width="850" />
+<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto with PHP" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -173,6 +173,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.10/samples/python.mdx
+++ b/versioned_docs/version-0.10/samples/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Python
+title: Getting Started on Okteto with Python
 description: This tutorial will show you how to develop a Python sample application
 sidebar_label: Python
 id: python
@@ -7,14 +7,14 @@ id: python
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Python sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Python sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Python Sample App
@@ -38,11 +38,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Python" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Python" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -138,7 +138,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `app.py` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*.
 Save your changes.
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in one of python's most popular IDE's, [PyCharm](https://www.jetbrains.com/pycharm/).
@@ -206,18 +206,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center borderless src="/docs/samples/images/python-debug.png" alt="breakpoint in Python" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.10/samples/ruby.mdx
+++ b/versioned_docs/version-0.10/samples/ruby.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with Ruby
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application
+title: Getting Started on Okteto with Ruby
+description: This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application
 sidebar_label: Ruby
 id: ruby
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Ruby Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Ruby" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Ruby" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/0.10/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -132,7 +132,7 @@ cindy:hello-world app> ruby app.rb
 [2020-03-20 09:23:04] INFO  WEBrick::HTTPServer#start: pid=66 port=8080
 ```
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `app.rb` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*. Save your changes.
 
@@ -147,7 +147,7 @@ Okteto will synchronize your changes to your development container in Kubernetes
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code, one of the most popular IDEs for Ruby development. If you haven't done it yet, install the [Ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby) available from Visual Studio marketplace. This extension comes with debug definitions covering the default `ruby-debug-ide` client setup.
 
@@ -186,11 +186,11 @@ Add a breakpoint on `app.rb`, line 8. Go back to the browser and reload the page
 
 <Image center src="/docs/samples/images/ruby-halt.png" alt="debugging in Okteto with Ruby" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -199,6 +199,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/0.10/tutorials/getting-started-with-pipelines/) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.10/tutorials/getting-started-with-pipelines.mdx
+++ b/versioned_docs/version-0.10/tutorials/getting-started-with-pipelines.mdx
@@ -8,7 +8,7 @@ id: getting-started-with-pipelines
 import Image from '@theme/Image';
 
 This tutorial provides a step by step guide to configure an [Okteto Pipeline](/docs/0.10/cloud/okteto-pipeline/).
-Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto Cloud in just one click.
+Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto in just one click.
 
 ## Overview
 
@@ -16,7 +16,7 @@ The tutorial is composed of the following steps:
 
 - Step 1: Code the Hello World application
 - Step 2: Define a Dockerfile for building the Docker image of the Hello World application
-- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 - Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 - Step 5: Deployment time!
 
@@ -68,7 +68,7 @@ $ go mod init go-getting-started
 
 ## Step 2: Define a Dockerfile for building the Docker image of the Hello World application
 
-You need to build a Docker image and push it to a Docker registry before Okteto Cloud can run your application.
+You need to build a Docker image and push it to a Docker registry before Okteto can run your application.
 
 To do that, you need to define a `Dockerfile`.
 A `Dockerfile` file is a sequence of instructions to build the Docker image of your application.
@@ -87,9 +87,9 @@ EXPOSE 8080
 CMD ["./app"]
 ```
 
-## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 
-To deploy an application to Okteto Cloud, you need to define it using Kubernetes manifests.
+To deploy an application to Okteto, you need to define it using Kubernetes manifests.
 
 Let's start by creating a new folder for the Kubernetes manifests:
 
@@ -156,7 +156,7 @@ The service manifest has four main sections:
 
 You now have everything ready to define the Okteto Pipeline of the Hello World application.
 
-> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto Cloud a secure environment to run your applications.
+> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto a secure environment to run your applications.
 
 ## Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 
@@ -181,21 +181,21 @@ Read the Okteto Pipeline [documentation](/docs/0.10/cloud/okteto-pipeline/) to l
 
 ## Step 5: Deployment time!
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs).
-Click on the **Deploy** button on the top left of the Okteto Cloud dashboard, select "**Git URL**" as the source
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs).
+Click on the **Deploy** button on the top left of the Okteto dashboard, select "**Git URL**" as the source
 and type the URL of your Git repository to deploy the Hello World application:
 
 <p align="center"><Image src="/docs/tutorials/images/deploy-from-git.png" alt="deploy a git repository" width="650" /></p>
 
 After a few seconds, your application will be ready. You can access the Hello World application by clicking its endpoint:
 
-<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto Cloud UI of Hello World app" width="850" />
+<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto UI of Hello World app" width="850" />
 
 > You can make the deployment experience even smoother by adding a [Develop on Okteto](/docs/0.10/cloud/develop-on-okteto-button/) button to the `README.md` file of your Git repository.
 
 ## Next steps
 
-Congratulations, you just configured **your first Okteto Pipeline on Okteto Cloud** 🚀.
+Congratulations, you just configured **your first Okteto Pipeline on Okteto** 🚀.
 
 We have covered how to deploy realistic environments for cloud-native applications in just one-click.
 The full source code used on this tutorial is available [here](https://github.com/okteto/pipeline-getting-started).

--- a/versioned_docs/version-0.10/tutorials/preview-environments.mdx
+++ b/versioned_docs/version-0.10/tutorials/preview-environments.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments for your Kubernetes Applications
-description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto Cloud and GitHub Actions
+description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto and GitHub Actions
 sidebar_label: Preview Environments for your Kubernetes Apps
 id: preview-environments
 ---
 
 import Image from '@theme/Image';
 
-In this section, we'll show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+In this section, we'll show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/kubernetes-preview-environment).
@@ -21,12 +21,12 @@ Start by forking the [kubernetes-preview-environment](https://github.com/okteto/
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we're going to use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we're going to use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Login to Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Login to Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/kubernetes-preview-environment/blob/master/.github/workflows/preview.yaml). If you want to use this one for your own repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.

--- a/versioned_docs/version-0.10/tutorials/repos.mdx
+++ b/versioned_docs/version-0.10/tutorials/repos.mdx
@@ -1,22 +1,22 @@
 ---
 title: How to Configure your Custom Helm Repository
-description: Tutorial on how to add your own Helm repository to Okteto Cloud
+description: Tutorial on how to add your own Helm repository to Okteto
 sidebar_label: Configure your Custom Helm Repository
 id: repos
 ---
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can deploy [Helm Charts with one click](/docs/0.10/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
+With Okteto you can deploy [Helm Charts with one click](/docs/0.10/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
 
-You can add your own Helm repositories to Okteto Cloud to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
+You can add your own Helm repositories to Okteto to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
 
 In order to add your Helm Charts, you'll need a Helm chart repository index with at least one published chart. [Follow this guide](https://helm.sh/docs/chart_repository/) to learn how to do it.
 
-## Add your repository to Okteto Cloud
+## Add your repository to Okteto
 
-On the left side of the Okteto Cloud UI click the **Settings** option. In the new window, click the **Integrations** tab.
-The Okteto Cloud UI will show you the Helm repositories you have configured in Okteto Cloud. Click the **Add Repository** button and put the address of your repository:
+On the left side of the Okteto UI click the **Settings** option. In the new window, click the **Integrations** tab.
+The Okteto UI will show you the Helm repositories you have configured in Okteto. Click the **Add Repository** button and put the address of your repository:
 
 <p align="center"><Image src="/docs/tutorials/images/helm-repos.png" alt="add a Helm repository" width="850" /></p>
 
@@ -31,12 +31,12 @@ Okteto will automatically load the `values-okteto.yaml` file and show it in the 
 
 ## Make your chart multi-tenant friendly.
 
-Okteto Cloud is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
+Okteto is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
 
-Your Helm chart will need to comply with these restrictions to function properly in Okteto Cloud:
+Your Helm chart will need to comply with these restrictions to function properly in Okteto:
 
 - Your chart cannot create `ClusterRole` or `ClusterRoleBinding` objects.
-- `NodePort` and `LoadBalancer` service types are not supported. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/0.10/cloud/ssl/).
+- `NodePort` and `LoadBalancer` service types are not supported. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/0.10/cloud/ssl/).
 - The following `Pod` options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Volume host paths are not allowed either.
 
 More information about our multi-tenant policies [is available here](/docs/0.10/cloud/multitenancy/).

--- a/versioned_docs/version-0.10/tutorials/stacks-getting-started.mdx
+++ b/versioned_docs/version-0.10/tutorials/stacks-getting-started.mdx
@@ -14,7 +14,7 @@ Okteto Stacks implement and extend the [Compose Specification](https://github.co
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/0.10/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/0.10/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Sample App
 
@@ -63,7 +63,7 @@ $ okteto stack deploy --wait
 
 The `deploy` command will create the necessary deployments, services, persistent volumes, and ingress rules needed to run the Sample App.  Cool no 😎?
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
 <Image src="/docs/tutorials/images/okteto-stack-ui.png" alt="Okteto stack UI" width="850" center />
 
@@ -121,7 +121,7 @@ In a matter of seconds, your changes are running in the Cloud 💥!
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 Read the docs for the [Okteto Stack Manifest](/docs/0.10/reference/stacks/) and the [available Okteto Stack CLI commands](/docs/0.10/reference/cli/#stack) to learn more about developing your application using Stacks.
 

--- a/versioned_docs/version-0.11/api.mdx
+++ b/versioned_docs/version-0.11/api.mdx
@@ -11,7 +11,7 @@ import Image from '@theme/Image';
 
 ## The GraphQL API endpoint
 
-If you using Okteto Cloud, the endpoint is available at:
+If you using Okteto, the endpoint is available at:
 ```
 https://cloud.okteto.com/graphql
 ```

--- a/versioned_docs/version-0.11/cloud.mdx
+++ b/versioned_docs/version-0.11/cloud.mdx
@@ -1,14 +1,14 @@
 ---
-title: Okteto Cloud
-description: Okteto Cloud gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
-sidebar_label: Okteto Cloud
+title: Okteto
+description: Okteto gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
+sidebar_label: Okteto
 id: cloud
 ---
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
-Develop your applications in Okteto Cloud and forget about slow and tedious local development forever.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
+Develop your applications in Okteto and forget about slow and tedious local development forever.
 
-With Okteto Cloud you can:
+With Okteto you can:
 
 - Deploy your development environments with the [Okteto CLI](/docs/cloud/okteto-cli/) or from your [Git Repositories](/docs/cloud/deploy-from-git/).
 - Configure [Secrets](/docs/cloud/secrets/) and prevent secure credentials from being stored in version control.
@@ -19,10 +19,10 @@ With Okteto Cloud you can:
 - Download your [Kubernetes Credentials](/docs/cloud/credentials/) to access your namespaces with `kubectl`, `helm`, or any other CLI tool.
 - Visualize your workloads in a Developer-focused Kubernetes dashboard.
 
-Head over to our [5 minutes getting started guide](/docs/cloud/okteto-cli/) and see how you can use Okteto Cloud and Okteto CLI to start developing applications the cloud-native way!
+Head over to our [5 minutes getting started guide](/docs/cloud/okteto-cli/) and see how you can use Okteto and Okteto CLI to start developing applications the cloud-native way!
 
-The [FAQs](/docs/reference/faqs) section also covers some common questions you might have regarding Okteto Cloud.
+The [FAQs](/docs/reference/faqs) section also covers some common questions you might have regarding Okteto.
 
-## Okteto Cloud in your own infrastructure
+## Okteto in your own infrastructure
 
-Interested in running Okteto Cloud in your own infrastructure? [Okteto Enterprise](/docs/enterprise/) allows you to run and host Okteto Cloud on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).
+Interested in running Okteto in your own infrastructure? [Okteto Enterprise](/docs/enterprise/) allows you to run and host Okteto on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).

--- a/versioned_docs/version-0.11/cloud/build.mdx
+++ b/versioned_docs/version-0.11/cloud/build.mdx
@@ -1,19 +1,19 @@
 ---
 title: Okteto Build Service
-description: The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure
+description: The Okteto Build service allows you to build your development images directly in the Okteto infrastructure
 sidebar_label: Build Service
 id: build
 ---
 
 import Image from '@theme/Image';
 
-The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto Cloud.
+The Okteto Build service allows you to build your development images directly in the Okteto infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto.
 
 ## Build images
 
 You'll need the [okteto CLI](/docs/cloud/okteto-cli/) in order to access the Okteto Build Service.
 
-Once the Okteto CLI is installed, run `okteto context` and select the Okteto Cloud option to download the credentials and certificates required to access the Okteto Build service.
+Once the Okteto CLI is installed, run `okteto context` and select the Okteto option to download the credentials and certificates required to access the Okteto Build service.
 
 After that, run the `okteto build` command to build and push your images.
 
@@ -27,4 +27,4 @@ You can build and push images to any available docker registry. If you're not us
 
 ## Quotas
 
-Access to the Okteto Registry is included with all Okteto Cloud accounts. Developer accounts get 15 builds per day for free.
+Access to the Okteto Registry is included with all Okteto accounts. Developer accounts get 15 builds per day for free.

--- a/versioned_docs/version-0.11/cloud/credentials.mdx
+++ b/versioned_docs/version-0.11/cloud/credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: Download your Kubernetes credentials
-description: Download your Kubernetes credentials and start developing your applications in Okteto Cloud
+description: Download your Kubernetes credentials and start developing your applications in Okteto
 sidebar_label: Kubernetes Credentials
 id: credentials
 ---
@@ -10,18 +10,18 @@ import Button from '@theme/Button';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Download your Kubernetes credentials and start developing your applications in Okteto Cloud with your favorite CLI tools.
+Download your Kubernetes credentials and start developing your applications in Okteto with your favorite CLI tools.
 There are two different ways of downloading your Kubernetes credentials:
 
 - Download your Kubernetes credentials [using the Okteto CLI](#download-your-kubernetes-credentials-using-the-okteto-cli).
 
-- Download your Kubernetes credentials [from the Okteto Cloud UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Download your Kubernetes credentials [from the Okteto UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Download your Kubernetes credentials using the Okteto CLI
 
 If this is your first time using the Okteto CLI, install it following [this guide](/docs/cloud/okteto-cli/).
 
-The Okteto CLI can download your Kubernetes credentials from Okteto Cloud. To do this, run the `okteto context` command:
+The Okteto CLI can download your Kubernetes credentials from Okteto. To do this, run the `okteto context` command:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -32,9 +32,9 @@ Authentication will continue in your default browser
  ✓  Context 'cloud.okteto.com' created
 ```
 
-If you're not logged into Okteto Cloud yet, it will also run the login sequence.
+If you're not logged into Okteto yet, it will also run the login sequence.
 
-Once your okteto context is configured to access Okteto Cloud, run the following command:
+Once your okteto context is configured to access Okteto, run the following command:
 
 ```console
 $ okteto kubeconfig
@@ -47,7 +47,7 @@ Updated kubernetes context 'cloud_okteto_com/cindy' in '/Users/cindy/.kube/confi
 The `okteto kubeconfig` command adds your Kubernetes credentials to your kubeconfig file, and sets it as the current Kubernetes context.
 Once you do this, you'll have full access to your Kubernetes namespace with `kubectl`, `helm` or any other CLI tool.
 
-## Download your Kubernetes credentials from the Okteto Cloud UI
+## Download your Kubernetes credentials from the Okteto UI
 
 Download your Kubernetes credentials and save them in a well-known location:
 
@@ -57,7 +57,7 @@ Download your Kubernetes credentials and save them in a well-known location:
   </Button>
 </p>
 
-From the Okteto Cloud UI you should also find your credentials in the `Settings > Setup` section.
+From the Okteto UI you should also find your credentials in the `Settings > Setup` section.
 
 Once downloaded, point your `KUBECONFIG` environment variable to the credentials file:
 
@@ -97,7 +97,7 @@ No resources found.
 
 ## Using your Kubernetes credentials
 
-Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 For example, you could use `kubectl` to deploy our `hello-world` application:
 
@@ -105,5 +105,5 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-[Okteto Cloud](/docs/cloud) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-Take a look at the [FAQs](/docs/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+[Okteto](/docs/reference/development-environments) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+Take a look at the [FAQs](/docs/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/versioned_docs/version-0.11/cloud/custom-domains.mdx
+++ b/versioned_docs/version-0.11/cloud/custom-domains.mdx
@@ -1,38 +1,38 @@
 ---
 title: Custom Domain Names for your Applications
-description: Use a custom domain name for your applications with Okteto Cloud
+description: Use a custom domain name for your applications with Okteto
 sidebar_label: Custom Domain Names
 id: custom-domains
 ---
 
 import Image from '@theme/Image';
 
-By default, an application deployed in Okteto Cloud will be available at its Okteto Cloud domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
+By default, an application deployed in Okteto will be available at its Okteto domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
 
 For example, an application called `hello` deployed in the namespace `cindylopez` will be available at `https://hello-cindylopez.cloud.okteto.net`.
 
-To make your applications available on a non-Okteto Cloud domain (for example: `myapp.com`), you can add a **custom domain to your Okteto Cloud namespace**.
+To make your applications available on a non-Okteto domain (for example: `myapp.com`), you can add a **custom domain to your Okteto namespace**.
 This feature is part of the Okteto Developer Pro plan. If you haven't tried it yet, [start your 14-day free trial here](https://cloud.okteto.com/#/settings/plans/pro-upgrade).
 
-Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto Cloud endpoints.
+Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto endpoints.
 
 > Okteto does not provide a domain registration service (for registering a custom domain name) or a DNS provider service.
 
 ## Add a Custom Domain Name to your Application.
 
-Perform the following tasks to register your custom domain in your Okteto Cloud account:
+Perform the following tasks to register your custom domain in your Okteto account:
 
 1. Confirm that you own the custom domain name. Need a custom domain name? You can buy one with a domain registration service.
 
-2. Register your custom domain with Okteto Cloud by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
+2. Register your custom domain with Okteto by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
 
-3. Update your DNS configuration so your custom domain points to Okteto Cloud's DNS target.
+3. Update your DNS configuration so your custom domain points to Okteto's DNS target.
 
 ## Configure your Application to use your Custom Domain
 
-Once your domain has been registered with your Okteto Cloud account, it's time to put it to use.
+Once your domain has been registered with your Okteto account, it's time to put it to use.
 
-If you're using Okteto Cloud's [auto-ingress](/docs/cloud/ssl/) or [generate the host](/docs/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
+If you're using Okteto's [auto-ingress](/docs/cloud/ssl/) or [generate the host](/docs/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
 
 For example, if your application's endpoint was `https://hello-cindylopez.cloud.okteto.net` and you added the custom domain `myapp.com`, after redeployment your application's endpoint will be `https://hello.myapp.com`.
 
@@ -40,7 +40,7 @@ For example, if your application's endpoint was `https://hello-cindylopez.cloud.
 
 If you want to make your application available in the root domain you provided, you'll need to make a small change to your manifests.
 
-If you're using Okteto Cloud's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
+If you're using Okteto's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
 
 ```yaml
 apiVersion: v1

--- a/versioned_docs/version-0.11/cloud/deploy-from-git.mdx
+++ b/versioned_docs/version-0.11/cloud/deploy-from-git.mdx
@@ -17,13 +17,13 @@ Please make sure to configure your Git repositories with the [appropriate manife
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
 A dialog will open asking for a Git repository to deploy. Make sure that "**Git URL**" is selected as the source.
 Type the URL for the Movies App repo (https://github.com/okteto/movies), pick a branch, and click **Launch**:
 
 <p align="center"><Image src="/docs/cloud/images/deploy-git.png" alt="deploy from git" width="650" /></p>
 
-When you launch a dev environment using a Git repository, Okteto Cloud will analyze your repo and automatically deploy it running `okteto deploy --build`.
+When you launch a dev environment using a Git repository, Okteto will analyze your repo and automatically deploy it running `okteto deploy --build`.
 In the example above, Okteto will install the chart of the Movies App with Helm.
 
 > Check the [Okteto Manifest](/docs/reference/manifest/) to learn more about how to configure your development environment deployment with an `okteto.yml` file.
@@ -65,7 +65,7 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in GitHub README files, documentation sites, or pretty much anywhere that renders an HTML file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 

--- a/versioned_docs/version-0.11/cloud/deploy-from-helm.mdx
+++ b/versioned_docs/version-0.11/cloud/deploy-from-helm.mdx
@@ -7,12 +7,12 @@ id: deploy-from-helm
 
 import Image from '@theme/Image';
 
-You can launch additional services for your development environments on Okteto Cloud using Helm repositories.
+You can launch additional services for your development environments on Okteto using Helm repositories.
 Okteto automates all the processes needed to deploy, configure, upgrade, and destroy your Helm releases, so you can focus on building amazing applications.
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
 Switch to the *From Chart* tab and a list of available services to deploy on your namespace will be shown.
 The list will look something like this:
 
@@ -22,7 +22,7 @@ Click on the service you want to deploy (we'll be using **Redis** in this exampl
 
 <p align="center"><Image src="/docs/cloud/images/deploy-redis.png" alt="deploy redis" width="650" /></p>
 
-When you click on **Launch**, Okteto Cloud will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
+When you click on **Launch**, Okteto will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
 
 As soon as your Helm release is deployed, you'll see its state in the UI. The UI will automatically update as the different components are created. Your Helm release will be ready to go once it reaches the `Success` state.
 
@@ -30,7 +30,7 @@ As soon as your Helm release is deployed, you'll see its state in the UI. The UI
 
 ## Redeploy
 
-You can also redeploy your Helm releases from Okteto Cloud. This is useful when you want to upgrade or redeploy your services.
+You can also redeploy your Helm releases from Okteto. This is useful when you want to upgrade or redeploy your services.
 
 Click on **Redeploy** on the right of your Helm release.
 The *Redeploy Helm Chart* dialog shows you the available versions, as well as the configuration used to deploy the current version of the Helm release.
@@ -48,10 +48,10 @@ A confirmation dialog will pop up. Click on the **Destroy** button to confirm yo
 <p align="center"><Image src="/docs/cloud/images/destroy-helm.png" alt="Destroy Helm releases" width="450" /></p>
 
 In this case, the persistent volume created by Redis won't be deleted to avoid losing any sensitive data.
-You can delete it manually from the Okteto Cloud UI if you want.
+You can delete it manually from the Okteto UI if you want.
 
 ## Application Catalog
 
-The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto Cloud.
+The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto.
 
 You can also [bring your own Helm repository](/docs/tutorials/repos/) to the catalog and get the same one-click deployment experience for your own services.

--- a/versioned_docs/version-0.11/cloud/deploy-from-terminal.mdx
+++ b/versioned_docs/version-0.11/cloud/deploy-from-terminal.mdx
@@ -7,11 +7,11 @@ id: deploy-from-terminal
 
 import Image from '@theme/Image';
 
-You have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+You have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 ## Download your Kubernetes credentials
 
-In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto Cloud.
+In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto.
 [This document](/docs/cloud/credentials/) will walk you through the necessary steps for this.
 
 You can also use the `okteto kubeconfig` command to download your Kubernetes credentials. This will let you interact with your Okteto Namespaces using Kubernetes-native tools like `kubectl` or `helm`.
@@ -25,6 +25,6 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-Okteto Cloud is a multi-tenant environment.
-A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-[Take a look at this document](/docs/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+Okteto is a multi-tenant environment.
+A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+[Take a look at this document](/docs/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/versioned_docs/version-0.11/cloud/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-0.11/cloud/develop-on-okteto-button.mdx
@@ -12,14 +12,14 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in Git `README` files, documentation sites, or pretty much anywhere that renders an html file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements
 
-The basic requirements for creating the button are that your application can be deployed in Okteto Cloud, and that the application's source code is hosted in a public Git repository.
+The basic requirements for creating the button are that your application can be deployed in Okteto, and that the application's source code is hosted in a public Git repository.
 
 The easiest way to validate this is to follow the instructions in the [Deploy from Git](/docs/cloud/deploy-from-git/) document.
 

--- a/versioned_docs/version-0.11/cloud/github-actions.mdx
+++ b/versioned_docs/version-0.11/cloud/github-actions.mdx
@@ -1,17 +1,17 @@
 ---
 title: GitHub Actions
-description: Automate your development workflows using GitHub Actions and Okteto Cloud
+description: Automate your development workflows using GitHub Actions and Okteto
 sidebar_label: GitHub Actions
 id: github-actions
 ---
 
-Automate your development workflows using GitHub Actions and Okteto Cloud.
+Automate your development workflows using GitHub Actions and Okteto.
 
-GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto Cloud, you can create workflows to build, deploy, and update your applications in Okteto Cloud.
+GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto, you can create workflows to build, deploy, and update your applications in Okteto.
 
 ## Available Actions
 
-The GitHub Actions for Okteto Cloud are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
+The GitHub Actions for Okteto are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
 
 - [Activate Namespace](https://github.com/marketplace/actions/activate-namespace)
 - [Apply](https://github.com/marketplace/actions/kubectl-apply)

--- a/versioned_docs/version-0.11/cloud/multitenancy.mdx
+++ b/versioned_docs/version-0.11/cloud/multitenancy.mdx
@@ -1,25 +1,25 @@
 ---
-title: Default Settings for Okteto Cloud
-description: Okteto Cloud gives you access to a Kubernetes namespace in a multi-tenant environment
+title: Default Settings for Okteto
+description: Okteto gives you access to a Kubernetes namespace in a multi-tenant environment
 sidebar_label: Default Settings
 id: multitenancy
 ---
 
-Okteto Cloud gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
+Okteto gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
 
-This document explains the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+This document explains the limitations and restrictions most likely to affect your applications in Okteto.
 
 ## Exposing services
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
 
 ## Pod Security Policies
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
 ## Resource quotas
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -56,11 +56,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 
 ## Network policies
 
-Okteto Cloud configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+Okteto configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
 ## RBAC
 
-Okteto Cloud uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Okteto uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/versioned_docs/version-0.11/cloud/namespaces.mdx
+++ b/versioned_docs/version-0.11/cloud/namespaces.mdx
@@ -7,13 +7,13 @@ id: namespaces
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can create and manage secure and isolated Kubernetes namespaces for you and your team.
+With Okteto you can create and manage secure and isolated Kubernetes namespaces for you and your team.
 
-Okteto Cloud will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
+Okteto will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
 
 ## Manage your namespaces
 
-You can create up to five namespaces per account. Go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
+You can create up to five namespaces per account. Go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
 
 <p align="center"><Image src="/docs/cloud/images/new-dialog.png" alt="new namespace dialog" width="650" /></p>
 
@@ -27,8 +27,8 @@ Once you're done, you can also delete your namespace via the UI, or with the `ok
 
 By default, you'll be the only person with access to your namespaces. Invite your teammates to enable true real-time collaboration.
 
-To share a namespace go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
+To share a namespace go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
 
 <p align="center"><Image src="/docs/cloud/images/share.png" alt="share a namespace" width="850" /></p>
 
-In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto Cloud will update the necessary permissions and notify your teammates via email.
+In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto will update the necessary permissions and notify your teammates via email.

--- a/versioned_docs/version-0.11/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-0.11/cloud/okteto-cli.mdx
@@ -5,7 +5,7 @@ sidebar_label: Okteto CLI
 id: okteto-cli
 ---
 
-[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto Cloud](/docs/cloud), or [Okteto Self-Hosted](/docs/enterprise).
+[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto](/docs/reference/development-environments), or [Okteto Self-Hosted](/docs/enterprise).
 
 
 Learn more about the Okteto CLI
@@ -69,7 +69,7 @@ The installation job also populates the following environment variables. You can
 - `OKTETO_GIT_BRANCH`: the name of the Git branch currently being deployed.
 - `OKTETO_GIT_COMMIT`: the SHA1 hash of the last commit of the branch.
 - `OKTETO_REGISTRY_URL`: the url of the [Okteto Registry](/docs/cloud/registry/).
-- `BUILDKIT_HOST`: the address of the [Okteto Cloud buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
+- `BUILDKIT_HOST`: the address of the [Okteto buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
 
 In order to refer to images in the `build` section of the Okteto Manifest, you can use the following environment variables:
 - `${OKTETO_BUILD_<service>_TAG}`: SHA for the last image build at the registry
@@ -77,7 +77,7 @@ In order to refer to images in the `build` section of the Okteto Manifest, you c
 - `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)
 - `${OKTETO_BUILD_<service>_IMAGE}`: the full image reference (using its SHA)
 
-### Built-in Tools When Deploying To Okteto Cloud
+### Built-in Tools When Deploying To Okteto
 
 When launching a development environment [from a Git Repository](/docs/cloud/deploy-from-git/), Okteto will run an installation job that clones the Git repository, checks out the selected branch, builds the images defined in the `build` section of your Okteto Manifest, and executes the sequence of `deploy` commands. The job will fail if any of the commands in the `deploy` list fails.
 The installation job will run in a Debian Linux container with the following tools preinstalled:

--- a/versioned_docs/version-0.11/cloud/okteto-pipeline.mdx
+++ b/versioned_docs/version-0.11/cloud/okteto-pipeline.mdx
@@ -5,7 +5,7 @@ sidebar_label: Okteto Pipeline
 id: okteto-pipeline
 ---
 
-Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto Cloud](/docs/cloud/). You might want to use them if Okteto Cloud cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
+Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto](/docs/reference/development-environments). You might want to use them if Okteto cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
 
 ### Example okteto-pipeline.yml
 
@@ -22,7 +22,7 @@ devs:
 
 ### Schema Reference
 
-- `icon`: the icon associated to your application in the Okteto Cloud Dashboard (optional).
+- `icon`: the icon associated to your application in the Okteto Dashboard (optional).
 - `deploy`: list of commands to deploy your application in your Kubernetes namespace. It is usually a combination of `helm`, `kubectl`, and `okteto` commands.
 - `destroy`: list of commands to be executed when the pipeline is destroyed. It can be used to release any resource created outside Okteto.
 - `devs`: the paths to the okteto manifests in your Git repository. This is used to fill the hints in the *Develop* dialog of each service (optional).
@@ -60,4 +60,4 @@ The installation job also populates the following environment variables. You can
 - `OKTETO_GIT_BRANCH`: the name of the Git branch currently being deployed.
 - `OKTETO_GIT_COMMIT`: the SHA1 hash of the last commit of the branch.
 - `OKTETO_REGISTRY_URL`: the url of the [Okteto Registry](/docs/cloud/registry/).
-- `BUILDKIT_HOST`: the address of the [Okteto Cloud buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
+- `BUILDKIT_HOST`: the address of the [Okteto buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.

--- a/versioned_docs/version-0.11/cloud/permissions.mdx
+++ b/versioned_docs/version-0.11/cloud/permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: GitHub Permissions for Okteto Cloud
-description: Details of permissions requested by Okteto Cloud when you login using your GitHub account
+title: GitHub Permissions for Okteto
+description: Details of permissions requested by Okteto when you login using your GitHub account
 sidebar_label: GitHub Permissions
 id: permissions
 ---
@@ -9,7 +9,7 @@ import Image from '@theme/Image';
 
 ## GitHub Permissions
 
-When using the Okteto Cloud Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
+When using the Okteto Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard-perms.png" alt="permissions requested on github for preview environments" width="650" /></p>
 
@@ -18,14 +18,14 @@ The reasons for requesting the above permissions are listed below.
 ### Repository Permissions
 
 - Contents: Needed to clone repositories for deploying Preview Environments
-- Metadata: Needed to list repositories a user has access to on the Okteto Cloud Dashboard
+- Metadata: Needed to list repositories a user has access to on the Okteto Dashboard
 - Pull Requests: Needed to comment on the pull requests with the deployed Preview Environment URL and to deploy/destroy a Preview Environment based on whether a PR has been opened/closed
 - Commit Statuses: Needed to change the status of a commit to show if the Preview Environment for it was deployed successfully or not
 
 ### Organization Permissions
 
-- Members: When an org admin installs Okteto Cloud for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto Cloud
+- Members: When an org admin installs Okteto for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto
 
 ### User Permissions
 
-- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto Cloud account.
+- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto account.

--- a/versioned_docs/version-0.11/cloud/preview-environments/dashboard.mdx
+++ b/versioned_docs/version-0.11/cloud/preview-environments/dashboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring Preview Environments
-description: Create preview environments for your application using the Okteto Cloud Dashboard
+description: Create preview environments for your application using the Okteto Dashboard
 sidebar_label: Configure
 id: dashboard
 ---
@@ -8,25 +8,25 @@ id: dashboard
 import Image from '@theme/Image';
 
 
-There are two ways to configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) using Okteto Cloud for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Cloud Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/cloud/preview-environments/preview-environments/#prerequisites) section.
+There are two ways to configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) using Okteto for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/cloud/preview-environments/preview-environments/#prerequisites) section.
 
 Note that this method is not applicable for users of [Okteto Self-Hosted](/docs/enterprise) or Okteto for Teams. Please checkout [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) for configuring Preview Environments in those cases.
 
-### Step 1: Log into Okteto Cloud
+### Step 1: Log into Okteto
 
-The first step is going to [Okteto Cloud](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
+The first step is going to [Okteto](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on okteto cloud" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on Okteto" /></p>
 
 In this guide, we will set up Preview Environments for a fork of the [movies-preview-environments](https://github.com/okteto/movies-preview-environments) repository. Head to that repository and [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of it under your GitHub account. Feel free to follow along with some other repository in your GitHub account once you've [configured](/docs/cloud/preview-environments/preview-environments/#prerequisites) it.
 
 ### Step 2: Add Your Repository
 
-Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto Cloud on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto Cloud requests and why over [here](/docs/cloud/permissions). 
+Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto requests and why over [here](/docs/cloud/permissions). 
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto Cloud on github account" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto on github account" /></p>
 
-Please note that you can only install Okteto Cloud for repositories belonging to your own GitHub account. Only org admins can install Okteto Cloud in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto Cloud to admins through GitHub.
+Please note that you can only install Okteto for repositories belonging to your own GitHub account. Only org admins can install Okteto in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto to admins through GitHub.
 
 Once you do that, you should see your repository appear in the list. 
 
@@ -42,7 +42,7 @@ That's right, this was all the configuration you needed to do! Head over to your
 
 Sharing this with team members is the best way to get their attention for reviews 😛
 
-You should also be able to see the pull request details along with the endpoints on the Okteto Cloud Dashboard.
+You should also be able to see the pull request details along with the endpoints on the Okteto Dashboard.
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/pr-in-dashboard.png" alt="endpoints for the pr" /></p>
 

--- a/versioned_docs/version-0.11/cloud/preview-environments/github.mdx
+++ b/versioned_docs/version-0.11/cloud/preview-environments/github.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments Using GitHub Actions
-description: Create a preview environment for your application using Okteto Cloud and GitHub Actions
+description: Create a preview environment for your application using Okteto and GitHub Actions
 sidebar_label: Using GitHub Actions
 id: preview-environments-github
 ---
 
 import Image from '@theme/Image';
 
-This section will show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+This section will show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/movies).
@@ -21,18 +21,18 @@ Start by forking the [movies](https://github.com/okteto/movies) repository with 
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we will use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we will use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Log into Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Log into Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/movies/blob/main/.github/workflows/preview.yaml).
 If you want to use this on for your repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.
 
-The workflow file to create the preview environments for Okteto Cloud users looks like this:
+The workflow file to create the preview environments for Okteto users looks like this:
 
 ```yaml
 # file: .github/workflows/preview.yaml

--- a/versioned_docs/version-0.11/cloud/preview-environments/gitlab.mdx
+++ b/versioned_docs/version-0.11/cloud/preview-environments/gitlab.mdx
@@ -1,6 +1,6 @@
 ---
 title: Preview Environments Using GitLab CI/CD
-description: Create a preview environment for your application using Okteto Cloud and GitLab
+description: Create a preview environment for your application using Okteto and GitLab
 sidebar_label: For GitLab
 id: preview-environments-gitlab
 ---
@@ -10,7 +10,7 @@ import Image from '@theme/Image';
 This section will show you how to automatically create a preview environment for your applications using Okteto and GitLab's preview apps.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitLab Account](https://gitlab.com)
 
 ## Step 1: Fork the Sample Repository
@@ -22,7 +22,7 @@ For this tutorial, we'll be using [this application](https://gitlab.com/okteto/p
 To deploy a preview environment with Okteto, you need to define the following environment variables:
 
 1. `OKTETO_TOKEN`: an Okteto [personal access token](/docs/cloud/personal-access-tokens/).
-1. `OKTETO_USERNAME`: your Okteto username (in Okteto Cloud, this is your GitHub Username).
+1. `OKTETO_USERNAME`: your Okteto username (in Okteto, this is your GitHub Username).
 1. [Optional] `OKTETO_URL`: if you are using [Okteto Enterprise](/enterprise/), specify the URL of your instance of Okteto Enterprise (e.g., https://okteto.dev.mycompany.com).
 
 To add the environment variables:
@@ -132,7 +132,7 @@ Okteto makes it easy to deploy your own [GitLab Runner](https://docs.gitlab.com/
 
 ### Deploy your GitLab Runner
 
-1. Log into [Okteto Cloud](https://cloud.okteto.com).
+1. Log into [Okteto](https://cloud.okteto.com).
 1. Click on the **Deploy** button on the top.
 1. Choose **Catalog** as the source, select **gitlab-runner** from the options below, and click **Deploy**.
 

--- a/versioned_docs/version-0.11/cloud/preview-environments/overview.mdx
+++ b/versioned_docs/version-0.11/cloud/preview-environments/overview.mdx
@@ -12,7 +12,7 @@ Preview environments allow you to include a live preview of your changes on ever
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-environments.png" alt="Preview Environments" /></p>
 
 Okteto's preview environments are powered by Kubernetes and easily integrate with your favorite source control and CI/CD provider. They work using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest), so are very simple to get started with.
-You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with [Okteto Self-Hosted](/docs/enterprise) if you want to run them on your Kubernetes infrastructure.
+You can use Preview Environments with either [Okteto](/docs/reference/development-environments) or with [Okteto Self-Hosted](/docs/enterprise) if you want to run them on your Kubernetes infrastructure.
 
 - [GitHub](/docs/cloud/preview-environments/preview-environments-github/)
 - [GitLab](/docs/cloud/preview-environments/preview-environments-gitlab/)
@@ -22,4 +22,4 @@ You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with
 
 ## Prerequisites
 
-Preview environments deploy the code in a pull request to [Okteto Cloud](/docs/cloud/) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest)'s `deploy` section.
+Preview environments deploy the code in a pull request to [Okteto](/docs/reference/development-environments) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest)'s `deploy` section.

--- a/versioned_docs/version-0.11/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.11/cloud/private-endpoints.mdx
@@ -10,9 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-Okteto Cloud allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
+Okteto allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
 
-Private endpoints can be identified by the lock icon in the Okteto Cloud UI:
+Private endpoints can be identified by the lock icon in the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/private-endpoints.png" alt="private endpoints UI" width="850" /></p>
 
@@ -137,6 +137,6 @@ services:
 
 ## Restrictions
 
-Private Endpoints use your Okteto Cloud account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
+Private Endpoints use your Okteto account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
 
 Private Endpoints only restrict external access to your applications. Applications running in your namespace will be able to access your private endpoints without authentication by using the `service` name.

--- a/versioned_docs/version-0.11/cloud/private-repositories.mdx
+++ b/versioned_docs/version-0.11/cloud/private-repositories.mdx
@@ -15,13 +15,13 @@ Okteto integrates with GitHub and allows you to easily deploy any repository fro
 
 You'll need to perform the following steps the first time you grant GitHub permissions to Okteto:
 
-1. Log into Okteto Cloud
+1. Log into Okteto
 1. Click on the "**Launch Dev Environment**" button on the top
 1. Make sure "**GitHub**" is the selected source
 <p align="center"><Image src="/docs/cloud/images/private-repositories-deploy.png" alt="Launch private repository from git" width="650" /></p>
 
-1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto Cloud App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
-<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto Cloud" width="400" /></p>
+1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
+<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto" width="400" /></p>
 
 1. Finally click on the **Install & Authorize** button to proceed. If you're not the administrator of the organization, GitHub will send an email notification to your administrator and wait for their authorization to complete the installation and grant you access.
 <p align="center"><Image src="/docs/cloud/images/private-repositories-authorize.png" alt="install and authorize repositories" width="400" /></p>

--- a/versioned_docs/version-0.11/cloud/registry.mdx
+++ b/versioned_docs/version-0.11/cloud/registry.mdx
@@ -47,6 +47,6 @@ registry.cloud.okteto.net/<okteto-namespace>/<image>:<tag>
 
 Any image pushed into the Okteto Registry is private. You'll need to authenticate with the registry before pulling an image.
 
-Namespaces in Okteto Cloud are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
+Namespaces in Okteto are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
 
 To pull an image from a different namespace, you'll need to create and configure the required `imagePullSecrets` as outlined [here](/docs/reference/faqs/#how-to-use-private-images).

--- a/versioned_docs/version-0.11/cloud/secrets.mdx
+++ b/versioned_docs/version-0.11/cloud/secrets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Okteto Secrets
-description: Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject them during deployment time
+description: Okteto Secrets allows you to save application configuration in Okteto, and automatically inject them during deployment time
 sidebar_label: Okteto Secrets
 id: secrets
 ---
@@ -9,11 +9,11 @@ import Image from '@theme/Image';
 
 Application configuration should be passed at deployment time, not hardcoded in your code.
 
-Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject it during deployment time.
+Okteto Secrets allows you to save application configuration in Okteto, and automatically inject it during deployment time.
 
-## Manage Okteto Secrets from the Okteto Cloud UI
+## Manage Okteto Secrets from the Okteto UI
 
-You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto Cloud UI:
+You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/secrets.png" alt="Secrets in settings" width="650" /></p>
 

--- a/versioned_docs/version-0.11/cloud/ssl.mdx
+++ b/versioned_docs/version-0.11/cloud/ssl.mdx
@@ -5,7 +5,7 @@ sidebar_label: Automatic SSL
 id: ssl
 ---
 
-Okteto Cloud can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
+Okteto can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
 
 ```
   dev.okteto.com/auto-ingress: "true"
@@ -36,7 +36,7 @@ spec:
 
 Adding this annotation will tell Okteto to automatically create an https ingress rule for you that redirects to the first http port of your service. `NodePort` or `LoadBalancer` services are managed as if they had this annotation too.
 
-You can see the address of your endpoint by going to Okteto Cloud's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
+You can see the address of your endpoint by going to Okteto's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
 
 ## Bring your own ingress
 
@@ -46,7 +46,7 @@ Keep in mind that all the hosts you use in your ingress must end with`-$NAMESPAC
 
 ### Let Okteto generate the host
 
-Okteto Cloud can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
+Okteto can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
 
 ```
   dev.okteto.com/generate-host: "true"
@@ -71,4 +71,4 @@ spec:
         path: /
 ```
 
-We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto Cloud namespace.
+We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto namespace.

--- a/versioned_docs/version-0.11/enterprise.mdx
+++ b/versioned_docs/version-0.11/enterprise.mdx
@@ -5,7 +5,7 @@ sidebar_label: Intro
 id: enterprise
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/cloud/), with the control and flexibility of running in your Kubernetes infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/reference/development-environments), with the control and flexibility of running in your Kubernetes infrastructure.
 
 With Okteto Enterprise your team can:
 

--- a/versioned_docs/version-0.11/enterprise/install/overview.mdx
+++ b/versioned_docs/version-0.11/enterprise/install/overview.mdx
@@ -5,7 +5,7 @@ sidebar_label: Overview
 id: overview
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/cloud/), with the control and flexibility of running in your own infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/reference/development-environments), with the control and flexibility of running in your own infrastructure.
 
 Okteto Enterprise is free for small teams.  You get all the features of [Okteto Enterprise](/docs/enterprise/) for up to 3 users with 3 namespaces each.
 

--- a/versioned_docs/version-0.11/getting-started.mdx
+++ b/versioned_docs/version-0.11/getting-started.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Okteto's Development Environments enable you to work directly with a deployed application and see your code changes live on the cloud as soon as you hit save.
 
-These Dev environments work using a combination of [Okteto Cloud](/docs/cloud), which is used to deploy your application, and [Okteto CLI](/docs/cloud/okteto-cli), which is used to launch the Dev Environment. This guide will teach how to get started with remote Development Environments.
+These Dev environments work using a combination of [Okteto](/docs/reference/development-environments), which is used to deploy your application, and [Okteto CLI](/docs/cloud/okteto-cli), which is used to launch the Dev Environment. This guide will teach how to get started with remote Development Environments.
 
 ## Installing Okteto CLI
 
@@ -43,11 +43,11 @@ $ scoop install okteto
 
 Alternatively, you can directly download the binary [from GitHub](https://github.com/okteto/okteto/releases) or build it directly from the source code.
 
-## Configuring Okteto CLI with Okteto Cloud
+## Configuring Okteto CLI with Okteto
 
-You can launch a remote Development Environment on [Okteto Cloud](https://cloud.okteto.com) or **any** Kubernetes cluster with the Okteto CLI. For this guide, we'll be using Okteto Cloud. 
+You can launch a remote Development Environment on [Okteto](https://cloud.okteto.com) or **any** Kubernetes cluster with the Okteto CLI. For this guide, we'll be using Okteto. 
 
-The first thing you need to do is configure Okteto CLI to use Okteto Cloud. To do this, run the command below:
+The first thing you need to do is configure Okteto CLI to use Okteto. To do this, run the command below:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -77,4 +77,4 @@ Once the Okteto manifest is created, we recommend that you review it and adjust 
 
 ## Next Steps
 
-In this section, we installed Okteto CLI on our machine and configured it to work with Okteto Cloud. [Next](/docs/using-dev-envs), we're going to launch our Dev Environment and fix a bug in a sample application.
+In this section, we installed Okteto CLI on our machine and configured it to work with Okteto. [Next](/docs/using-dev-envs), we're going to launch our Dev Environment and fix a bug in a sample application.

--- a/versioned_docs/version-0.11/reference/cli.mdx
+++ b/versioned_docs/version-0.11/reference/cli.mdx
@@ -88,7 +88,7 @@ This will prompt you to select one of your existing contexts or to create a new 
 A context defines the default cluster/namespace for any Okteto CLI command.
 Select the context you want to use:
 Use the arrow keys to navigate: ↓ ↑ → ←
-  ▸ https://cloud.okteto.com (Okteto Cloud) *
+  ▸ https://cloud.okteto.com (Okteto) *
     minikube
     staging
     production
@@ -120,7 +120,7 @@ Available subcommands:
 
 Delete a context.
 
-For example, to delete the Okteto Cloud context, run:
+For example, to delete the Okteto context, run:
 
 ```console
 $ okteto context delete https://cloud.okteto.com

--- a/versioned_docs/version-0.11/reference/development-containers.mdx
+++ b/versioned_docs/version-0.11/reference/development-containers.mdx
@@ -20,9 +20,9 @@ For using `okteto up`, you will need to install the Okteto CLI. Okteto CLI is an
 
 Coming to the first step of deploying your application code, there are multiple options available for you to choose from. You can choose to deploy it on an existing cluster and use Okteto CLI to interact with this cluster. 
 
-A second option available is Okteto Cloud. Using Okteto Cloud, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto Cloud was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto Cloud [documentation](/docs/cloud). 
+A second option available is Okteto. Using Okteto, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto [documentation](/docs/cloud). 
 
-Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto Cloud - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto Cloud. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
+Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
 
 ## Getting started
 

--- a/versioned_docs/version-0.11/reference/development-environments.mdx
+++ b/versioned_docs/version-0.11/reference/development-environments.mdx
@@ -18,11 +18,24 @@ Setting up development environments using Okteto involves two main steps:
 
 For using `okteto up`, you will need to install the Okteto CLI. Okteto CLI is an [open-source](https://github.com/okteto/okteto) tool that helps spin up development containers regardless of where you choose to deploy your application code as part of the first step. You can learn more about it by heading to the documentation [here](/docs/cloud/okteto-cli/). 
 
-Coming to the first step of deploying your application code, there are multiple options available for you to choose from. You can choose to deploy it on an existing cluster and use Okteto CLI to interact with this cluster. 
+For the first step of deploying your application, there are multiple approaches for you to choose from. You can use Okteto for deploying your application. This way, you get a robust developer experience specially tailored by us, keeping Remote Development Environments in mind. Okteto comes with useful additional features you would not find in a traditional cluster.
 
-A second option available is Okteto Cloud. Using Okteto Cloud, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto Cloud was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto Cloud [documentation](/docs/cloud). 
+With Okteto you can:
 
-Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto Cloud - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto Cloud. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
+- Deploy your development environments with the [Okteto CLI](/docs/cloud/okteto-cli/) or from your [Git Repositories](/docs/cloud/deploy-from-git/).
+- Configure [Secrets](/docs/cloud/secrets/) and prevent secure credentials from being stored in version control.
+- Expose your development environments via [Automatic HTTPs Endpoints](/docs/cloud/ssl/) for your services, [Private Endpoints](/docs/cloud/private-endpoints/) to restrict access, and [Custom Domain Names](/docs/cloud/custom-domains/).
+- Build your images directly in the cloud using the [Okteto Build Service](/docs/cloud/build).
+- Push your container images in the [Okteto Registry](/docs/cloud/registry).
+- Create secure Kubernetes [Namespaces](/docs/cloud/namespaces/) with one click.
+- Download your [Kubernetes Credentials](/docs/cloud/credentials/) to access your namespaces with `kubectl`, `helm`, or any other CLI tool.
+- Visualize your workloads in a Developer-focused Kubernetes dashboard.
+
+If you want to try it out, head to our [Getting Started Guide](/docs/getting-started/) and see how you can use Okteto to simplify developing cloud-native applications. 
+
+With Okteto, you can also further choose between either hosting the infrastructure yourself or letting us take care of managing the cloud infrastructure for you. The former offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. You can learn more about the exact differences from the [pricing page](https://www.okteto.com/pricing/).
+
+Okteto CLI works out of the box with any Kubernetes cluster. This means that the other option available for you is to take care of creating a convenient developer experience around your dev environments yourself and then only relying on Okteto CLI to launch the Remote Development Environments. With this approach, you are also responsible for setting up and managing the Kubernetes cluster. This approach is completely independent of using the Okteto platform or any of its features. 
 
 ## Getting started
 

--- a/versioned_docs/version-0.11/reference/docker-compose.mdx
+++ b/versioned_docs/version-0.11/reference/docker-compose.mdx
@@ -453,7 +453,7 @@ will use `change-me!` for the value of the `MYSQL_ROOT_PASSWORD` environment var
 
 > Values in the shell and/or the `.env` file take precedence over those specified in Okteto Secrets.
 
-## Okteto Cloud makes Docker Compose even more powerful!
+## Okteto makes Docker Compose even more powerful!
 
 Okteto extends the Compose Specification to make it even easier for you and your team to build cloud-native applications.
 

--- a/versioned_docs/version-0.11/reference/faqs.mdx
+++ b/versioned_docs/version-0.11/reference/faqs.mdx
@@ -70,13 +70,13 @@ $ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcr
 
 With this configuration, all the deployments, stateful sets, jobs, and development containers launched in your namespace will automatically use your registry credentials when pulling private images.
 
-## What types of Kubernetes services are supported in Okteto Cloud?
+## What types of Kubernetes services are supported in Okteto?
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/). Okteto Cloud also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/). Okteto also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
-## What resource quotas are present in Okteto Cloud Namespaces?
+## What resource quotas are present in Okteto Namespaces?
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -109,11 +109,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 | Persistent Volume Claims  | 10  |
 
 
-## Are there any restrictions on applications deployed on Okteto Cloud?
+## Are there any restrictions on applications deployed on Okteto?
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
-Apart from that, Okteto Cloud also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Apart from that, Okteto also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/versioned_docs/version-0.11/reference/known-issues.mdx
+++ b/versioned_docs/version-0.11/reference/known-issues.mdx
@@ -17,7 +17,7 @@ For example, you can do it by running this command on each node:
 $ sudo sysctl -w fs.inotify.max_user_watches=10048576
 ```
 
-Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
+Okteto and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
 
 ## *kubectl apply* changes are undone by *okteto up*
 
@@ -25,7 +25,7 @@ Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automat
 
 If you need to apply changes to your Kubernetes Deployment Manifest after running `okteto up`, note that **you need to run `okteto down` first** or `okteto up` will undo the changes you do to your Kubernetes Deployment Manifests. The reason is that `okteto up` records a copy of the deployment when `okteto up` is executed. This copy is used by `okteto down` to restore the original Kubernetes Deployment Manifest. But it is also used by `okteto up` as the original deployment to avoid ambiguities of "kubectl apply" concurrent changes.
 
-This issue does not apply if you're using Okteto Cloud or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
+This issue does not apply if you're using Okteto or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
 
 ## The okteto prompt doesn't look right in Windows
 

--- a/versioned_docs/version-0.11/samples/aspnetcore.mdx
+++ b/versioned_docs/version-0.11/samples/aspnetcore.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with ASP.NET
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application
+title: Getting Started on Okteto with ASP.NET
+description: This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application
 sidebar_label: ASP.NET
 id: aspnetcore
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application.
+This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the ASP.NET Sample App
 
@@ -36,11 +36,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI ASP.NET" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI ASP.NET" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Activate your development container
 
@@ -81,7 +81,7 @@ The `okteto up` command starts a [development container](/docs/reference/develop
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 3: Develop directly in Okteto Cloud
+## Step 3: Develop directly in Okteto
 
 Open the file `Controllers/HelloWorldController.cs` in your favorite local IDE and modify the response message on line 25 to be *Hello world from Okteto!*. Save your changes.
 
@@ -113,7 +113,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code using the VS dotnet debugger.
 
@@ -131,11 +131,11 @@ Go back to the browser and reload the page. As soon as the service receives the 
 
 <Image center borderless src="/docs/samples/images/aspnetcore-debug.png" alt="ASP.NET core debug" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -144,6 +144,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.11/samples/golang.mdx
+++ b/versioned_docs/version-0.11/samples/golang.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Go
+title: Getting Started on Okteto with Go
 description: This tutorial will show you how to develop a Go sample application
 sidebar_label: Go
 id: golang
@@ -7,14 +7,14 @@ id: golang
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Go sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Go sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Go Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI golang" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI golang" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -139,7 +139,7 @@ Starting hello-world server...
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the file `main.go` in your favorite local IDE and modify the response message on line 17 to be *Hello world from Okteto!*. Save your changes.
 
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Go development.
@@ -210,18 +210,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/golang-debug.png" alt="debugging in Okteto with golang" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.11/samples/java.mdx
+++ b/versioned_docs/version-0.11/samples/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Java
+title: Getting Started on Okteto with Java
 description: This tutorial will show you how to develop a Java sample application
 sidebar_label: Java
 id: java
@@ -7,14 +7,14 @@ id: java
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Java sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Java sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Java Sample App
 
@@ -46,11 +46,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Java" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Java" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -165,7 +165,7 @@ The first time you run the application, Maven/Gradle will compile your applicati
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open `src/main/java/com/okteto/helloworld/RestHelloWorld.java` in your favorite local IDE and modify the response message on line 11 to be *Hello world from Okteto!*. Save your changes.
 
@@ -185,13 +185,13 @@ public class RestHelloWorld {
 }
 ```
 
-Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto Cloud. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
+Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
 
 > Import the `spring-boot-devtools` dependency to automatically restart your Java application whenever a file is changed.
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in Eclipse, one of the most popular IDEs for Java development.
 
@@ -207,17 +207,17 @@ Click the Debug button to start a debugging session. Add a breakpoint on `src/ma
 
 <Image center src="/docs/samples/images/java-halt.png" alt="breakpoint in Java" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.11/samples/node.mdx
+++ b/versioned_docs/version-0.11/samples/node.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Node.js
+title: Getting Started on Okteto with Node.js
 description: This tutorial will show you how to develop a Node.js sample application
 sidebar_label: Node.js
 id: node
@@ -7,14 +7,14 @@ id: node
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Node.js sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Node.js sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Node.js Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Node.js" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Node.js" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -135,7 +135,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `index.js` file in your favorite local IDE and modify the response message on line 5 to be *Hello world from the cluster!*. Save your changes.
 
@@ -154,7 +154,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Node development.
@@ -201,18 +201,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/node-halt.png" alt="breakpoint in Node.js" width="850" />
 
-Your code is running in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is running in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing on a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.11/samples/php.mdx
+++ b/versioned_docs/version-0.11/samples/php.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with PHP
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application
+title: Getting Started on Okteto with PHP
+description: This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application
 sidebar_label: PHP
 id: php
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the PHP Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI PHP" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI PHP" width="850" />
 
-Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -134,7 +134,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `index.php` file in your favorite local IDE and modify the response message on line 2 to be *Hello world from the cluster!*. Save your changes.
 
@@ -146,7 +146,7 @@ echo($message);
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works with [PHPStorm](https://www.jetbrains.com/phpstorm/), one of the most popular IDEs for PHP development.
 
@@ -158,13 +158,13 @@ Go back to your browser and reload the page. The execution will automatically ha
 
 At this point, you're able to inspect the request object, the current values of everything, the contents of `$_SERVER` variable, etc.
 
-<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto Cloud with PHP" width="850" />
+<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto with PHP" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -173,6 +173,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.11/samples/python.mdx
+++ b/versioned_docs/version-0.11/samples/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Python
+title: Getting Started on Okteto with Python
 description: This tutorial will show you how to develop a Python sample application
 sidebar_label: Python
 id: python
@@ -7,14 +7,14 @@ id: python
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Python sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Python sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Python Sample App
@@ -38,11 +38,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Python" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Python" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -138,7 +138,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `app.py` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*.
 Save your changes.
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in one of python's most popular IDE's, [PyCharm](https://www.jetbrains.com/pycharm/).
@@ -206,18 +206,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center borderless src="/docs/samples/images/python-debug.png" alt="breakpoint in Python" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.11/samples/ruby.mdx
+++ b/versioned_docs/version-0.11/samples/ruby.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with Ruby
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application
+title: Getting Started on Okteto with Ruby
+description: This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application
 sidebar_label: Ruby
 id: ruby
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Ruby Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Ruby" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Ruby" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -132,7 +132,7 @@ cindy:hello-world app> ruby app.rb
 [2020-03-20 09:23:04] INFO  WEBrick::HTTPServer#start: pid=66 port=8080
 ```
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `app.rb` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*. Save your changes.
 
@@ -147,7 +147,7 @@ Okteto will synchronize your changes to your development container in Kubernetes
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code, one of the most popular IDEs for Ruby development. If you haven't done it yet, install the [Ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby) available from Visual Studio marketplace. This extension comes with debug definitions covering the default `ruby-debug-ide` client setup.
 
@@ -186,11 +186,11 @@ Add a breakpoint on `app.rb`, line 8. Go back to the browser and reload the page
 
 <Image center src="/docs/samples/images/ruby-halt.png" alt="debugging in Okteto with Ruby" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -199,6 +199,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.11/tutorials/compose-getting-started.mdx
+++ b/versioned_docs/version-0.11/tutorials/compose-getting-started.mdx
@@ -14,7 +14,7 @@ Okteto implements and extends the [Compose Specification](https://github.com/com
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Launch your Development Environment
 
@@ -128,7 +128,7 @@ Your code changes were instantly applied. No commit, build, or push required!
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 Read the docs for the [Docker Compose](/docs/reference/compose/) and the [available Okteto CLI commands](/docs/reference/cli) to learn more about developing your Docker Compose application on Okteto.
 

--- a/versioned_docs/version-0.11/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-0.11/tutorials/getting-started-with-okteto.mdx
@@ -15,7 +15,7 @@ The tutorial is composed of the following steps:
 
 - Step 1: Code the Hello World application
 - Step 2: Define a Dockerfile for building the Docker image of the Hello World application
-- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 - Step 4: Generate your Okteto manifest
 - Step 5: Launch your Development Environment
 - Step 6: Configure a Remote Development Container
@@ -69,7 +69,7 @@ $ go mod init go-getting-started
 
 ## Step 2: Define a Dockerfile for building the Docker image of the Hello World application
 
-You need to build a Docker image and push it to a Docker registry before Okteto Cloud can run your application.
+You need to build a Docker image and push it to a Docker registry before Okteto can run your application.
 
 To do that, you need to define a `Dockerfile`.
 A `Dockerfile` file is a sequence of instructions to build the Docker image of your application.
@@ -88,9 +88,9 @@ EXPOSE 8080
 CMD ["./app"]
 ```
 
-## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 
-To deploy an application to Okteto Cloud, you need to define it using Kubernetes manifests.
+To deploy an application to Okteto, you need to define it using Kubernetes manifests.
 
 Let's start by creating a new folder for the Kubernetes manifests:
 
@@ -157,7 +157,7 @@ The service manifest has four main sections:
 
 You now have everything ready to define the Okteto Manifest of the Hello World application.
 
-> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto Cloud a secure environment to run your applications.
+> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto a secure environment to run your applications.
 
 ## Step 4: Generate your Okteto manifest
 
@@ -183,7 +183,7 @@ You can make use of tools such as `kubectl`, `helm`, `okteto`, and `kustomize` i
 
 ## Step 5: Deploy your Development Environment
 
-[Install](/docs/cloud/okteto-cli/) the Okteto CLI and configure access to Okteto Cloud:
+[Install](/docs/cloud/okteto-cli/) the Okteto CLI and configure access to Okteto:
 
 ```console
 $ okteto context use https://cloud.okteto.com

--- a/versioned_docs/version-0.11/tutorials/getting-started-with-pipelines.mdx
+++ b/versioned_docs/version-0.11/tutorials/getting-started-with-pipelines.mdx
@@ -8,7 +8,7 @@ id: getting-started-with-pipelines
 import Image from '@theme/Image';
 
 This tutorial provides a step by step guide to configure an [Okteto Pipeline](/docs/cloud/okteto-pipeline/).
-Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto Cloud in just one click.
+Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto in just one click.
 
 ## Overview
 
@@ -16,7 +16,7 @@ The tutorial is composed of the following steps:
 
 - Step 1: Code the Hello World application
 - Step 2: Define a Dockerfile for building the Docker image of the Hello World application
-- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 - Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 - Step 5: Deployment time!
 
@@ -68,7 +68,7 @@ $ go mod init go-getting-started
 
 ## Step 2: Define a Dockerfile for building the Docker image of the Hello World application
 
-You need to build a Docker image and push it to a Docker registry before Okteto Cloud can run your application.
+You need to build a Docker image and push it to a Docker registry before Okteto can run your application.
 
 To do that, you need to define a `Dockerfile`.
 A `Dockerfile` file is a sequence of instructions to build the Docker image of your application.
@@ -87,9 +87,9 @@ EXPOSE 8080
 CMD ["./app"]
 ```
 
-## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 
-To deploy an application to Okteto Cloud, you need to define it using Kubernetes manifests.
+To deploy an application to Okteto, you need to define it using Kubernetes manifests.
 
 Let's start by creating a new folder for the Kubernetes manifests:
 
@@ -156,7 +156,7 @@ The service manifest has four main sections:
 
 You now have everything ready to define the Okteto Pipeline of the Hello World application.
 
-> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto Cloud a secure environment to run your applications.
+> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto a secure environment to run your applications.
 
 ## Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 
@@ -181,21 +181,21 @@ Read the Okteto Pipeline [documentation](/docs/cloud/okteto-pipeline/) to learn 
 
 ## Step 5: Deployment time!
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs).
-Click on the **Deploy** button on the top left of the Okteto Cloud dashboard, select "**Git URL**" as the source
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs).
+Click on the **Deploy** button on the top left of the Okteto dashboard, select "**Git URL**" as the source
 and type the URL of your Git repository to deploy the Hello World application:
 
 <p align="center"><Image src="/docs/tutorials/images/deploy-from-git.png" alt="deploy a git repository" width="650" /></p>
 
 After a few seconds, your application will be ready. You can access the Hello World application by clicking its endpoint:
 
-<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto Cloud UI of Hello World app" width="850" />
+<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto UI of Hello World app" width="850" />
 
 > You can make the deployment experience even smoother by adding a [Develop on Okteto](/docs/cloud/develop-on-okteto-button/) button to the `README.md` file of your Git repository.
 
 ## Next steps
 
-Congratulations, you just configured **your first Okteto Pipeline on Okteto Cloud** 🚀.
+Congratulations, you just configured **your first Okteto Pipeline on Okteto** 🚀.
 
 We have covered how to deploy realistic environments for cloud-native applications in just one-click.
 The full source code used on this tutorial is available [here](https://github.com/okteto/pipeline-getting-started).

--- a/versioned_docs/version-0.11/tutorials/preview-environments.mdx
+++ b/versioned_docs/version-0.11/tutorials/preview-environments.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments for your Kubernetes Applications
-description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto Cloud and GitHub Actions
+description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto and GitHub Actions
 sidebar_label: Preview Environments for your Kubernetes Apps
 id: preview-environments
 ---
 
 import Image from '@theme/Image';
 
-In this section, we'll show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+In this section, we'll show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/kubernetes-preview-environment).
@@ -21,12 +21,12 @@ Start by forking the [kubernetes-preview-environment](https://github.com/okteto/
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we're going to use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we're going to use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Login to Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Login to Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/kubernetes-preview-environment/blob/master/.github/workflows/preview.yaml). If you want to use this one for your own repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.

--- a/versioned_docs/version-0.11/tutorials/repos.mdx
+++ b/versioned_docs/version-0.11/tutorials/repos.mdx
@@ -1,22 +1,22 @@
 ---
 title: How to Configure your Custom Helm Repository
-description: Tutorial on how to add your own Helm repository to Okteto Cloud
+description: Tutorial on how to add your own Helm repository to Okteto
 sidebar_label: Configure your Custom Helm Repository
 id: repos
 ---
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can deploy [Helm Charts with one click](/docs/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
+With Okteto you can deploy [Helm Charts with one click](/docs/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
 
-You can add your own Helm repositories to Okteto Cloud to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
+You can add your own Helm repositories to Okteto to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
 
 In order to add your Helm Charts, you'll need a Helm chart repository index with at least one published chart. [Follow this guide](https://helm.sh/docs/chart_repository/) to learn how to do it.
 
-## Add your repository to Okteto Cloud
+## Add your repository to Okteto
 
-On the left side of the Okteto Cloud UI click the **Settings** option. In the new window, click the **Integrations** tab.
-The Okteto Cloud UI will show you the Helm repositories you have configured in Okteto Cloud. Click the **Add Repository** button and put the address of your repository:
+On the left side of the Okteto UI click the **Settings** option. In the new window, click the **Integrations** tab.
+The Okteto UI will show you the Helm repositories you have configured in Okteto. Click the **Add Repository** button and put the address of your repository:
 
 <p align="center"><Image src="/docs/tutorials/images/helm-repos.png" alt="add a Helm repository" width="850" /></p>
 
@@ -31,12 +31,12 @@ Okteto will automatically load the `values-okteto.yaml` file and show it in the 
 
 ## Make your chart multi-tenant friendly.
 
-Okteto Cloud is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
+Okteto is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
 
-Your Helm chart will need to comply with these restrictions to function properly in Okteto Cloud:
+Your Helm chart will need to comply with these restrictions to function properly in Okteto:
 
 - Your chart cannot create `ClusterRole` or `ClusterRoleBinding` objects.
-- `NodePort` and `LoadBalancer` service types are not supported. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
+- `NodePort` and `LoadBalancer` service types are not supported. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
 - The following `Pod` options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Volume host paths are not allowed either.
 
 More information about our multi-tenant policies [is available here](/docs/cloud/multitenancy/).

--- a/versioned_docs/version-0.11/using-dev-envs.mdx
+++ b/versioned_docs/version-0.11/using-dev-envs.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-We set configured Okteto CLI with Okteto Cloud in the [previous section](/docs/getting-started). In this section, let's do the fun bits of developing our application in our Development Environment.
+We set configured Okteto CLI with Okteto in the [previous section](/docs/getting-started). In this section, let's do the fun bits of developing our application in our Development Environment.
 
 ## One Command To Rule Them All
 
@@ -53,7 +53,7 @@ Since we already have a [Docker compose file](/docs/cloud/okteto-cli/#okteto-man
 
 The Movies app only has the `api` and `frontent` microservices, which we see in the prompt. Let's go with `api` because we know there's a bug there we need to fix 🙂
 
-Once you do that, you should see Okteto CLI building the required Docker images for your microservices. When it is done building the images, it will start deploying your application to Okteto Cloud. You should see the deployed endpoints as part of the output in the CLI:
+Once you do that, you should see Okteto CLI building the required Docker images for your microservices. When it is done building the images, it will start deploying your application to Okteto. You should see the deployed endpoints as part of the output in the CLI:
 
 ```console
 Success! Your application will be available shortly.
@@ -62,7 +62,7 @@ i  Endpoints available:
   - https://movies-with-helm-cindylopez.cloud.okteto.net/api
 ```
 
-You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto Cloud dashboard:
+You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
 <Image
@@ -104,7 +104,7 @@ In case your application images aren't already built, you'll also have the optio
 
 The images for the Movies app haven't already been built, so let's select `api/Dockerfile` first and then `frontend/Dockerfile`.
 
-Once Okteto CLI is done building the images for you, it will start deploying your application to Okteto Cloud. You should see the deployed endpoints as part of the output in the CLI:
+Once Okteto CLI is done building the images for you, it will start deploying your application to Okteto. You should see the deployed endpoints as part of the output in the CLI:
 
 ```console
 Success! Your application will be available shortly.
@@ -113,7 +113,7 @@ i  Endpoints available:
   - https://movies-with-helm-cindylopez.cloud.okteto.net/api
 ```
 
-You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto Cloud dashboard:
+You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
 <Image
@@ -212,7 +212,7 @@ Okteto's Development Environment allowed the changes you made to your code local
 
 Congratulations! You successfully developed your first application in a Remote Development Environment. 
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
 
 From here, we recommend the following next steps:
 - Try launching a Dev Environment for your own application following similar steps to what we saw in this guide.

--- a/versioned_docs/version-0.12/api.mdx
+++ b/versioned_docs/version-0.12/api.mdx
@@ -11,7 +11,7 @@ import Image from '@theme/Image';
 
 ## The GraphQL API endpoint
 
-If you using Okteto Cloud, the endpoint is available at:
+If you using Okteto, the endpoint is available at:
 ```
 https://cloud.okteto.com/graphql
 ```

--- a/versioned_docs/version-0.12/cloud.mdx
+++ b/versioned_docs/version-0.12/cloud.mdx
@@ -1,14 +1,14 @@
 ---
-title: Okteto Cloud
-description: Okteto Cloud gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
-sidebar_label: Okteto Cloud
+title: Okteto
+description: Okteto gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities
+sidebar_label: Okteto
 id: cloud
 ---
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
-Develop your applications in Okteto Cloud and forget about slow and tedious local development forever.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives you free access to secure Kubernetes namespaces, fully integrated with remote development capabilities.
+Develop your applications in Okteto and forget about slow and tedious local development forever.
 
-With Okteto Cloud you can:
+With Okteto you can:
 
 - Deploy your development environments with the [Okteto CLI](/docs/cloud/okteto-cli/) or from your [Git Repositories](/docs/cloud/deploy-from-git/).
 - Configure [Secrets](/docs/cloud/secrets/) and prevent secure credentials from being stored in version control.
@@ -19,10 +19,10 @@ With Okteto Cloud you can:
 - Download your [Kubernetes Credentials](/docs/cloud/credentials/) to access your namespaces with `kubectl`, `helm`, or any other CLI tool.
 - Visualize your workloads in a Developer-focused Kubernetes dashboard.
 
-Head over to our [5 minutes getting started guide](/docs/cloud/okteto-cli/) and see how you can use Okteto Cloud and Okteto CLI to start developing applications the cloud-native way!
+Head over to our [5 minutes getting started guide](/docs/cloud/okteto-cli/) and see how you can use Okteto and Okteto CLI to start developing applications the cloud-native way!
 
-The [FAQs](/docs/reference/faqs) section also covers some common questions you might have regarding Okteto Cloud.
+The [FAQs](/docs/reference/faqs) section also covers some common questions you might have regarding Okteto.
 
-## Okteto Cloud in your own infrastructure
+## Okteto in your own infrastructure
 
-Interested in running Okteto Cloud in your own infrastructure? [Okteto Enterprise](/docs/enterprise/) allows you to run and host Okteto Cloud on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).
+Interested in running Okteto in your own infrastructure? [Okteto Enterprise](/docs/enterprise/) allows you to run and host Okteto on any Kubernetes cluster, on public or private clouds. [Talk to us to learn more](/enterprise#sales).

--- a/versioned_docs/version-0.12/cloud/build.mdx
+++ b/versioned_docs/version-0.12/cloud/build.mdx
@@ -1,19 +1,19 @@
 ---
 title: Okteto Build Service
-description: The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure
+description: The Okteto Build service allows you to build your development images directly in the Okteto infrastructure
 sidebar_label: Build Service
 id: build
 ---
 
 import Image from '@theme/Image';
 
-The Okteto Build service allows you to build your development images directly in the Okteto Cloud infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto Cloud.
+The Okteto Build service allows you to build your development images directly in the Okteto infrastructure. Another reason to remove Docker and Kubernetes from your laptop and develop directly in Okteto.
 
 ## Build images
 
 You'll need the [okteto CLI](/docs/cloud/okteto-cli/) in order to access the Okteto Build Service.
 
-Once the Okteto CLI is installed, run `okteto context` and select the Okteto Cloud option to download the credentials and certificates required to access the Okteto Build service.
+Once the Okteto CLI is installed, run `okteto context` and select the Okteto option to download the credentials and certificates required to access the Okteto Build service.
 
 After that, run the `okteto build` command to build and push your images.
 
@@ -27,4 +27,4 @@ You can build and push images to any available docker registry. If you're not us
 
 ## Quotas
 
-Access to the Okteto Registry is included with all Okteto Cloud accounts. Developer accounts get 15 builds per day for free.
+Access to the Okteto Registry is included with all Okteto accounts. Developer accounts get 15 builds per day for free.

--- a/versioned_docs/version-0.12/cloud/credentials.mdx
+++ b/versioned_docs/version-0.12/cloud/credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: Download your Kubernetes credentials
-description: Download your Kubernetes credentials and start developing your applications in Okteto Cloud
+description: Download your Kubernetes credentials and start developing your applications in Okteto
 sidebar_label: Kubernetes Credentials
 id: credentials
 ---
@@ -10,18 +10,18 @@ import Button from '@theme/Button';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Download your Kubernetes credentials and start developing your applications in Okteto Cloud with your favorite CLI tools.
+Download your Kubernetes credentials and start developing your applications in Okteto with your favorite CLI tools.
 There are two different ways of downloading your Kubernetes credentials:
 
 - Download your Kubernetes credentials [using the Okteto CLI](#download-your-kubernetes-credentials-using-the-okteto-cli).
 
-- Download your Kubernetes credentials [from the Okteto Cloud UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Download your Kubernetes credentials [from the Okteto UI](#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Download your Kubernetes credentials using the Okteto CLI
 
 If this is your first time using the Okteto CLI, install it following [this guide](/docs/cloud/okteto-cli/).
 
-The Okteto CLI can download your Kubernetes credentials from Okteto Cloud. To do this, run the `okteto context` command:
+The Okteto CLI can download your Kubernetes credentials from Okteto. To do this, run the `okteto context` command:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -32,9 +32,9 @@ Authentication will continue in your default browser
  ✓  Context 'cloud.okteto.com' created
 ```
 
-If you're not logged into Okteto Cloud yet, it will also run the login sequence.
+If you're not logged into Okteto yet, it will also run the login sequence.
 
-Once your okteto context is configured to access Okteto Cloud, run the following command:
+Once your okteto context is configured to access Okteto, run the following command:
 
 ```console
 $ okteto kubeconfig
@@ -47,7 +47,7 @@ Updated kubernetes context 'cloud_okteto_com/cindy' in '/Users/cindy/.kube/confi
 The `okteto kubeconfig` command adds your Kubernetes credentials to your kubeconfig file, and sets it as the current Kubernetes context.
 Once you do this, you'll have full access to your Kubernetes namespace with `kubectl`, `helm` or any other CLI tool.
 
-## Download your Kubernetes credentials from the Okteto Cloud UI
+## Download your Kubernetes credentials from the Okteto UI
 
 Download your Kubernetes credentials and save them in a well-known location:
 
@@ -57,7 +57,7 @@ Download your Kubernetes credentials and save them in a well-known location:
   </Button>
 </p>
 
-From the Okteto Cloud UI you should also find your credentials in the `Settings > Setup` section.
+From the Okteto UI you should also find your credentials in the `Settings > Setup` section.
 
 Once downloaded, point your `KUBECONFIG` environment variable to the credentials file:
 
@@ -97,7 +97,7 @@ No resources found.
 
 ## Using your Kubernetes credentials
 
-Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+Once you've downloaded your credentials, you'll have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 For example, you could use `kubectl` to deploy our `hello-world` application:
 
@@ -105,5 +105,5 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-[Okteto Cloud](/docs/cloud) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-Take a look at the [FAQs](/docs/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+[Okteto](/docs/reference/development-environments) is a multi-tenant environment. A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code are put in place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+Take a look at the [FAQs](/docs/reference/faqs) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/versioned_docs/version-0.12/cloud/custom-domains.mdx
+++ b/versioned_docs/version-0.12/cloud/custom-domains.mdx
@@ -1,38 +1,38 @@
 ---
 title: Custom Domain Names for your Applications
-description: Use a custom domain name for your applications with Okteto Cloud
+description: Use a custom domain name for your applications with Okteto
 sidebar_label: Custom Domain Names
 id: custom-domains
 ---
 
 import Image from '@theme/Image';
 
-By default, an application deployed in Okteto Cloud will be available at its Okteto Cloud domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
+By default, an application deployed in Okteto will be available at its Okteto domain, which has the form `*-$NAMESPACE.cloud.okteto.net`.
 
 For example, an application called `hello` deployed in the namespace `cindylopez` will be available at `https://hello-cindylopez.cloud.okteto.net`.
 
-To make your applications available on a non-Okteto Cloud domain (for example: `myapp.com`), you can add a **custom domain to your Okteto Cloud namespace**.
+To make your applications available on a non-Okteto domain (for example: `myapp.com`), you can add a **custom domain to your Okteto namespace**.
 This feature is part of the Okteto Developer Pro plan. If you haven't tried it yet, [start your 14-day free trial here](https://cloud.okteto.com/#/settings/plans/pro-upgrade).
 
-Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto Cloud endpoints.
+Applications that use custom domains will automatically get issued a valid certificate, just like regular Okteto endpoints.
 
 > Okteto does not provide a domain registration service (for registering a custom domain name) or a DNS provider service.
 
 ## Add a Custom Domain Name to your Application.
 
-Perform the following tasks to register your custom domain in your Okteto Cloud account:
+Perform the following tasks to register your custom domain in your Okteto account:
 
 1. Confirm that you own the custom domain name. Need a custom domain name? You can buy one with a domain registration service.
 
-2. Register your custom domain with Okteto Cloud by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
+2. Register your custom domain with Okteto by [emailing us](mailto:support@okteto.com). Please include the domain, your github ID, and the namespace you want to use in the email.
 
-3. Update your DNS configuration so your custom domain points to Okteto Cloud's DNS target.
+3. Update your DNS configuration so your custom domain points to Okteto's DNS target.
 
 ## Configure your Application to use your Custom Domain
 
-Once your domain has been registered with your Okteto Cloud account, it's time to put it to use.
+Once your domain has been registered with your Okteto account, it's time to put it to use.
 
-If you're using Okteto Cloud's [auto-ingress](/docs/cloud/ssl/) or [generate the host](/docs/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
+If you're using Okteto's [auto-ingress](/docs/cloud/ssl/) or [generate the host](/docs/cloud/ssl/#let-okteto-generate-the-host) features, then there's nothing to change. Just redeploy your application, and it will automatically pick up your custom domain.
 
 For example, if your application's endpoint was `https://hello-cindylopez.cloud.okteto.net` and you added the custom domain `myapp.com`, after redeployment your application's endpoint will be `https://hello.myapp.com`.
 
@@ -40,7 +40,7 @@ For example, if your application's endpoint was `https://hello-cindylopez.cloud.
 
 If you want to make your application available in the root domain you provided, you'll need to make a small change to your manifests.
 
-If you're using Okteto Cloud's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
+If you're using Okteto's auto-ingress features, change the value of the `dev.okteto.com/auto-ingress` annotation in your service to the word `domain`, as shown below:
 
 ```yaml
 apiVersion: v1

--- a/versioned_docs/version-0.12/cloud/deploy-from-git.mdx
+++ b/versioned_docs/version-0.12/cloud/deploy-from-git.mdx
@@ -17,13 +17,13 @@ Please make sure to configure your Git repositories with the [appropriate manife
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left.
 A dialog will open asking for a Git repository to deploy. Make sure that "**Git URL**" is selected as the source.
 Type the URL for the Movies App repo (https://github.com/okteto/movies), pick a branch, and click **Launch**:
 
 <p align="center"><Image src="/docs/cloud/images/deploy-git.png" alt="deploy from git" width="650" /></p>
 
-When you launch a dev environment using a Git repository, Okteto Cloud will analyze your repo and automatically deploy it running `okteto deploy --build`.
+When you launch a dev environment using a Git repository, Okteto will analyze your repo and automatically deploy it running `okteto deploy --build`.
 In the example above, Okteto will install the chart of the Movies App with Helm.
 
 > Check the [Okteto Manifest](/docs/reference/manifest/) to learn more about how to configure your development environment deployment with an `okteto.yml` file.
@@ -65,7 +65,7 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in GitHub README files, documentation sites, or pretty much anywhere that renders an HTML file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 

--- a/versioned_docs/version-0.12/cloud/deploy-from-helm.mdx
+++ b/versioned_docs/version-0.12/cloud/deploy-from-helm.mdx
@@ -7,12 +7,12 @@ id: deploy-from-helm
 
 import Image from '@theme/Image';
 
-You can launch additional services for your development environments on Okteto Cloud using Helm repositories.
+You can launch additional services for your development environments on Okteto using Helm repositories.
 Okteto automates all the processes needed to deploy, configure, upgrade, and destroy your Helm releases, so you can focus on building amazing applications.
 
 ## Deploy
 
-Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
+Log in to [Okteto](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
 Switch to the *From Chart* tab and a list of available services to deploy on your namespace will be shown.
 The list will look something like this:
 
@@ -22,7 +22,7 @@ Click on the service you want to deploy (we'll be using **Redis** in this exampl
 
 <p align="center"><Image src="/docs/cloud/images/deploy-redis.png" alt="deploy redis" width="650" /></p>
 
-When you click on **Launch**, Okteto Cloud will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
+When you click on **Launch**, Okteto will launch an installation job for you directly in the cluster. The installation job is in charge of executing the required `helm` commands to deploy your Helm Chart.
 
 As soon as your Helm release is deployed, you'll see its state in the UI. The UI will automatically update as the different components are created. Your Helm release will be ready to go once it reaches the `Success` state.
 
@@ -30,7 +30,7 @@ As soon as your Helm release is deployed, you'll see its state in the UI. The UI
 
 ## Redeploy
 
-You can also redeploy your Helm releases from Okteto Cloud. This is useful when you want to upgrade or redeploy your services.
+You can also redeploy your Helm releases from Okteto. This is useful when you want to upgrade or redeploy your services.
 
 Click on **Redeploy** on the right of your Helm release.
 The *Redeploy Helm Chart* dialog shows you the available versions, as well as the configuration used to deploy the current version of the Helm release.
@@ -48,10 +48,10 @@ A confirmation dialog will pop up. Click on the **Destroy** button to confirm yo
 <p align="center"><Image src="/docs/cloud/images/destroy-helm.png" alt="Destroy Helm releases" width="450" /></p>
 
 In this case, the persistent volume created by Redis won't be deleted to avoid losing any sensitive data.
-You can delete it manually from the Okteto Cloud UI if you want.
+You can delete it manually from the Okteto UI if you want.
 
 ## Application Catalog
 
-The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto Cloud.
+The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto.
 
 You can also [bring your own Helm repository](/docs/tutorials/repos/) to the catalog and get the same one-click deployment experience for your own services.

--- a/versioned_docs/version-0.12/cloud/deploy-from-terminal.mdx
+++ b/versioned_docs/version-0.12/cloud/deploy-from-terminal.mdx
@@ -7,11 +7,11 @@ id: deploy-from-terminal
 
 import Image from '@theme/Image';
 
-You have full access to your Kubernetes namespaces on Okteto Cloud directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
+You have full access to your Kubernetes namespaces on Okteto directly from your terminal, using the tools you're already familiar with, such as `helm`, `kubectl`, `okteto` or `skaffold`.
 
 ## Download your Kubernetes credentials
 
-In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto Cloud.
+In order to access your namespaces from your terminal, download your Kubernetes credentials from Okteto.
 [This document](/docs/cloud/credentials/) will walk you through the necessary steps for this.
 
 You can also use the `okteto kubeconfig` command to download your Kubernetes credentials. This will let you interact with your Okteto Namespaces using Kubernetes-native tools like `kubectl` or `helm`.
@@ -25,6 +25,6 @@ For example, you could use `kubectl` to deploy our `hello-world` application:
 kubectl apply -f https://raw.githubusercontent.com/okteto/go-getting-started/master/k8s.yml
 ```
 
-Okteto Cloud is a multi-tenant environment.
-A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
-[Take a look at this document](/docs/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+Okteto is a multi-tenant environment.
+A combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code is put in-place to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
+[Take a look at this document](/docs/cloud/multitenancy/) to understand the limitations and restrictions most likely to affect your applications in Okteto.

--- a/versioned_docs/version-0.12/cloud/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-0.12/cloud/develop-on-okteto-button.mdx
@@ -12,14 +12,14 @@ The **Develop on Okteto** button is a shortcut to deploy your development enviro
 The button is designed to be used in Git `README` files, documentation sites, or pretty much anywhere that renders an html file.
 Use this instead of writing a never-ending list of manual steps on how to deploy your development environments.
 
-Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud.
+Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto.
 
 [![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements
 
-The basic requirements for creating the button are that your application can be deployed in Okteto Cloud, and that the application's source code is hosted in a public Git repository.
+The basic requirements for creating the button are that your application can be deployed in Okteto, and that the application's source code is hosted in a public Git repository.
 
 The easiest way to validate this is to follow the instructions in the [Deploy from Git](/docs/cloud/deploy-from-git/) document.
 

--- a/versioned_docs/version-0.12/cloud/github-actions.mdx
+++ b/versioned_docs/version-0.12/cloud/github-actions.mdx
@@ -1,17 +1,17 @@
 ---
 title: GitHub Actions
-description: Automate your development workflows using GitHub Actions and Okteto Cloud
+description: Automate your development workflows using GitHub Actions and Okteto
 sidebar_label: GitHub Actions
 id: github-actions
 ---
 
-Automate your development workflows using GitHub Actions and Okteto Cloud.
+Automate your development workflows using GitHub Actions and Okteto.
 
-GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto Cloud, you can create workflows to build, deploy, and update your applications in Okteto Cloud.
+GitHub Actions gives you the flexibility to build automated software development workflows. With GitHub Actions for Okteto, you can create workflows to build, deploy, and update your applications in Okteto.
 
 ## Available Actions
 
-The GitHub Actions for Okteto Cloud are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
+The GitHub Actions for Okteto are available directly from [the GitHub Markeplace](https://github.com/marketplace?type=actions&query=okteto).
 
 - [Activate Namespace](https://github.com/marketplace/actions/activate-namespace)
 - [Apply](https://github.com/marketplace/actions/kubectl-apply)

--- a/versioned_docs/version-0.12/cloud/multitenancy.mdx
+++ b/versioned_docs/version-0.12/cloud/multitenancy.mdx
@@ -1,25 +1,25 @@
 ---
-title: Default Settings for Okteto Cloud
-description: Okteto Cloud gives you access to a Kubernetes namespace in a multi-tenant environment
+title: Default Settings for Okteto
+description: Okteto gives you access to a Kubernetes namespace in a multi-tenant environment
 sidebar_label: Default Settings
 id: multitenancy
 ---
 
-Okteto Cloud gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto Cloud namespaces are isolated, secure, and easy to use for everyone.
+Okteto gives you access to a vanilla Kubernetes namespace in a multi-tenant environment. Okteto uses a combination of RBAC, pod security policies, resource quotas, network policies, admission controllers, and custom code to ensure that Okteto namespaces are isolated, secure, and easy to use for everyone.
 
-This document explains the limitations and restrictions most likely to affect your applications in Okteto Cloud.
+This document explains the limitations and restrictions most likely to affect your applications in Okteto.
 
 ## Exposing services
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
 
 ## Pod Security Policies
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
 ## Resource quotas
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -56,11 +56,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 
 ## Network policies
 
-Okteto Cloud configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+Okteto configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
 ## RBAC
 
-Okteto Cloud uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Okteto uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/versioned_docs/version-0.12/cloud/namespaces.mdx
+++ b/versioned_docs/version-0.12/cloud/namespaces.mdx
@@ -7,13 +7,13 @@ id: namespaces
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can create and manage secure and isolated Kubernetes namespaces for you and your team.
+With Okteto you can create and manage secure and isolated Kubernetes namespaces for you and your team.
 
-Okteto Cloud will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
+Okteto will take care of all the required RBAC roles and bindings, resources quotas and limits, pod security policies, and network policies so everyone in your team can safely deploy and develop applications in Kubernetes.
 
 ## Manage your namespaces
 
-You can create up to five namespaces per account. Go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
+You can create up to five namespaces per account. Go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs) and click on the (+) symbol on the left.
 
 <p align="center"><Image src="/docs/cloud/images/new-dialog.png" alt="new namespace dialog" width="650" /></p>
 
@@ -27,8 +27,8 @@ Once you're done, you can also delete your namespace via the UI, or with the `ok
 
 By default, you'll be the only person with access to your namespaces. Invite your teammates to enable true real-time collaboration.
 
-To share a namespace go to the [Okteto Cloud UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
+To share a namespace go to the [Okteto UI](https://cloud.okteto.com/#/?origin=docs), select the namespace you want to share and press the `Share` button in the namespace menu (you'll find it in the main bar at the top).
 
 <p align="center"><Image src="/docs/cloud/images/share.png" alt="share a namespace" width="850" /></p>
 
-In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto Cloud will update the necessary permissions and notify your teammates via email.
+In the `Share` dialog, type the email address of the team members you want to share this namespace with. Once you press save, Okteto will update the necessary permissions and notify your teammates via email.

--- a/versioned_docs/version-0.12/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-0.12/cloud/okteto-cli.mdx
@@ -5,7 +5,7 @@ sidebar_label: Okteto CLI
 id: okteto-cli
 ---
 
-[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto Cloud](/docs/cloud), or [Okteto Self-Hosted](/docs/enterprise).
+[Dev Environments](/docs/reference/development-environments/) allow you to develop your deployed application locally. You continue coding in your favorite IDE and see the changes live on the deployed version of your application as soon as you hit save. Okteto CLI is an [open source](https://github.com/okteto/okteto) client-side only tool that allows you to launch Dev Environments in any Kubernetes cluster: your own, [Okteto](/docs/reference/development-environments), or [Okteto Self-Hosted](/docs/enterprise).
 
 Learn more about the Okteto CLI
 
@@ -68,7 +68,7 @@ The installation job also populates the following environment variables. You can
 - `OKTETO_GIT_BRANCH`: the name of the Git branch currently being deployed.
 - `OKTETO_GIT_COMMIT`: the SHA1 hash of the last commit of the branch.
 - `OKTETO_REGISTRY_URL`: the url of the [Okteto Registry](/docs/cloud/registry/).
-- `BUILDKIT_HOST`: the address of the [Okteto Cloud buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
+- `BUILDKIT_HOST`: the address of the [Okteto buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
 
 In order to refer to images in the `build` section of the Okteto Manifest, you can use the following environment variables:
 - `${OKTETO_BUILD_<service>_TAG}`: SHA for the last image build at the registry
@@ -76,7 +76,7 @@ In order to refer to images in the `build` section of the Okteto Manifest, you c
 - `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)
 - `${OKTETO_BUILD_<service>_IMAGE}`: the full image reference (using its SHA)
 
-### Built-in Tools When Deploying To Okteto Cloud
+### Built-in Tools When Deploying To Okteto
 
 When launching a development environment [from a Git Repository](/docs/cloud/deploy-from-git/), Okteto will run an installation job that clones the Git repository, checks out the selected branch, builds the images defined in the `build` section of your Okteto Manifest, and executes the sequence of `deploy` commands. The job will fail if any of the commands in the `deploy` list fails.
 The installation job will run in a Debian Linux container with the following tools preinstalled:

--- a/versioned_docs/version-0.12/cloud/okteto-pipeline.mdx
+++ b/versioned_docs/version-0.12/cloud/okteto-pipeline.mdx
@@ -5,7 +5,7 @@ sidebar_label: Okteto Pipeline
 id: okteto-pipeline
 ---
 
-Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto Cloud](/docs/cloud/). You might want to use them if Okteto Cloud cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
+Okteto Pipelines allow you to configure how your [Git repositories](/docs/cloud/deploy-from-git) get deployed to [Okteto](/docs/reference/development-environments). You might want to use them if Okteto cannot detect how to deploy your application from your [deployment manifests](/docs/cloud/deploy-from-git#prerequisites) or simply when you want more control over how your application gets deployed. 
 
 ### Example okteto-pipeline.yml
 
@@ -22,7 +22,7 @@ devs:
 
 ### Schema Reference
 
-- `icon`: the icon associated to your application in the Okteto Cloud Dashboard (optional).
+- `icon`: the icon associated to your application in the Okteto Dashboard (optional).
 - `deploy`: list of commands to deploy your application in your Kubernetes namespace. It is usually a combination of `helm`, `kubectl`, and `okteto` commands.
 - `destroy`: list of commands to be executed when the pipeline is destroyed. It can be used to release any resource created outside Okteto.
 - `devs`: the paths to the okteto manifests in your Git repository. This is used to fill the hints in the *Develop* dialog of each service (optional).
@@ -60,4 +60,4 @@ The installation job also populates the following environment variables. You can
 - `OKTETO_GIT_BRANCH`: the name of the Git branch currently being deployed.
 - `OKTETO_GIT_COMMIT`: the SHA1 hash of the last commit of the branch.
 - `OKTETO_REGISTRY_URL`: the url of the [Okteto Registry](/docs/cloud/registry/).
-- `BUILDKIT_HOST`: the address of the [Okteto Cloud buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.
+- `BUILDKIT_HOST`: the address of the [Okteto buildkit instance](/docs/cloud/build/). You can use it to build your images with any CLI tool that supports Buildkit builds.

--- a/versioned_docs/version-0.12/cloud/permissions.mdx
+++ b/versioned_docs/version-0.12/cloud/permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: GitHub Permissions for Okteto Cloud
-description: Details of permissions requested by Okteto Cloud when you login using your GitHub account
+title: GitHub Permissions for Okteto
+description: Details of permissions requested by Okteto when you login using your GitHub account
 sidebar_label: GitHub Permissions
 id: permissions
 ---
@@ -9,7 +9,7 @@ import Image from '@theme/Image';
 
 ## GitHub Permissions
 
-When using the Okteto Cloud Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
+When using the Okteto Dashboard to enable Preview Environments for your GitHub repositories, we request the following permissions:
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard-perms.png" alt="permissions requested on github for preview environments" width="650" /></p>
 
@@ -18,14 +18,14 @@ The reasons for requesting the above permissions are listed below.
 ### Repository Permissions
 
 - Contents: Needed to clone repositories for deploying Preview Environments
-- Metadata: Needed to list repositories a user has access to on the Okteto Cloud Dashboard
+- Metadata: Needed to list repositories a user has access to on the Okteto Dashboard
 - Pull Requests: Needed to comment on the pull requests with the deployed Preview Environment URL and to deploy/destroy a Preview Environment based on whether a PR has been opened/closed
 - Commit Statuses: Needed to change the status of a commit to show if the Preview Environment for it was deployed successfully or not
 
 ### Organization Permissions
 
-- Members: When an org admin installs Okteto Cloud for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto Cloud
+- Members: When an org admin installs Okteto for a GitHub organization, this permission allows us to list available repositories to all org members who log in to Okteto
 
 ### User Permissions
 
-- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto Cloud account.
+- Email Address: This is required during the sign up in order to link your GitHub account to your Okteto account.

--- a/versioned_docs/version-0.12/cloud/preview-environments/dashboard.mdx
+++ b/versioned_docs/version-0.12/cloud/preview-environments/dashboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring Preview Environments
-description: Create preview environments for your application using the Okteto Cloud Dashboard
+description: Create preview environments for your application using the Okteto Dashboard
 sidebar_label: Configure
 id: dashboard
 ---
@@ -8,25 +8,25 @@ id: dashboard
 import Image from '@theme/Image';
 
 
-There are two ways to configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) using Okteto Cloud for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Cloud Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/cloud/preview-environments/preview-environments/#prerequisites) section.
+There are two ways to configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) using Okteto for your GitHub repositories. This page will be covering the easier of the two methods, that is, using the Okteto Dashboard. If you want more control and configuration options for your Preview Environments, [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) are the way to go. Before proceeding with the steps here, please ensure you've gone through the [Prerequisites](/docs/cloud/preview-environments/preview-environments/#prerequisites) section.
 
 Note that this method is not applicable for users of [Okteto Self-Hosted](/docs/enterprise) or Okteto for Teams. Please checkout [GitHub Actions](/docs/cloud/preview-environments/preview-environments-github) for configuring Preview Environments in those cases.
 
-### Step 1: Log into Okteto Cloud
+### Step 1: Log into Okteto
 
-The first step is going to [Okteto Cloud](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
+The first step is going to [Okteto](https://cloud.okteto.com/) and logging in. Once you log in, head over to the Preview Environments section using the sidebar menu.
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on okteto cloud" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/preview-env-dashboard.png" alt="preview env dashboard on Okteto" /></p>
 
 In this guide, we will set up Preview Environments for a fork of the [movies-preview-environments](https://github.com/okteto/movies-preview-environments) repository. Head to that repository and [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of it under your GitHub account. Feel free to follow along with some other repository in your GitHub account once you've [configured](/docs/cloud/preview-environments/preview-environments/#prerequisites) it.
 
 ### Step 2: Add Your Repository
 
-Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto Cloud on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto Cloud requests and why over [here](/docs/cloud/permissions). 
+Click on the "Add a repository" button on the dashboard. If you're doing this for the first time, you'll have to install and authorize Okteto on the GitHub organization/account having the repository you want to configure the Preview Environments for. You can read more about what permissions Okteto requests and why over [here](/docs/cloud/permissions). 
 
-<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto Cloud on github account" /></p>
+<p align="center"><Image src="/docs/cloud/preview-environments/images/auth-okteto-cloud.png" alt="install and authorize Okteto on github account" /></p>
 
-Please note that you can only install Okteto Cloud for repositories belonging to your own GitHub account. Only org admins can install Okteto Cloud in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto Cloud to admins through GitHub.
+Please note that you can only install Okteto for repositories belonging to your own GitHub account. Only org admins can install Okteto in the case of repositories part of a GitHub organization. Non-admin users will have the option of sending a request to install Okteto to admins through GitHub.
 
 Once you do that, you should see your repository appear in the list. 
 
@@ -42,7 +42,7 @@ That's right, this was all the configuration you needed to do! Head over to your
 
 Sharing this with team members is the best way to get their attention for reviews 😛
 
-You should also be able to see the pull request details along with the endpoints on the Okteto Cloud Dashboard.
+You should also be able to see the pull request details along with the endpoints on the Okteto Dashboard.
 
 <p align="center"><Image src="/docs/cloud/preview-environments/images/pr-in-dashboard.png" alt="endpoints for the pr" /></p>
 

--- a/versioned_docs/version-0.12/cloud/preview-environments/github.mdx
+++ b/versioned_docs/version-0.12/cloud/preview-environments/github.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments Using GitHub Actions
-description: Create a preview environment for your application using Okteto Cloud and GitHub Actions
+description: Create a preview environment for your application using Okteto and GitHub Actions
 sidebar_label: Using GitHub Actions
 id: preview-environments-github
 ---
 
 import Image from '@theme/Image';
 
-This section will show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+This section will show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/movies).
@@ -21,18 +21,18 @@ Start by forking the [movies](https://github.com/okteto/movies) repository with 
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we will use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we will use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Log into Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Log into Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/movies/blob/main/.github/workflows/preview.yaml).
 If you want to use this on for your repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.
 
-The workflow file to create the preview environments for Okteto Cloud users looks like this:
+The workflow file to create the preview environments for Okteto users looks like this:
 
 ```yaml
 # file: .github/workflows/preview.yaml

--- a/versioned_docs/version-0.12/cloud/preview-environments/gitlab.mdx
+++ b/versioned_docs/version-0.12/cloud/preview-environments/gitlab.mdx
@@ -1,6 +1,6 @@
 ---
 title: Preview Environments Using GitLab CI/CD
-description: Create a preview environment for your application using Okteto Cloud and GitLab
+description: Create a preview environment for your application using Okteto and GitLab
 sidebar_label: For GitLab
 id: preview-environments-gitlab
 ---
@@ -10,7 +10,7 @@ import Image from '@theme/Image';
 This section will show you how to automatically create a preview environment for your applications using Okteto and GitLab's preview apps.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitLab Account](https://gitlab.com)
 
 ## Step 1: Fork the Sample Repository
@@ -22,7 +22,7 @@ For this tutorial, we'll be using [this application](https://gitlab.com/okteto/p
 To deploy a preview environment with Okteto, you need to define the following environment variables:
 
 1. `OKTETO_TOKEN`: an Okteto [personal access token](/docs/cloud/personal-access-tokens/).
-1. `OKTETO_USERNAME`: your Okteto username (in Okteto Cloud, this is your GitHub Username).
+1. `OKTETO_USERNAME`: your Okteto username (in Okteto, this is your GitHub Username).
 1. [Optional] `OKTETO_URL`: if you are using [Okteto Enterprise](/enterprise/), specify the URL of your instance of Okteto Enterprise (e.g., https://okteto.dev.mycompany.com).
 
 To add the environment variables:
@@ -132,7 +132,7 @@ Okteto makes it easy to deploy your own [GitLab Runner](https://docs.gitlab.com/
 
 ### Deploy your GitLab Runner
 
-1. Log into [Okteto Cloud](https://cloud.okteto.com).
+1. Log into [Okteto](https://cloud.okteto.com).
 1. Click on the **Deploy** button on the top.
 1. Choose **Catalog** as the source, select **gitlab-runner** from the options below, and click **Deploy**.
 

--- a/versioned_docs/version-0.12/cloud/preview-environments/overview.mdx
+++ b/versioned_docs/version-0.12/cloud/preview-environments/overview.mdx
@@ -12,7 +12,7 @@ Preview environments allow you to include a live preview of your changes on ever
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-environments.png" alt="Preview Environments" /></p>
 
 Okteto's preview environments are powered by Kubernetes and easily integrate with your favorite source control and CI/CD provider. They work using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest), so are very simple to get started with.
-You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with [Okteto Self-Hosted](/docs/enterprise) if you want to run them on your Kubernetes infrastructure.
+You can use Preview Environments with either [Okteto](/docs/reference/development-environments) or with [Okteto Self-Hosted](/docs/enterprise) if you want to run them on your Kubernetes infrastructure.
 
 - [GitHub](/docs/cloud/preview-environments/preview-environments-github/)
 - [GitLab](/docs/cloud/preview-environments/preview-environments-gitlab/)
@@ -22,4 +22,4 @@ You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with
 
 ## Prerequisites
 
-Preview environments deploy the code in a pull request to [Okteto Cloud](/docs/cloud/) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest)'s `deploy` section.
+Preview environments deploy the code in a pull request to [Okteto](/docs/reference/development-environments) or [Self-Hosted](/docs/enterprise/). You can configure the way your code gets deployed using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest)'s `deploy` section.

--- a/versioned_docs/version-0.12/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.12/cloud/private-endpoints.mdx
@@ -10,9 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-Okteto Cloud allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
+Okteto allows you to restrict access to your application by marking its endpoints as private.  Private endpoints can only be accessed by Okteto users who have access to your Okteto namespace, and they'll need to provide their credentials before being granted access.
 
-Private endpoints can be identified by the lock icon in the Okteto Cloud UI:
+Private endpoints can be identified by the lock icon in the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/private-endpoints.png" alt="private endpoints UI" width="850" /></p>
 
@@ -137,6 +137,6 @@ services:
 
 ## Restrictions
 
-Private Endpoints use your Okteto Cloud account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
+Private Endpoints use your Okteto account for authentication, so they're best suited to protect endpoints that you and your team will access via the browser. They're not recommended for automation, or to protect endpoints that will be accessed by your end users.
 
 Private Endpoints only restrict external access to your applications. Applications running in your namespace will be able to access your private endpoints without authentication by using the `service` name.

--- a/versioned_docs/version-0.12/cloud/private-repositories.mdx
+++ b/versioned_docs/version-0.12/cloud/private-repositories.mdx
@@ -15,13 +15,13 @@ Okteto integrates with GitHub and allows you to easily deploy any repository fro
 
 You'll need to perform the following steps the first time you grant GitHub permissions to Okteto:
 
-1. Log into Okteto Cloud
+1. Log into Okteto
 1. Click on the "**Launch Dev Environment**" button on the top
 1. Make sure "**GitHub**" is the selected source
 <p align="center"><Image src="/docs/cloud/images/private-repositories-deploy.png" alt="Launch private repository from git" width="650" /></p>
 
-1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto Cloud App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
-<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto Cloud" width="400" /></p>
+1. Click on the **Configure GitHub** button, to open the authorization dialog from GitHub. GitHub will ask you to install the Okteto App in the accounts and organizations you select. Follow the instructions to grant permissions to your repositories.
+<p align="center"><Image src="/docs/cloud/images/private-repositories-enable.png" alt="install Okteto" width="400" /></p>
 
 1. Finally click on the **Install & Authorize** button to proceed. If you're not the administrator of the organization, GitHub will send an email notification to your administrator and wait for their authorization to complete the installation and grant you access.
 <p align="center"><Image src="/docs/cloud/images/private-repositories-authorize.png" alt="install and authorize repositories" width="400" /></p>

--- a/versioned_docs/version-0.12/cloud/registry.mdx
+++ b/versioned_docs/version-0.12/cloud/registry.mdx
@@ -47,6 +47,6 @@ registry.cloud.okteto.net/<okteto-namespace>/<image>:<tag>
 
 Any image pushed into the Okteto Registry is private. You'll need to authenticate with the registry before pulling an image.
 
-Namespaces in Okteto Cloud are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
+Namespaces in Okteto are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
 
 To pull an image from a different namespace, you'll need to create and configure the required `imagePullSecrets` as outlined [here](/docs/reference/faqs/#how-to-use-private-images).

--- a/versioned_docs/version-0.12/cloud/secrets.mdx
+++ b/versioned_docs/version-0.12/cloud/secrets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Okteto Secrets
-description: Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject them during deployment time
+description: Okteto Secrets allows you to save application configuration in Okteto, and automatically inject them during deployment time
 sidebar_label: Okteto Secrets
 id: secrets
 ---
@@ -9,11 +9,11 @@ import Image from '@theme/Image';
 
 Application configuration should be passed at deployment time, not hardcoded in your code.
 
-Okteto Secrets allows you to save application configuration in Okteto Cloud, and automatically inject it during deployment time.
+Okteto Secrets allows you to save application configuration in Okteto, and automatically inject it during deployment time.
 
-## Manage Okteto Secrets from the Okteto Cloud UI
+## Manage Okteto Secrets from the Okteto UI
 
-You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto Cloud UI:
+You can create and delete your Okteto Secrets from the `Secrets` tab in the `Settings` view of the Okteto UI:
 
 <p align="center"><Image src="/docs/cloud/images/secrets.png" alt="Secrets in settings" width="650" /></p>
 

--- a/versioned_docs/version-0.12/cloud/ssl.mdx
+++ b/versioned_docs/version-0.12/cloud/ssl.mdx
@@ -5,7 +5,7 @@ sidebar_label: Automatic SSL
 id: ssl
 ---
 
-Okteto Cloud can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
+Okteto can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
 
 ```
   dev.okteto.com/auto-ingress: "true"
@@ -36,7 +36,7 @@ spec:
 
 Adding this annotation will tell Okteto to automatically create an https ingress rule for you that redirects to the first http port of your service. `NodePort` or `LoadBalancer` services are managed as if they had this annotation too.
 
-You can see the address of your endpoint by going to Okteto Cloud's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
+You can see the address of your endpoint by going to Okteto's UI. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
 
 ## Bring your own ingress
 
@@ -46,7 +46,7 @@ Keep in mind that all the hosts you use in your ingress must end with`-$NAMESPAC
 
 ### Let Okteto generate the host
 
-Okteto Cloud can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
+Okteto can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
 
 ```
   dev.okteto.com/generate-host: "true"
@@ -71,4 +71,4 @@ spec:
         path: /
 ```
 
-We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto Cloud namespace.
+We recommend you follow this option. This way your ingress configuration can be deployed on any Okteto namespace.

--- a/versioned_docs/version-0.12/enterprise.mdx
+++ b/versioned_docs/version-0.12/enterprise.mdx
@@ -5,7 +5,7 @@ sidebar_label: Intro
 id: enterprise
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/cloud/), with the control and flexibility of running in your Kubernetes infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/reference/development-environments), with the control and flexibility of running in your Kubernetes infrastructure.
 
 With Okteto Enterprise your team can:
 

--- a/versioned_docs/version-0.12/enterprise/install/overview.mdx
+++ b/versioned_docs/version-0.12/enterprise/install/overview.mdx
@@ -5,7 +5,7 @@ sidebar_label: Overview
 id: overview
 ---
 
-Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto Cloud](/docs/cloud/), with the control and flexibility of running in your own infrastructure.
+Okteto Enterprise is a development platform for Kubernetes applications. Build better applications by developing and testing your code directly in your own Kubernetes infrastructure. Give your team the power of [Okteto](/docs/reference/development-environments), with the control and flexibility of running in your own infrastructure.
 
 Okteto Enterprise is free for small teams.  You get all the features of [Okteto Enterprise](/docs/enterprise/) for up to 3 users with 3 namespaces each.
 

--- a/versioned_docs/version-0.12/getting-started.mdx
+++ b/versioned_docs/version-0.12/getting-started.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Okteto's Development Environments enable you to work directly with a deployed application and see your code changes live on the cloud as soon as you hit save.
 
-These Dev environments work using a combination of [Okteto Cloud](/docs/cloud), which is used to deploy your application, and [Okteto CLI](/docs/cloud/okteto-cli), which is used to launch the Dev Environment. This guide will teach how to get started with remote Development Environments.
+These Dev environments work using a combination of [Okteto](/docs/reference/development-environments), which is used to deploy your application, and [Okteto CLI](/docs/cloud/okteto-cli), which is used to launch the Dev Environment. This guide will teach how to get started with remote Development Environments.
 
 ## Installing Okteto CLI
 
@@ -43,11 +43,11 @@ $ scoop install okteto
 
 Alternatively, you can directly download the binary [from GitHub](https://github.com/okteto/okteto/releases) or build it directly from the source code.
 
-## Configuring Okteto CLI with Okteto Cloud
+## Configuring Okteto CLI with Okteto
 
-You can launch a remote Development Environment on [Okteto Cloud](https://cloud.okteto.com) or **any** Kubernetes cluster with the Okteto CLI. For this guide, we'll be using Okteto Cloud. 
+You can launch a remote Development Environment on [Okteto](https://cloud.okteto.com) or **any** Kubernetes cluster with the Okteto CLI. For this guide, we'll be using Okteto. 
 
-The first thing you need to do is configure Okteto CLI to use Okteto Cloud. To do this, run the command below:
+The first thing you need to do is configure Okteto CLI to use Okteto. To do this, run the command below:
 
 ```console
 $ okteto context use https://cloud.okteto.com
@@ -77,4 +77,4 @@ Once the Okteto manifest is created, we recommend that you review it and adjust 
 
 ## Next Steps
 
-In this section, we installed Okteto CLI on our machine and configured it to work with Okteto Cloud. [Next](/docs/using-dev-envs), we're going to launch our Dev Environment and fix a bug in a sample application.
+In this section, we installed Okteto CLI on our machine and configured it to work with Okteto. [Next](/docs/using-dev-envs), we're going to launch our Dev Environment and fix a bug in a sample application.

--- a/versioned_docs/version-0.12/reference/cli.mdx
+++ b/versioned_docs/version-0.12/reference/cli.mdx
@@ -88,7 +88,7 @@ This will prompt you to select one of your existing contexts or to create a new 
 A context defines the default cluster/namespace for any Okteto CLI command.
 Select the context you want to use:
 Use the arrow keys to navigate: ↓ ↑ → ←
-  ▸ https://cloud.okteto.com (Okteto Cloud) *
+  ▸ https://cloud.okteto.com (Okteto) *
     minikube
     staging
     production
@@ -120,7 +120,7 @@ Available subcommands:
 
 Delete a context.
 
-For example, to delete the Okteto Cloud context, run:
+For example, to delete the Okteto context, run:
 
 ```console
 $ okteto context delete https://cloud.okteto.com

--- a/versioned_docs/version-0.12/reference/development-containers.mdx
+++ b/versioned_docs/version-0.12/reference/development-containers.mdx
@@ -20,9 +20,9 @@ For using `okteto up`, you will need to install the Okteto CLI. Okteto CLI is an
 
 Coming to the first step of deploying your application code, there are multiple options available for you to choose from. You can choose to deploy it on an existing cluster and use Okteto CLI to interact with this cluster. 
 
-A second option available is Okteto Cloud. Using Okteto Cloud, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto Cloud was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto Cloud [documentation](/docs/cloud). 
+A second option available is Okteto. Using Okteto, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto [documentation](/docs/cloud). 
 
-Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto Cloud - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto Cloud. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
+Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
 
 ## Getting started
 

--- a/versioned_docs/version-0.12/reference/development-environments.mdx
+++ b/versioned_docs/version-0.12/reference/development-environments.mdx
@@ -18,11 +18,24 @@ Setting up development environments using Okteto involves two main steps:
 
 For using `okteto up`, you will need to install the Okteto CLI. Okteto CLI is an [open-source](https://github.com/okteto/okteto) tool that helps spin up development containers regardless of where you choose to deploy your application code as part of the first step. You can learn more about it by heading to the documentation [here](/docs/cloud/okteto-cli/). 
 
-Coming to the first step of deploying your application code, there are multiple options available for you to choose from. You can choose to deploy it on an existing cluster and use Okteto CLI to interact with this cluster. 
+For the first step of deploying your application, there are multiple approaches for you to choose from. You can use Okteto for deploying your application. This way, you get a robust developer experience specially tailored by us, keeping Remote Development Environments in mind. Okteto comes with useful additional features you would not find in a traditional cluster.
 
-A second option available is Okteto Cloud. Using Okteto Cloud, you don't have to take care of setting up the infrastructure for deployment yourself. Okteto Cloud was built keeping dev environments in mind, so it also comes with useful [additional features](/docs/cloud) you would not find in a traditional cluster. To know more about it, you can head over to the Okteto Cloud [documentation](/docs/cloud). 
+With Okteto you can:
 
-Another option available is Okteto Self-Hosted. Okteto Self-Hosted gives you all the features of Okteto Cloud - on your own infrastructure. This offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto Cloud. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. 
+- Deploy your development environments with the [Okteto CLI](/docs/cloud/okteto-cli/) or from your [Git Repositories](/docs/cloud/deploy-from-git/).
+- Configure [Secrets](/docs/cloud/secrets/) and prevent secure credentials from being stored in version control.
+- Expose your development environments via [Automatic HTTPs Endpoints](/docs/cloud/ssl/) for your services, [Private Endpoints](/docs/cloud/private-endpoints/) to restrict access, and [Custom Domain Names](/docs/cloud/custom-domains/).
+- Build your images directly in the cloud using the [Okteto Build Service](/docs/cloud/build).
+- Push your container images in the [Okteto Registry](/docs/cloud/registry).
+- Create secure Kubernetes [Namespaces](/docs/cloud/namespaces/) with one click.
+- Download your [Kubernetes Credentials](/docs/cloud/credentials/) to access your namespaces with `kubectl`, `helm`, or any other CLI tool.
+- Visualize your workloads in a Developer-focused Kubernetes dashboard.
+
+If you want to try it out, head to our [Getting Started Guide](/docs/getting-started/) and see how you can use Okteto to simplify developing cloud-native applications. 
+
+With Okteto, you can also further choose between either hosting the infrastructure yourself or letting us take care of managing the cloud infrastructure for you. The former offers you full control of your Kubernetes infrastructure while delivering the same smooth experience you expect from Okteto. The Okteto Self-Hosted [documentation](/docs/enterprise) covers how you can get started with it. You can learn more about the exact differences from the [pricing page](https://www.okteto.com/pricing/).
+
+Okteto CLI works out of the box with any Kubernetes cluster. This means that the other option available for you is to take care of creating a convenient developer experience around your dev environments yourself and then only relying on Okteto CLI to launch the Remote Development Environments. With this approach, you are also responsible for setting up and managing the Kubernetes cluster. This approach is completely independent of using the Okteto platform or any of its features. 
 
 ## Getting started
 

--- a/versioned_docs/version-0.12/reference/docker-compose.mdx
+++ b/versioned_docs/version-0.12/reference/docker-compose.mdx
@@ -453,7 +453,7 @@ will use `change-me!` for the value of the `MYSQL_ROOT_PASSWORD` environment var
 
 > Values in the shell and/or the `.env` file take precedence over those specified in Okteto Secrets.
 
-## Okteto Cloud makes Docker Compose even more powerful!
+## Okteto makes Docker Compose even more powerful!
 
 Okteto extends the Compose Specification to make it even easier for you and your team to build cloud-native applications.
 

--- a/versioned_docs/version-0.12/reference/faqs.mdx
+++ b/versioned_docs/version-0.12/reference/faqs.mdx
@@ -70,13 +70,13 @@ $ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcr
 
 With this configuration, all the deployments, stateful sets, jobs, and development containers launched in your namespace will automatically use your registry credentials when pulling private images.
 
-## What types of Kubernetes services are supported in Okteto Cloud?
+## What types of Kubernetes services are supported in Okteto?
 
-`NodePort` or `LoadBalancer` services are not supported in Okteto Cloud. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/). Okteto Cloud also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
+`NodePort` or `LoadBalancer` services are not supported in Okteto. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/). Okteto also configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace. Only traffic between the pods running in your namespaces is allowed, as well as external traffic to the internet.
 
-## What resource quotas are present in Okteto Cloud Namespaces?
+## What resource quotas are present in Okteto Namespaces?
 
-The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto Cloud:
+The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/) are associated to every namespace created in Okteto:
 
 ### Developer Plan
 
@@ -109,11 +109,11 @@ The following [resource quotas](https://kubernetes.io/docs/concepts/policy/resou
 | Persistent Volume Claims  | 10  |
 
 
-## Are there any restrictions on applications deployed on Okteto Cloud?
+## Are there any restrictions on applications deployed on Okteto?
 
-Okteto Cloud configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
+Okteto configures [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to limit the privileges of your applications. The following options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Mounting volume host paths is also not allowed.
 
-Apart from that, Okteto Cloud also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
+Apart from that, Okteto also uses [RBAC rules](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to limit the access to the Kubernetes API. The supported endpoints are:
 
 ```yaml
 - apiGroups:

--- a/versioned_docs/version-0.12/reference/known-issues.mdx
+++ b/versioned_docs/version-0.12/reference/known-issues.mdx
@@ -17,7 +17,7 @@ For example, you can do it by running this command on each node:
 $ sudo sysctl -w fs.inotify.max_user_watches=10048576
 ```
 
-Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
+Okteto and Okteto Enterprise use a Daemon Set to apply this change automatically to every Kubernetes node.
 
 ## *kubectl apply* changes are undone by *okteto up*
 
@@ -25,7 +25,7 @@ Okteto Cloud and Okteto Enterprise use a Daemon Set to apply this change automat
 
 If you need to apply changes to your Kubernetes Deployment Manifest after running `okteto up`, note that **you need to run `okteto down` first** or `okteto up` will undo the changes you do to your Kubernetes Deployment Manifests. The reason is that `okteto up` records a copy of the deployment when `okteto up` is executed. This copy is used by `okteto down` to restore the original Kubernetes Deployment Manifest. But it is also used by `okteto up` as the original deployment to avoid ambiguities of "kubectl apply" concurrent changes.
 
-This issue does not apply if you're using Okteto Cloud or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
+This issue does not apply if you're using Okteto or Okteto Enterprise since the `okteto up` translation is done by a Mutation Webhook and there is no need to restore the original definition of the Kubernetes Deployment Manifest on `okteto down`.
 
 ## The okteto prompt doesn't look right in Windows
 

--- a/versioned_docs/version-0.12/samples/aspnetcore.mdx
+++ b/versioned_docs/version-0.12/samples/aspnetcore.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with ASP.NET
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application
+title: Getting Started on Okteto with ASP.NET
+description: This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application
 sidebar_label: ASP.NET
 id: aspnetcore
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop an ASP.NET sample application.
+This tutorial will show you how to create an account in Okteto and how to develop an ASP.NET sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the ASP.NET Sample App
 
@@ -36,11 +36,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI ASP.NET" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI ASP.NET" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Activate your development container
 
@@ -81,7 +81,7 @@ The `okteto up` command starts a [development container](/docs/reference/develop
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 3: Develop directly in Okteto Cloud
+## Step 3: Develop directly in Okteto
 
 Open the file `Controllers/HelloWorldController.cs` in your favorite local IDE and modify the response message on line 25 to be *Hello world from Okteto!*. Save your changes.
 
@@ -113,7 +113,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code using the VS dotnet debugger.
 
@@ -131,11 +131,11 @@ Go back to the browser and reload the page. As soon as the service receives the 
 
 <Image center borderless src="/docs/samples/images/aspnetcore-debug.png" alt="ASP.NET core debug" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -144,6 +144,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.12/samples/golang.mdx
+++ b/versioned_docs/version-0.12/samples/golang.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Go
+title: Getting Started on Okteto with Go
 description: This tutorial will show you how to develop a Go sample application
 sidebar_label: Go
 id: golang
@@ -7,14 +7,14 @@ id: golang
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Go sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Go sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Go Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI golang" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI golang" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -139,7 +139,7 @@ Starting hello-world server...
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the file `main.go` in your favorite local IDE and modify the response message on line 17 to be *Hello world from Okteto!*. Save your changes.
 
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Go development.
@@ -210,18 +210,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/golang-debug.png" alt="debugging in Okteto with golang" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.12/samples/java.mdx
+++ b/versioned_docs/version-0.12/samples/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Java
+title: Getting Started on Okteto with Java
 description: This tutorial will show you how to develop a Java sample application
 sidebar_label: Java
 id: java
@@ -7,14 +7,14 @@ id: java
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Java sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Java sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI >= 1.9.0. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Java Sample App
 
@@ -46,11 +46,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Java" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Java" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -165,7 +165,7 @@ The first time you run the application, Maven/Gradle will compile your applicati
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open `src/main/java/com/okteto/helloworld/RestHelloWorld.java` in your favorite local IDE and modify the response message on line 11 to be *Hello world from Okteto!*. Save your changes.
 
@@ -185,13 +185,13 @@ public class RestHelloWorld {
 }
 ```
 
-Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto Cloud. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
+Your IDE will auto compile only the necessary `*.class` files which will be synchronized by Okteto to your application in Okteto. Take a look at the development container shell and notice how the changes are detected by Spring Boot and automatically hot reloaded.
 
 > Import the `spring-boot-devtools` dependency to automatically restart your Java application whenever a file is changed.
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in Eclipse, one of the most popular IDEs for Java development.
 
@@ -207,17 +207,17 @@ Click the Debug button to start a debugging session. Add a breakpoint on `src/ma
 
 <Image center src="/docs/samples/images/java-halt.png" alt="breakpoint in Java" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.12/samples/node.mdx
+++ b/versioned_docs/version-0.12/samples/node.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Node.js
+title: Getting Started on Okteto with Node.js
 description: This tutorial will show you how to develop a Node.js sample application
 sidebar_label: Node.js
 id: node
@@ -7,14 +7,14 @@ id: node
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run cloud-native applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Node.js sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Node.js sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Deploy the Node.js Sample App
 
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Node.js" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Node.js" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -135,7 +135,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `index.js` file in your favorite local IDE and modify the response message on line 5 to be *Hello world from the cluster!*. Save your changes.
 
@@ -154,7 +154,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly on Okteto Cloud
+## Step 5: Debug directly on Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in VS Code, one of the most popular IDEs for Node development.
@@ -201,18 +201,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center src="/docs/samples/images/node-halt.png" alt="breakpoint in Node.js" width="850" />
 
-Your code is running in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is running in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing on a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.12/samples/php.mdx
+++ b/versioned_docs/version-0.12/samples/php.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with PHP
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application
+title: Getting Started on Okteto with PHP
+description: This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application
 sidebar_label: PHP
 id: php
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a PHP sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a PHP sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the PHP Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI PHP" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI PHP" width="850" />
 
-Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPS endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -134,7 +134,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 
 Go back to the browser, and reload the page to test that your application is running.
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `index.php` file in your favorite local IDE and modify the response message on line 2 to be *Hello world from the cluster!*. Save your changes.
 
@@ -146,7 +146,7 @@ echo($message);
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build or push required 😎!
 
-## Step 4: Debug directly in Okteto Cloud
+## Step 4: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works with [PHPStorm](https://www.jetbrains.com/phpstorm/), one of the most popular IDEs for PHP development.
 
@@ -158,13 +158,13 @@ Go back to your browser and reload the page. The execution will automatically ha
 
 At this point, you're able to inspect the request object, the current values of everything, the contents of `$_SERVER` variable, etc.
 
-<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto Cloud with PHP" width="850" />
+<Image center src="/docs/samples/images/php-halt.png" alt="debugging in Okteto with PHP" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -173,6 +173,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.12/samples/python.mdx
+++ b/versioned_docs/version-0.12/samples/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started on Okteto Cloud with Python
+title: Getting Started on Okteto with Python
 description: This tutorial will show you how to develop a Python sample application
 sidebar_label: Python
 id: python
@@ -7,14 +7,14 @@ id: python
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to develop and debug a Python sample application running in Okteto Cloud.
+This tutorial will show you how to develop and debug a Python sample application running in Okteto.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Python Sample App
@@ -38,11 +38,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs) and click on the URL of the application:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Python" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Python" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -138,7 +138,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page to test that your application is running.
 
-## Step 4: Develop directly on Okteto Cloud
+## Step 4: Develop directly on Okteto
 
 Open the `app.py` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*.
 Save your changes.
@@ -163,7 +163,7 @@ Starting hello-world server...
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE.
 Let's take a look at how that works in one of python's most popular IDE's, [PyCharm](https://www.jetbrains.com/pycharm/).
@@ -206,18 +206,18 @@ The execution will halt at your breakpoint. You can then inspect the request, th
 
 <Image center borderless src="/docs/samples/images/python-debug.png" alt="breakpoint in Python" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools.
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools.
 Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly on Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
 > - Test your application end to end as fast as you type code
 > - No more CPU cycles wasted in your machine. Develop at the speed of the cloud!
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.12/samples/ruby.mdx
+++ b/versioned_docs/version-0.12/samples/ruby.mdx
@@ -1,20 +1,20 @@
 ---
-title: Getting Started on Okteto Cloud with Ruby
-description: This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application
+title: Getting Started on Okteto with Ruby
+description: This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application
 sidebar_label: Ruby
 id: ruby
 ---
 
 import Image from '@theme/Image';
 
-[Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto](https://cloud.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
-This tutorial will show you how to create an account in Okteto Cloud and how to develop a Ruby sample application.
+This tutorial will show you how to create an account in Okteto and how to develop a Ruby sample application.
 
 ## Prerequisites
 
 - Install the Okteto CLI (>= 1.12.13). Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 
 ## Step 1: Deploy the Ruby Sample App
@@ -37,11 +37,11 @@ deployment.apps "hello-world" created
 service "hello-world" created
 ```
 
-Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
+Open your browser and go to the URL of the application. You can get the URL by logging into [Okteto](https://cloud.okteto.com/#/?origin=docs) and clicking on the application's endpoint:
 
-<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto Cloud UI Ruby" width="850" />
+<Image center src="/docs/samples/images/okteto-ui.png" alt="Okteto UI Ruby" width="850" />
 
-Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto Cloud will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
+Did you notice that you're accessing your application through an HTTPs endpoint? This is because Okteto will [automatically create them](/docs/cloud/ssl/) for you when you deploy your application. Cool no 😎?
 
 ## Step 2: Create your okteto manifest
 
@@ -132,7 +132,7 @@ cindy:hello-world app> ruby app.rb
 [2020-03-20 09:23:04] INFO  WEBrick::HTTPServer#start: pid=66 port=8080
 ```
 
-## Step 4: Develop directly in Okteto Cloud
+## Step 4: Develop directly in Okteto
 
 Open the `app.rb` file in your favorite local IDE and modify the response message on line 7 to be *Hello world from the cluster!*. Save your changes.
 
@@ -147,7 +147,7 @@ Okteto will synchronize your changes to your development container in Kubernetes
 
 Go back to the browser and reload the page. Your code changes were instantly applied. No commit, build, or push required 😎!
 
-## Step 5: Debug directly in Okteto Cloud
+## Step 5: Debug directly in Okteto
 
 Okteto enables you to debug your applications directly from your favorite IDE. Let's take a look at how that works in VS Code, one of the most popular IDEs for Ruby development. If you haven't done it yet, install the [Ruby extension](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby) available from Visual Studio marketplace. This extension comes with debug definitions covering the default `ruby-debug-ide` client setup.
 
@@ -186,11 +186,11 @@ Add a breakpoint on `app.rb`, line 8. Go back to the browser and reload the page
 
 <Image center src="/docs/samples/images/ruby-halt.png" alt="debugging in Okteto with Ruby" width="850" />
 
-Your code is executing in Okteto Cloud, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
+Your code is executing in Okteto, but you can debug it from your local machine without any extra services or tools. Pretty cool no? 😉
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 > Okteto lets you develop your applications directly in Kubernetes. This way you can:
 > - Eliminate integration issues by developing in a realistic environment
@@ -199,6 +199,6 @@ Congratulations, you just developed **your first application in Okteto Cloud** �
 
 Okteto uses the `okteto.yml` file to determine the name of your development container, the docker image to use, and where to upload your code. Check the [Okteto manifest docs](https://okteto.com/docs/reference/manifest/) to customize your development containers with your own dev tools, images, and dependencies to adapt Okteto to your own application.
 
-Ready to develop your application on Okteto Cloud? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
+Ready to develop your application on Okteto? Read our [step by step tutorial](/docs/cloud/okteto-cli/#okteto-manifest) on how to configure an Okteto Pipeline to deploy realistic environments for your application in just one click.
 
 Find more advanced samples with Okteto in [this repository](https://github.com/okteto/samples) or [join our community](https://community.okteto.com) to ask questions and share your feedback.

--- a/versioned_docs/version-0.12/tutorials/compose-getting-started.mdx
+++ b/versioned_docs/version-0.12/tutorials/compose-getting-started.mdx
@@ -14,7 +14,7 @@ Okteto implements and extends the [Compose Specification](https://github.com/com
 ## Prerequisites
 
 - Install the Okteto CLI. Follow this [guide](/docs/cloud/okteto-cli/) if you haven't done it yet.
-- Configure Access to your Okteto Cloud Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto Cloud UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
+- Configure Access to your Okteto Namespace [using the Okteto CLI](/docs/cloud/credentials/#download-your-kubernetes-credentials-using-the-okteto-cli) or [using the Okteto UI](/docs/cloud/credentials/#download-your-kubernetes-credentials-from-the-okteto-cloud-ui).
 
 ## Step 1: Launch your Development Environment
 
@@ -128,7 +128,7 @@ Your code changes were instantly applied. No commit, build, or push required!
 
 ## Next steps
 
-Congratulations, you just developed **your first application in Okteto Cloud** 🚀.
+Congratulations, you just developed **your first application in Okteto** 🚀.
 
 Read the docs for the [Docker Compose](/docs/reference/compose/) and the [available Okteto CLI commands](/docs/reference/cli) to learn more about developing your Docker Compose application on Okteto.
 

--- a/versioned_docs/version-0.12/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-0.12/tutorials/getting-started-with-okteto.mdx
@@ -15,7 +15,7 @@ The tutorial is composed of the following steps:
 
 - Step 1: Code the Hello World application
 - Step 2: Define a Dockerfile for building the Docker image of the Hello World application
-- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 - Step 4: Generate your Okteto manifest
 - Step 5: Launch your Development Environment
 - Step 6: Configure a Remote Development Container
@@ -69,7 +69,7 @@ $ go mod init go-getting-started
 
 ## Step 2: Define a Dockerfile for building the Docker image of the Hello World application
 
-You need to build a Docker image and push it to a Docker registry before Okteto Cloud can run your application.
+You need to build a Docker image and push it to a Docker registry before Okteto can run your application.
 
 To do that, you need to define a `Dockerfile`.
 A `Dockerfile` file is a sequence of instructions to build the Docker image of your application.
@@ -88,9 +88,9 @@ EXPOSE 8080
 CMD ["./app"]
 ```
 
-## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 
-To deploy an application to Okteto Cloud, you need to define it using Kubernetes manifests.
+To deploy an application to Okteto, you need to define it using Kubernetes manifests.
 
 Let's start by creating a new folder for the Kubernetes manifests:
 
@@ -157,7 +157,7 @@ The service manifest has four main sections:
 
 You now have everything ready to define the Okteto Manifest of the Hello World application.
 
-> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto Cloud a secure environment to run your applications.
+> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto a secure environment to run your applications.
 
 ## Step 4: Generate your Okteto manifest
 
@@ -183,7 +183,7 @@ You can make use of tools such as `kubectl`, `helm`, `okteto`, and `kustomize` i
 
 ## Step 5: Deploy your Development Environment
 
-[Install](/docs/cloud/okteto-cli/) the Okteto CLI and configure access to Okteto Cloud:
+[Install](/docs/cloud/okteto-cli/) the Okteto CLI and configure access to Okteto:
 
 ```console
 $ okteto context use https://cloud.okteto.com

--- a/versioned_docs/version-0.12/tutorials/getting-started-with-pipelines.mdx
+++ b/versioned_docs/version-0.12/tutorials/getting-started-with-pipelines.mdx
@@ -8,7 +8,7 @@ id: getting-started-with-pipelines
 import Image from '@theme/Image';
 
 This tutorial provides a step by step guide to configure an [Okteto Pipeline](/docs/cloud/okteto-pipeline/).
-Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto Cloud in just one click.
+Okteto Pipelines allow anyone on your team or your open source community to deploy a realistic environment for your application on Okteto in just one click.
 
 ## Overview
 
@@ -16,7 +16,7 @@ The tutorial is composed of the following steps:
 
 - Step 1: Code the Hello World application
 - Step 2: Define a Dockerfile for building the Docker image of the Hello World application
-- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+- Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 - Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 - Step 5: Deployment time!
 
@@ -68,7 +68,7 @@ $ go mod init go-getting-started
 
 ## Step 2: Define a Dockerfile for building the Docker image of the Hello World application
 
-You need to build a Docker image and push it to a Docker registry before Okteto Cloud can run your application.
+You need to build a Docker image and push it to a Docker registry before Okteto can run your application.
 
 To do that, you need to define a `Dockerfile`.
 A `Dockerfile` file is a sequence of instructions to build the Docker image of your application.
@@ -87,9 +87,9 @@ EXPOSE 8080
 CMD ["./app"]
 ```
 
-## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto Cloud
+## Step 3: Create Kubernetes manifests to deploy the Hello World application on Okteto
 
-To deploy an application to Okteto Cloud, you need to define it using Kubernetes manifests.
+To deploy an application to Okteto, you need to define it using Kubernetes manifests.
 
 Let's start by creating a new folder for the Kubernetes manifests:
 
@@ -156,7 +156,7 @@ The service manifest has four main sections:
 
 You now have everything ready to define the Okteto Pipeline of the Hello World application.
 
-> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto Cloud a secure environment to run your applications.
+> When writing your Kubernetes manifests, take into account the [multitenant Kubernetes restrictions](https://okteto.com/docs/cloud/multitenancy/) that we have in place to make Okteto a secure environment to run your applications.
 
 ## Step 4: Automate the deployment of the Hello World application with an Okteto Pipeline
 
@@ -181,21 +181,21 @@ Read the Okteto Pipeline [documentation](/docs/cloud/okteto-pipeline/) to learn 
 
 ## Step 5: Deployment time!
 
-Log into [Okteto Cloud](https://cloud.okteto.com/#/?origin=docs).
-Click on the **Deploy** button on the top left of the Okteto Cloud dashboard, select "**Git URL**" as the source
+Log into [Okteto](https://cloud.okteto.com/#/?origin=docs).
+Click on the **Deploy** button on the top left of the Okteto dashboard, select "**Git URL**" as the source
 and type the URL of your Git repository to deploy the Hello World application:
 
 <p align="center"><Image src="/docs/tutorials/images/deploy-from-git.png" alt="deploy a git repository" width="650" /></p>
 
 After a few seconds, your application will be ready. You can access the Hello World application by clicking its endpoint:
 
-<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto Cloud UI of Hello World app" width="850" />
+<Image center src="/docs/tutorials/images/okteto-hello-world-ui.png" alt="Okteto UI of Hello World app" width="850" />
 
 > You can make the deployment experience even smoother by adding a [Develop on Okteto](/docs/cloud/develop-on-okteto-button/) button to the `README.md` file of your Git repository.
 
 ## Next steps
 
-Congratulations, you just configured **your first Okteto Pipeline on Okteto Cloud** 🚀.
+Congratulations, you just configured **your first Okteto Pipeline on Okteto** 🚀.
 
 We have covered how to deploy realistic environments for cloud-native applications in just one-click.
 The full source code used on this tutorial is available [here](https://github.com/okteto/pipeline-getting-started).

--- a/versioned_docs/version-0.12/tutorials/preview-environments.mdx
+++ b/versioned_docs/version-0.12/tutorials/preview-environments.mdx
@@ -1,16 +1,16 @@
 ---
 title: Preview Environments for your Kubernetes Applications
-description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto Cloud and GitHub Actions
+description: Tutorial on how to automatically create a preview environments for a Kubernetes application using Okteto and GitHub Actions
 sidebar_label: Preview Environments for your Kubernetes Apps
 id: preview-environments
 ---
 
 import Image from '@theme/Image';
 
-In this section, we'll show you how to automatically create a preview environment for your applications using Okteto Cloud and GitHub Actions.
+In this section, we'll show you how to automatically create a preview environment for your applications using Okteto and GitHub Actions.
 
 ## Pre-Requisites
-- An [Okteto Cloud account](https://cloud.okteto.com)
+- An [Okteto account](https://cloud.okteto.com)
 - A [GitHub account](https://github.com)
 
 For this tutorial, we'll be using [this application](https://github.com/okteto/kubernetes-preview-environment).
@@ -21,12 +21,12 @@ Start by forking the [kubernetes-preview-environment](https://github.com/okteto/
 
 ## Step 2: Create the GitHub Workflow
 
-To create the preview environments, we're going to use our [GitHub Actions for Okteto Cloud](https://github.com/okteto/actions).
+To create the preview environments, we're going to use our [GitHub Actions for Okteto](https://github.com/okteto/actions).
 
 Creating a preview environment requires performing the following steps:
 
-1. Login to Okteto Cloud.
-1. Deploy a preview environment in Okteto Cloud.
+1. Login to Okteto.
+1. Deploy a preview environment in Okteto.
 1. Update the PR with the URL of the preview environment.
 
 The sample repository configured to use [the workflow described above](https://github.com/okteto/kubernetes-preview-environment/blob/master/.github/workflows/preview.yaml). If you want to use this one for your own repositories, all you need to do is to create a `.github/workflow` folder in the root of your repo, and save your workflow file in it.

--- a/versioned_docs/version-0.12/tutorials/repos.mdx
+++ b/versioned_docs/version-0.12/tutorials/repos.mdx
@@ -1,22 +1,22 @@
 ---
 title: How to Configure your Custom Helm Repository
-description: Tutorial on how to add your own Helm repository to Okteto Cloud
+description: Tutorial on how to add your own Helm repository to Okteto
 sidebar_label: Configure your Custom Helm Repository
 id: repos
 ---
 
 import Image from '@theme/Image';
 
-With Okteto Cloud you can deploy [Helm Charts with one click](/docs/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
+With Okteto you can deploy [Helm Charts with one click](/docs/cloud/deploy-from-helm/). A default list of Helm Charts is provided to get you and your team up and running.
 
-You can add your own Helm repositories to Okteto Cloud to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
+You can add your own Helm repositories to Okteto to extend this list. This gives you the same one-click deployment experience with the services that you and your team use. You can use this to simplify onboarding and standarize your dependencies.
 
 In order to add your Helm Charts, you'll need a Helm chart repository index with at least one published chart. [Follow this guide](https://helm.sh/docs/chart_repository/) to learn how to do it.
 
-## Add your repository to Okteto Cloud
+## Add your repository to Okteto
 
-On the left side of the Okteto Cloud UI click the **Settings** option. In the new window, click the **Integrations** tab.
-The Okteto Cloud UI will show you the Helm repositories you have configured in Okteto Cloud. Click the **Add Repository** button and put the address of your repository:
+On the left side of the Okteto UI click the **Settings** option. In the new window, click the **Integrations** tab.
+The Okteto UI will show you the Helm repositories you have configured in Okteto. Click the **Add Repository** button and put the address of your repository:
 
 <p align="center"><Image src="/docs/tutorials/images/helm-repos.png" alt="add a Helm repository" width="850" /></p>
 
@@ -31,12 +31,12 @@ Okteto will automatically load the `values-okteto.yaml` file and show it in the 
 
 ## Make your chart multi-tenant friendly.
 
-Okteto Cloud is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
+Okteto is a multi-tenant environment. It gives you access to a Kubernetes namespace with a few restrictions in place to make it safer and easier to use for everyone.
 
-Your Helm chart will need to comply with these restrictions to function properly in Okteto Cloud:
+Your Helm chart will need to comply with these restrictions to function properly in Okteto:
 
 - Your chart cannot create `ClusterRole` or `ClusterRoleBinding` objects.
-- `NodePort` and `LoadBalancer` service types are not supported. Okteto Cloud automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
+- `NodePort` and `LoadBalancer` service types are not supported. Okteto automatically translates `NodePort` or `LoadBalancer` services into ingress rules. More information is [available here](/docs/cloud/ssl/).
 - The following `Pod` options are not allowed: `privileged`, `hostNetwork`, `allowPrivilegeEscalation`, `hostPID`, `hostIPC`. Volume host paths are not allowed either.
 
 More information about our multi-tenant policies [is available here](/docs/cloud/multitenancy/).

--- a/versioned_docs/version-0.12/using-dev-envs.mdx
+++ b/versioned_docs/version-0.12/using-dev-envs.mdx
@@ -10,7 +10,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-We set configured Okteto CLI with Okteto Cloud in the [previous section](/docs/getting-started). In this section, let's do the fun bits of developing our application in our Development Environment.
+We set configured Okteto CLI with Okteto in the [previous section](/docs/getting-started). In this section, let's do the fun bits of developing our application in our Development Environment.
 
 ## One Command To Rule Them All
 
@@ -53,7 +53,7 @@ Since we already have a [Docker compose file](/docs/cloud/okteto-cli/#okteto-man
 
 The Movies app only has the `api` and `frontent` microservices, which we see in the prompt. Let's go with `api` because we know there's a bug there we need to fix 🙂
 
-Once you do that, you should see Okteto CLI building the required Docker images for your microservices. When it is done building the images, it will start deploying your application to Okteto Cloud. You should see the deployed endpoints as part of the output in the CLI:
+Once you do that, you should see Okteto CLI building the required Docker images for your microservices. When it is done building the images, it will start deploying your application to Okteto. You should see the deployed endpoints as part of the output in the CLI:
 
 ```console
 Success! Your application will be available shortly.
@@ -62,7 +62,7 @@ i  Endpoints available:
   - https://movies-with-helm-cindylopez.cloud.okteto.net/api
 ```
 
-You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto Cloud dashboard:
+You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
 <Image
@@ -104,7 +104,7 @@ In case your application images aren't already built, you'll also have the optio
 
 The images for the Movies app haven't already been built, so let's select `api/Dockerfile` first and then `frontend/Dockerfile`.
 
-Once Okteto CLI is done building the images for you, it will start deploying your application to Okteto Cloud. You should see the deployed endpoints as part of the output in the CLI:
+Once Okteto CLI is done building the images for you, it will start deploying your application to Okteto. You should see the deployed endpoints as part of the output in the CLI:
 
 ```console
 Success! Your application will be available shortly.
@@ -113,7 +113,7 @@ i  Endpoints available:
   - https://movies-with-helm-cindylopez.cloud.okteto.net/api
 ```
 
-You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto Cloud dashboard:
+You should be able to view your application when you visit these endpoints. The first endpoint serves the UI for our application, while the second one has the backend API deployed. These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
 <Image
@@ -212,7 +212,7 @@ Okteto's Development Environment allowed the changes you made to your code local
 
 Congratulations! You successfully developed your first application in a Remote Development Environment. 
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
 
 From here, we recommend the following next steps:
 - Try launching a Dev Environment for your own application following similar steps to what we saw in this guide.

--- a/versioned_sidebars/version-0.11-sidebars.json
+++ b/versioned_sidebars/version-0.11-sidebars.json
@@ -5,13 +5,15 @@
       {
         "type": "category",
         "label": "Getting Started",
-        "items": ["getting-started", "using-dev-envs"]
+        "items": [
+          "getting-started",
+          "using-dev-envs"
+        ]
       }
     ],
     "Dev Environments": [
       "reference/development-environments",
       "cloud/okteto-cli",
-      "cloud",
       {
         "type": "category",
         "label": "Deploying",

--- a/versioned_sidebars/version-0.12-sidebars.json
+++ b/versioned_sidebars/version-0.12-sidebars.json
@@ -5,13 +5,15 @@
       {
         "type": "category",
         "label": "Getting Started",
-        "items": ["getting-started", "using-dev-envs"]
+        "items": [
+          "getting-started",
+          "using-dev-envs"
+        ]
       }
     ],
     "Dev Environments": [
       "reference/development-environments",
       "cloud/okteto-cli",
-      "cloud",
       {
         "type": "category",
         "label": "Deploying",


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

For the upcoming pricing model changes.

Changes:

- Removed the `/cloud` page and added redirects to `/docs/reference/development-environments/` instead
- Added list of features (from the `/cloud` page) and wrote new description for the `/docs/reference/development-environments/` page
- Replcaed all instances of "Okteto Cloud" with "Okteto"