### PR TITLE
Document ingress.oktetoIngressClass

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -545,21 +545,21 @@ There is only one exception where this storage class is overwritten. In case of 
 Configure default values for the ingress created by Okteto.
 
 - `annotations`: The annotations to apply to all the ingresses created during the Okteto installation.
-- `class`: If set, Okteto will set this as the `ingress.class` of all ingresses managed by Okteto. This is useful if you have more than one ingress controller in your cluster.
+- `oktetoIngressClass`: The `ingressClassName` to apply to all the ingresses created during the Okteto installation (defaults to `nginx`).
+- `class`: If specified, Okteto will set this as the `ingressClassName` of all ingresses managed by Okteto. This is useful if you have more than one ingress controller in your cluster.
 - `forceIngressClass`: If enabled, all ingresses deployed in namespaces managed by Okteto will have the ingress class defined in  `ingress.class` (default: `false`).
 - `ip`: The internal IP of the ingress. Pods will call the Okteto API and the Okteto Registry using this IP. Required if the Okteto API/Registry is exposed using an ingress not managed by Okteto.
 - `tlsSecret`: TLS secret for the ingress created by Okteto. If empty, okteto defaults to the wildcard certificate created by Okteto.
 
 ```yaml
 ingress:
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  annotations: {}
+  oktetoIngressClass: nginx
   class: nginx
   forceIngressClass: false
   ip: ""
   tlsSecret: ""
 ```
-
 ### ingressLimits
 
 Configure ingress connections limits for each public endpoint. Disabled by default.

--- a/versioned_docs/version-0.15/enterprise/administration/configuration.mdx
+++ b/versioned_docs/version-0.15/enterprise/administration/configuration.mdx
@@ -53,7 +53,27 @@ Okteto supports using Bitbucket, GitHub, Google, or OpenID Connect as authentica
 
 > You can also use a [secret](/docs/enterprise/install/deployment/#cloud-provider-secret) to store the sensitive part of these credentials.
 
-- `bitbucket`: Use this group of settings when using Bitbucket OAauth as your authentication provider.
+#### Bitbucket
+
+Follow Bitbucket's official documentation on [how to create an OAuth Consumer](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/).
+
+When creating the OAuth Consumer, you will need to provide the following values:
+
+**Callback URL**:
+```
+https://okteto.DOMAIN/auth/callback
+```
+
+**URL**:
+```
+https://okteto.DOMAIN
+```
+
+**Permissions**:
+Account: Email
+Account: Read
+
+Use this group of settings when using Bitbucket OAauth as your authentication provider.
 
 ```yaml
 auth:
@@ -66,7 +86,23 @@ auth:
 
 The `workspace` field is optional. Only members of the workspace will be allowed to login into your Okteto instance. An empty `workspace` field permits any user to log in.
 
-- `github`: Use this group of settings when using GitHub OAuth as your authentication provider.
+#### GitHub
+
+Follow GitHub's official documentation on [how to create an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/).
+
+When creating the OAuth App, you will need to provide the following values:
+
+**Homepage URL**:
+```
+https://okteto.DOMAIN
+```
+
+**Authorization callback URL**:
+```
+https://okteto.DOMAIN/auth/callback
+```
+
+Use this group of settings when using GitHub OAuth as your authentication provider.
 
 ```yaml
 auth:
@@ -79,7 +115,24 @@ auth:
 
 The `organization` field is optional. Only members of the organization will be allowed to log in into your Okteto instance. An empty `organization` field permits any user to log in.
 
-- `google`: Use this group of settings when using Google OAuth as your authentication provider.
+#### Google
+
+Follow Google's official documentation on [how to create an OAuth 2.0 Client](https://support.google.com/cloud/answer/6158849?hl=en).
+
+When creating the OAUTH 2.0 Client, you will need to provide the following values:
+
+**Authorized javascript origin**:
+```
+https://okteto.DOMAIN
+```
+
+**Authorized redirect URIs**:
+```
+https://okteto.DOMAIN
+https://okteto.DOMAIN/auth/callback
+```
+
+Use this group of settings when using Google OAuth as your authentication provider.
 
 ```yaml
 auth:
@@ -89,7 +142,19 @@ auth:
     clientSecret: clientSecret
 ```
 
-- `openid`: Use this group of settings when using an OpenID Connect provider as your authentication provider.
+#### OpenID Connect
+
+Follow your OpenID Connect service provider's documentation on how to create the required application.
+
+When creating the application, you'll need to provide the following values:
+
+- Start SSO URL:  `https://okteto.DOMAIN`
+- Redirect URIs: `https://okteto.DOMAIN`, `https://okteto.DOMAIN/auth/callback`
+- Scopes: `openid`, `email`, `profile`
+- Response Type: `code`
+- Grant Type: `authorization code`
+
+Use this group of settings when using an OpenID Connect provider as your authentication provider.
 
 ```yaml
 auth:


### PR DESCRIPTION
In order to set the ingress class name of ingresses created by the okteto installation, the field`ingressClassName` must be set on each ingress. USing annotations is no longer supported