### PR TITLE
Add a comment on `BUILDKIT_HOST`

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -59,7 +59,7 @@ $ okteto build [service...]
 ```
 
 If your [okteto context](/docs/reference/cli/#context) points to an Okteto URL, images are built using the [Okteto Build Service](/docs/cloud/build/).
-Otherwise, images are built using your local Docker daemon. If you want to use your own BuildKit instance, set the variable `BUILDKIT_HOST` to point to your Buildkit server address.
+Otherwise, images are built using your local Docker daemon. If you want to use another BuildKit instance, set the variable `BUILDKIT_HOST` to point to its address, using the format `HOST:PORT`. 
 
 The following flags can be used (very similar to `docker build`):
 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -59,7 +59,7 @@ $ okteto build [service...]
 ```
 
 If your [okteto context](/docs/reference/cli/#context) points to an Okteto URL, images are built using the [Okteto Build Service](/docs/cloud/build/).
-Otherwise, images are built using your local Docker daemon.
+Otherwise, images are built using your local Docker daemon. If you want to use your own BuildKit instance, set the variable `BUILDKIT_HOST` to point to your Buildkit server address.
 
 The following flags can be used (very similar to `docker build`):
 


### PR DESCRIPTION
`BUILDKIT_HOST` can be used to configure your own buildkit server