### PR TITLE
Document cluster role supported configurations

### DIFF
--- a/src/content/enterprise/administration/configuration.mdx
+++ b/src/content/enterprise/administration/configuration.mdx
@@ -501,10 +501,11 @@ applications:
 
 ### clusterRole
 
-The role Okteto assigns to every user. If empty, Okteto will create a default role.
+Okteto assings this cluster role to every user via a namespace-scoped role binding.
+The default value assigns each developer a `cluster-admin` role binding with only access to their personal namespaces.
 
 ```yaml
-clusterRole: "role name"
+clusterRole: "cluster-admin"
 ```
 
 ### convertLoadBalancedServices
@@ -529,6 +530,15 @@ devStorageClass:
 ```
 
 There is only one exception where this storage class is overwritten. In case of having [volume snapshots feature](/docs/enterprise/administration/volume-snapshots/) configured, if a storage class is required for the snapshots that storage class will have preference.
+
+### globalClusterRole
+
+Okteto assings this cluster role to every user via a cluster role binding. By default, this behavior is disabled.
+This can be useful to give access to cluster level resources to every developer account, like accessing the Node API.
+
+```yaml
+globalClusterRole: ""
+```
 
 ### ingress
 


### PR DESCRIPTION
It's time to document `globalClusterRole` because it's used now by several users 