### PR TITLE
Update docs to document that the Helm catalog is disabled by default

### DIFF
--- a/src/content/cloud/deploy-from-helm.mdx
+++ b/src/content/cloud/deploy-from-helm.mdx
@@ -10,7 +10,8 @@ import Image from '@theme/Image';
 You can launch additional services for your development environments on Okteto Cloud using Helm repositories.
 Okteto automates all the processes needed to deploy, configure, upgrade, and destroy your Helm releases, so you can focus on building amazing applications.
 
-You can also [list your own repository under the **Helm Catalog**](/docs/enterprise/administration/configuration/#applications) tab of the **Deployment** menu. This would give you the same one-click deployment experience for your own services when using [Okteto Self-Hosted](/docs/enterprise/).
+You can also list your own charts under the [Helm Catalog](/docs/enterprise/administration/configuration/#applications) tab of the **Launch Dev Environment** menu.
+This would give you the same one-click deployment experience for your own services when using [Okteto Self-Hosted](/docs/enterprise/).
 
 ## Deploy
 

--- a/src/content/cloud/deploy-from-helm.mdx
+++ b/src/content/cloud/deploy-from-helm.mdx
@@ -10,7 +10,7 @@ import Image from '@theme/Image';
 You can launch additional services for your development environments on Okteto Cloud using Helm repositories.
 Okteto automates all the processes needed to deploy, configure, upgrade, and destroy your Helm releases, so you can focus on building amazing applications.
 
-You can also [bring your own Helm repository](/docs/enterprise/administration/configuration/#applications) to the catalog and get the same one-click deployment experience for your own services when using [Okteto Self-Hosted](/docs/enterprise/).
+You can also [list your own repository under the **Helm Catalog**](/docs/enterprise/administration/configuration/#applications) tab of the **Deployment** menu. This would give you the same one-click deployment experience for your own services when using [Okteto Self-Hosted](/docs/enterprise/).
 
 ## Deploy
 

--- a/src/content/cloud/deploy-from-helm.mdx
+++ b/src/content/cloud/deploy-from-helm.mdx
@@ -10,6 +10,8 @@ import Image from '@theme/Image';
 You can launch additional services for your development environments on Okteto Cloud using Helm repositories.
 Okteto automates all the processes needed to deploy, configure, upgrade, and destroy your Helm releases, so you can focus on building amazing applications.
 
+You can also [bring your own Helm repository](/docs/enterprise/administration/configuration/#applications) to the catalog and get the same one-click deployment experience for your own services when using [Okteto Self-Hosted](/docs/enterprise/).
+
 ## Deploy
 
 Log in to [Okteto Cloud](https://cloud.okteto.com), and click on the **Launch Dev Environment** button on the top left. A deploy dialog will open.
@@ -49,9 +51,3 @@ A confirmation dialog will pop up. Click on the **Destroy** button to confirm yo
 
 In this case, the persistent volume created by Redis won't be deleted to avoid losing any sensitive data.
 You can delete it manually from the Okteto Cloud UI if you want.
-
-## Application Catalog
-
-The default catalog contains building blocks like MongoDB and Redis, well-known frameworks like OpenFaaS or TensorFlow Notebooks, and a couple of commodity services like a web terminal.  Did we miss your favorite one? [Open an issue](https://github.com/okteto/charts/issues/new) to let us know. Or submit [your very own chart](https://github.com/okteto/charts/pulls) to make it available for every developer in Okteto Cloud.
-
-You can also [bring your own Helm repository](/docs/tutorials/repos/) to the catalog and get the same one-click deployment experience for your own services.

--- a/src/content/enterprise/administration/configuration.mdx
+++ b/src/content/enterprise/administration/configuration.mdx
@@ -460,7 +460,7 @@ In this case, pods deployed in namespaces created by Okteto will have a preferre
 
 ### applications
 
-- `repository`: The default [application repository](/docs/tutorials/repos/) for every Okteto Enterprise user. It defaults to `https://apps.okteto.com` when not specified.
+- `repository`: The [Helm repository](/docs/cloud/deploy-from-helm/) available for every developer. By default, deploying from a Helm repository isn't available.
 
 ```yaml
 applications:


### PR DESCRIPTION
We are disabling the Helm catalog by default in self-hosted installations.
Our catalog requires to install custom CRDs that make the whole installation process more complicated