### PR TITLE
add keepalive client docs

### DIFF
--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -76,6 +76,13 @@ In order to refer to images in the `build` section of the Okteto Manifest, you c
 - `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)
 - `${OKTETO_BUILD_<service>_IMAGE}`: the full image reference (using its SHA)
 
+It is also possible to handle timeouts from the client side when communicating with the buldkit daemon. To do so, the following environment variables can be modified:
+
+- `OKTETO_KEEPALIVE_CLIENT_TIME_MS`: After this duration of time, if the client doesn't see any activity it will ping the server to see if the transport is still alive. If set below 10s, a minimum value of 10s will be used. The current default value is infinity.
+- `OKTETO_KEEPALIVE_CLIENT_TIMEOUT_MS`: After sending a keepalive ping, the client waits for a duration of this value and if no activity is seen even after that the connection is closed. The current default value is 20 seconds.
+- `OKTETO_KEEPALIVE_CLIENT_PERMIT_WITHOUT_STREAM`: If true, the client sends keepalive pings even with no active RPCs. If false, when there are no active RPCs, Time and Timeout will be ignored and no keepalive pings will be sent. False by default.
+
+
 ### Built-in Tools When Deploying To Okteto Cloud
 
 When launching a development environment [from a Git Repository](/docs/cloud/deploy-from-git/), Okteto will run an installation job that clones the Git repository, checks out the selected branch, builds the images defined in the `build` section of your Okteto Manifest, and executes the sequence of `deploy` commands. The job will fail if any of the commands in the `deploy` list fails.

--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -79,7 +79,7 @@ In order to refer to images in the `build` section of the Okteto Manifest, you c
 It is also possible to handle timeouts from the client side when communicating with the buldkit daemon. To do so, the following environment variables can be modified:
 
 - `OKTETO_KEEPALIVE_CLIENT_TIME_MS`: After this duration of time, if the client doesn't see any activity it will ping the server to see if the transport is still alive. If set below 10s, a minimum value of 10s will be used. The current default value is infinity.
-- `OKTETO_KEEPALIVE_CLIENT_TIMEOUT_MS`: After sending a keepalive ping, the client waits for a duration of this value and if no activity is seen even after that the connection is closed. The current default value is 20 seconds.
+- `OKTETO_KEEPALIVE_CLIENT_TIMEOUT_MS`: After sending a keepalive ping, the client waits for this duration of time and if no activity is seen even after that the connection is closed. The current default value is 20 seconds.
 - `OKTETO_KEEPALIVE_CLIENT_PERMIT_WITHOUT_STREAM`: If true, the client sends keepalive pings even with no active RPCs. If false, when there are no active RPCs, Time and Timeout will be ignored and no keepalive pings will be sent. False by default.
 
 

--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -76,13 +76,6 @@ In order to refer to images in the `build` section of the Okteto Manifest, you c
 - `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)
 - `${OKTETO_BUILD_<service>_IMAGE}`: the full image reference (using its SHA)
 
-It is also possible to handle timeouts from the client side when communicating with the buldkit daemon. To do so, the following environment variables can be modified:
-
-- `OKTETO_KEEPALIVE_CLIENT_TIME_MS`: After this duration of time, if the client doesn't see any activity it will ping the server to see if the transport is still alive. If set below 10s, a minimum value of 10s will be used. The current default value is infinity.
-- `OKTETO_KEEPALIVE_CLIENT_TIMEOUT_MS`: After sending a keepalive ping, the client waits for this duration of time and if no activity is seen even after that the connection is closed. The current default value is 20 seconds.
-- `OKTETO_KEEPALIVE_CLIENT_PERMIT_WITHOUT_STREAM`: If true, the client sends keepalive pings even with no active RPCs. If false, when there are no active RPCs, Time and Timeout will be ignored and no keepalive pings will be sent. False by default.
-
-
 ### Built-in Tools When Deploying To Okteto Cloud
 
 When launching a development environment [from a Git Repository](/docs/cloud/deploy-from-git/), Okteto will run an installation job that clones the Git repository, checks out the selected branch, builds the images defined in the `build` section of your Okteto Manifest, and executes the sequence of `deploy` commands. The job will fail if any of the commands in the `deploy` list fails.

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -22,6 +22,15 @@ Use `okteto command --help` for information on a specific command. The synopsis 
 
 The amount of information outputted (defaults to _warn_).
 
+## Advanced configuration
+
+It is possible to handle timeouts from the client side when communicating with the buldkit daemon through the Okteto CLI. To do so, the following environment variables can be modified:
+
+- `OKTETO_KEEPALIVE_CLIENT_TIME_MS`: After this duration of time, if the client doesn't see any activity it will ping the server to see if the transport is still alive. If set below 10s, a minimum value of 10s will be used. The current default value is infinity.
+- `OKTETO_KEEPALIVE_CLIENT_TIMEOUT_MS`: After sending a keepalive ping, the client waits for this duration of time and if no activity is seen even after that the connection is closed. The current default value is 20 seconds.
+- `OKTETO_KEEPALIVE_CLIENT_PERMIT_WITHOUT_STREAM`: If true, the client sends keepalive pings even with no active RPCs. If false, when there are no active RPCs, Time and Timeout will be ignored and no keepalive pings will be sent. False by default.
+
+
 ## Available commands
 
 ### analytics


### PR DESCRIPTION
Signed-off-by: adripedriza <adripedriza@gmail.com>

documentation on timeout handling by the client when communicating with the buildkit daemon

https://github.com/okteto/buildkit/pull/18