### PR TITLE
Remove requirements for publicly accessible dns domains

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -20,7 +20,7 @@ In order to fully install Okteto, you'll need the following:
 
 ### Subdomain
 
-You'll need access to an internet accessible subdomain to which you can add a wildcard DNS record, such as dev.example.com.
+You'll need access to a subdomain to which you can add a wildcard DNS record, such as dev.example.com.
 
 This guide will assume that your domain is registered in [AzureDNS](https://docs.microsoft.com/en-us/azure/dns/dns-overview). Other DNS services can be used, but aren't covered here.
 
@@ -81,9 +81,8 @@ helm repo update
 
 ### Getting your Okteto License
 
-Okteto is free for small teams. You get all the features of [Okteto](/free-trial/) for up to 3 users with 3 namespaces each.
-
-Want to use Okteto with a bigger team? [Let's talk](https://okteto.com/#talktous)
+Okteto is free for up to 3 users without a license.
+You can also sign on for the [free trial](/free-trial/) to give access up to 100 users for a month.
 
 ## Installing Okteto
 

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -21,7 +21,7 @@ In order to fully install Okteto, you'll need the following:
 
 ### Subdomain
 
-You'll need to have access to a internet accessible subdomain to which you can add a wildcard DNS record, such as dev.example.com.
+You'll need access to a subdomain to which you can add a wildcard DNS record, such as dev.example.com.
 
 This guide will assume that your domain is registered in [Civo](https://www.civo.com/account/dns). Other DNS services can be used, but aren't covered here.
 
@@ -69,9 +69,8 @@ You'll use the `Client ID` and `Client Secret` when installing Okteto.
 
 ### Getting your Okteto License
 
-Okteto is free for small teams.  You get all the features of [Okteto](/docs/self-hosted/) for up to 3 users with 3 namespaces each.
-
-Want to use Okteto with a bigger team? [Let's talk](https://okteto.com/#talktous)
+Okteto is free for up to 3 users without a license.
+You can also sign on for the [free trial](/free-trial/) to give access up to 100 users for a month.
 
 ## Installing Okteto
 

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -21,7 +21,7 @@ In order to fully install Okteto, you'll need the following:
 
 ### Subdomain
 
-You'll need to have access to a internet accessible subdomain to which you can add a wildcard DNS record, such as dev.example.com.
+You'll need access to a subdomain to which you can add a wildcard DNS record, such as dev.example.com.
 
 This guide will assume that your domain is registered in [DigitalOcean](https://cloud.digitalocean.com/networking/domains). Other DNS services can be used, but aren't covered here.
 
@@ -78,9 +78,8 @@ Create the space in the same region as your Kubernetes cluster and restrict file
 
 ### Getting your Okteto License
 
-Okteto is free for small teams. You get all the features of [Okteto](/free-trial/) for up to 3 users with 3 namespaces each.
-
-Want to use Okteto with a bigger team? [Let's talk](https://okteto.com/#talktous)
+Okteto is free for up to 3 users without a license.
+You can also sign on for the [free trial](/free-trial/) to give access up to 100 users for a month.
 
 ## Installing Okteto
 

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -21,7 +21,7 @@ In order to fully install Okteto, you'll need the following:
 
 ### Subdomain
 
-You'll need to have access to a internet accessible subdomain to which you can add a wildcard DNS record, such as dev.example.com.
+You'll need access to a subdomain to which you can add a wildcard DNS record, such as dev.example.com.
 
 This guide will assume that your domain is registered in [Amazon Route53](https://aws.amazon.com/route53/). Other DNS services can be used, but aren't covered here.
 
@@ -123,9 +123,8 @@ helm repo update
 
 ### Getting your Okteto License
 
-Okteto is free for small teams. You get all the features of [Okteto](/free-trial/) for up to 3 users with 3 namespaces each.
-
-Want to use Okteto with a bigger team? [Let's talk](https://okteto.com/#talktous)
+Okteto is free for up to 3 users without a license.
+You can also sign on for the [free trial](/free-trial/) to give access up to 100 users for a month.
 
 ## Installing Okteto
 

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -21,7 +21,7 @@ In order to fully install Okteto, you will need the following:
 
 ### Subdomain
 
-You will need access to an internet-accessible subdomain to which you can add a wildcard DNS record, such as dev.example.com. Let's Encrypt servers must be able to resolve the addresses in order to issue the required certificates.
+You'll need access to a subdomain to which you can add a wildcard DNS record, such as dev.example.com.
 
 This guide will assume that your domain is registered in Google's [Cloud DNS](https://cloud.google.com/dns). Other DNS services can be used as well, but are not covered by this guide.
 
@@ -92,9 +92,8 @@ helm repo update
 
 ### Getting your Okteto License
 
-Okteto is free for small teams. You get all the features of [Okteto](/free-trial/) for up to 3 users with 3 namespaces each.
-
-Want to use Okteto with a bigger team? [Let's talk](https://okteto.com/#talktous)
+Okteto is free for up to 3 users without a license.
+You can also sign on for the [free trial](/free-trial/) to give access up to 100 users for a month.
 
 ## Installing Okteto
 


### PR DESCRIPTION
This guide covers on-premise installations where s3-like services are not available and applications must be exposed behind an existing ingress controller, including Okteto