### PR TITLE
Document `dev.okteto.com/skip-snapshot-if-same-namespace: "true"` ann…

### DIFF
--- a/src/content/enterprise/administration/volume-snapshots.mdx
+++ b/src/content/enterprise/administration/volume-snapshots.mdx
@@ -238,6 +238,9 @@ spec:
 ```
 
 If the annotation `dev.okteto.com/from-snapshot-namespace` is not defined, Okteto will default to the namespace of the new persistent volume claim.
+
+Use the annotation `dev.okteto.com/skip-snapshot-if-same-namespace: "true"` to skip the data cloning operation if the source snapshot and the new PVC are in the same namespace.
+
 By default, all users in your cluster will be able to use any of the available snapshots as a data source for their development environments. You can limit this via the `enableNamespaceAccessValidation` key in the `volumeSnapshots` section of the configuration, value of `true` will enable the validation.
 
 ## Using Storage Snapshots in your Development Environment


### PR DESCRIPTION
…otation

This is useful to avoid cloning data when redeploying the volumes in the namespace where the source snapshot is defined