### PR TITLE
Redirect /enterprise to /self-hosted 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,11 @@
   from = "/"
   to = "/docs/welcome/overview/"
   status = 301
+
+[[redirects]]
+  from = "/docs/enterprise/*"
+  to = "/docs/self-hosted/:splat"
+  status = 301
   
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
For v1, we renamed our folders structure. Make sure we avoid broken links

### Test plan

These should redirect to `/self-hosted` instead of 404:

https://deploy-preview-205--okteto-docs.netlify.app/docs/enterprise/install/overview/
https://deploy-preview-205--okteto-docs.netlify.app/docs/enterprise/eks/#creating-an-iam