### PR TITLE
Make it clearer "organization" should be defined when using GitHub OAuth

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -108,6 +108,7 @@ Download a copy of the [Okteto AKS configuration file](/docs/self-hosted/aks/con
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the OAuth Application you created
+- You GitHub `organization`.  An empty `organization` field permits any user to log in.
 - Your cluster's API server endpoint
 - The name of the `storage container` you created
 - The `Storage Account Name`
@@ -126,6 +127,7 @@ auth:
     enabled: true
     clientId: ae8924d074d8c8809999
     clientSecret: ABCD90598b706d5342f07cce18fee5e5da391234
+    organization: my-org
 
 cloud:
   provider:

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -9,6 +9,7 @@ auth:
     enabled: true
     clientId: 
     clientSecret:
+    organization:
 
 cluster:
   endpoint:

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -90,6 +90,7 @@ Download a copy of the [Okteto Civo configuration file](/docs/self-hosted/civo/c
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the GitHub OAuth Application you created
+- You GitHub `organization`.  An empty `organization` field permits any user to log in.
 
 For example:
 
@@ -102,6 +103,7 @@ auth:
     enabled: true
     clientId: ae8924d074d8c8809999
     clientSecret: ABCD90598b706d5342f07cce18fee5e5da391234
+    organization: my-org
 
 cloud:
   provider:

--- a/src/content/self-hosted/civo/config.yaml
+++ b/src/content/self-hosted/civo/config.yaml
@@ -9,6 +9,7 @@ auth:
     enabled: true
     clientId: 
     clientSecret:
+    organization:
 
 cloud:
   provider:

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -5,9 +5,12 @@ license:
 subdomain: 
 
 auth:
-  github:
+  openid:
     enabled: true
-    clientId: 
+    endpoints:
+       issuer:
+       authorization:
+    clientId:
     clientSecret:
 
 cluster:

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -150,6 +150,7 @@ Download a copy of the [Okteto EKS configuration file](/docs/self-hosted/eks/con
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the OAuth Application you created
+- You GitHub `organization`.  An empty `organization` field permits any user to log in.
 - Your cluster's API server endpoint
 - The name of the `bucket` you created
 - The `Access key ID` of the IAM User
@@ -170,6 +171,7 @@ auth:
     enabled: true
     clientId: ae8924d074d8c8809999
     clientSecret: ABCD90598b706d5342f07cce18fee5e5da391234
+    organization: my-org
 
 cloud:
   provider:

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -9,6 +9,7 @@ auth:
     enabled: true
     clientId: 
     clientSecret:
+    organization:
 
 cluster:
   endpoint:


### PR DESCRIPTION
This is a critical setting that should be configured from day one. Otherwise, everyone with a github account is able to login to Okteto