### PR TITLE
Fixing a typo in our welcome overview.

### DIFF
--- a/src/content/welcome/overview.md
+++ b/src/content/welcome/overview.md
@@ -8,21 +8,21 @@ id: overview
 Okteto is a platform to simplify the application development process by leveraging pre-configured cloud environments. This overview covers what Okteto offers and how you can get started.
 
 ## Development Environments
-Okteto's [Dev Environments](/docs/reference/development-environments/) offer you a way to deploy and develop applications directly on the cloud. The traditional development workflow involves committing and pushing your changes and then waiting for the CI to build and deploy them before you can take a look. If you have to do this multiple times a day, not only is it frustrating, it is also extremely time-consuming, especially if multiple developers are using a single staging environment. 
+Okteto's [Dev Environments](/docs/reference/development-environments/) offer you a way to deploy and develop applications directly on the cloud. The traditional development workflow involves committing and pushing your changes and then waiting for the CI to build and deploy them before you can take a look. If you have to do this multiple times a day, not only is it frustrating, it is also extremely time-consuming, especially if multiple developers are using a single staging environment.
 
-Dev Environments solve this exact problem by allowing you to code locally on your machine but seeing your changes live deployed on a cluster **as soon as you hit save**! You don't have to spend time configuring a bunch of things for this - Okteto takes care of that for you. If you'd like to see this in action, head right to the [Quick Start Guide](/docs/getting-started). If you're looking for more in-detail documentation, you can find that [here](/docs/reference/development-environments/). 
+Dev Environments solve this exact problem by allowing you to code locally on your machine but seeing your changes live deployed on a cluster **as soon as you hit save**! You don't have to spend time configuring a bunch of things for this - Okteto takes care of that for you. If you'd like to see this in action, head right to the [Quick Start Guide](/docs/getting-started). If you're looking for more in-detail documentation, you can find that [here](/docs/reference/development-environments/).
 
 ## Preview Environments
-Using Okteto, you can configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) for your code repositories. Every pull request will then get deployed and will get its own separate sharable URL. This allows teams to browse the changes in a pull request even before it gets merged - without having to take care of any deployment-related setup. These URLs can also be shared with other stakeholders so that the review process isn't just limited to developers. 
+Using Okteto, you can configure [Preview Environments](/docs/cloud/preview-environments/preview-environments) for your code repositories. Every pull request will then get deployed and will get its own separate sharable URL. This allows teams to browse the changes in a pull request even before it gets merged - without having to take care of any deployment-related setup. These URLs can also be shared with other stakeholders so that the review process isn't just limited to developers.
 
-You can learn how to configure Preview Environments by following the docs [here](/docs/cloud/preview-environments/preview-environments). 
+You can learn how to configure Preview Environments by following the docs [here](/docs/cloud/preview-environments/preview-environments).
 
 ## Why Okteto?
 
-Okteto was built for developers, by developers. We understand how frustrating it is for developers to deal with the modern-day challenges of cloud-native development. 
+Okteto was built for developers, by developers. We understand how frustrating it is for developers to deal with the modern-day challenges of cloud-native development.
 
-Seeing what you're developing, deployed, while you're developing is a problem multiple tools try to solve - but not as effectively as Okteto. We know that developers only want to focus on writing code, and we provide just that by abstracting away the complexities of developing on a cloud environment. 
+Seeing what you're developing, deployed, while you're developing is a problem multiple tools try to solve - but not as effectively as Okteto. We know that developers only want to focus on writing code, and we provide just that by abstracting away the complexities of developing on a cloud environment.
 
-With Okteto, we had back developers the freedom they love. Developers can focus on writing code and let Okteto take care of handling the boring parts of setting up and managing the development infrastructure!
+With Okteto, we hand back developers the freedom they love. Developers can focus on writing code and let Okteto take care of handling the boring parts of setting up and managing the development infrastructure!
 
 If you have more questions on how you can leverage Okteto to simplify your development process, we're here to [talk](https://okteto.com/schedule/)! 🙂


### PR DESCRIPTION
There is a typo at the end of the diff. My editor also cleaned up some trailing whitespace.