### PR TITLE
docs: add injected build_args

### DIFF
--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -72,7 +72,7 @@ You can build all these images by running `okteto build`, or `okteto build xxx` 
 
 > if a `<service>` name includes the symbol `-`, in the corresponding `OKTETO_BUILD_<service>` environment variables, the symbol `-` will be replaced by `_`.  For example, if `<service>` is `name-with-hyphen`, the environment variable names will start with `$OKTETO_BUILD_NAME_WITH_HYPHEN_`.
 
-> Okteto autoinjects `OKTETO_NAMESPACE` and `OKTETO_CONTEXT` on every build as build args.
+> Okteto will automatically add `OKTETO_NAMESPACE` and `OKTETO_CONTEXT` on every build as a build argument.
 
 ### context (string, optional)
 

--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -72,6 +72,8 @@ You can build all these images by running `okteto build`, or `okteto build xxx` 
 
 > if a `<service>` name includes the symbol `-`, in the corresponding `OKTETO_BUILD_<service>` environment variables, the symbol `-` will be replaced by `_`.  For example, if `<service>` is `name-with-hyphen`, the environment variable names will start with `$OKTETO_BUILD_NAME_WITH_HYPHEN_`.
 
+> Okteto autoinjects the namespace and context you're currently working on as build_args.
+
 ### context (string, optional)
 
 The okteto context when the development environment is deployed. By default, it uses the current okteto context.

--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -72,7 +72,7 @@ You can build all these images by running `okteto build`, or `okteto build xxx` 
 
 > if a `<service>` name includes the symbol `-`, in the corresponding `OKTETO_BUILD_<service>` environment variables, the symbol `-` will be replaced by `_`.  For example, if `<service>` is `name-with-hyphen`, the environment variable names will start with `$OKTETO_BUILD_NAME_WITH_HYPHEN_`.
 
-> Okteto autoinjects the namespace and context you're currently working on as build_args.
+> Okteto autoinjects `OKTETO_NAMESPACE` and `OKTETO_CONTEXT` on every build as build args.
 
 ### context (string, optional)
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

We autoinject `OKTETO_NAMESPACE` and `OKTETO_CONTEXT` on every build as build_args. 

Introduced in: https://github.com/okteto/okteto/pull/2996
