### PR TITLE
Remove "kubectl" command to retrieve ssh key

### DIFF
--- a/src/content/administration/private-repositories/ssh-key.mdx
+++ b/src/content/administration/private-repositories/ssh-key.mdx
@@ -20,14 +20,6 @@ The public SSH is available on the `Settings` section on the `Admin -> General` 
 
 <p align="center"><Image src="/docs/administration/private-repositories/images/private-repository-ssh-key.png" alt="show SSH key" width="676" /></p>
 
-### Retrive the SSH key using kubectl <TiersList tiers="Self-Hosted" />
-
-You can also retreive the public SSH key by running the command below:
-
-```console
-kubectl get secret okteto-ssh -n=okteto -ojsonpath='{.data.identity\.pub}' | base64 --decode
-```
-
 ## Add the Public Key to your Source Code Provider
 Once you have the public key, follow your source code provider's instructions on how to add the SSH key to your account. We recommend that you create a dedicated `bot` account for Okteto.
 


### PR DESCRIPTION
Now we have the ability to download the SSH key from the Admin View, we shouldn't document how to access it using `kubectl`. This is too dependent on the implementation of the feature, and it's a poorer experience