### PR TITLE
Document `cluster.endpoint` for GKE

### DIFF
--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -119,6 +119,7 @@ Download a copy of the [Okteto GKE configuration file](/docs/self-hosted/gke/con
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the OAuth 2.0 Client you created
+- Your cluster's API server endpoint
 - The name of the `bucket` you created
 - The `project` id of your cluster
 
@@ -134,6 +135,9 @@ auth:
     enabled: true
     clientId: clientid.apps.googleusercontent.com
     clientSecret: clientSecret
+
+cluster:
+  endpoint: https://35.205.100.149
 
 cloud:
   provider:

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -10,6 +10,9 @@ auth:
     clientId: 
     clientSecret: 
 
+cluster:
+  endpoint:
+
 cloud:
   provider:
     gcp:


### PR DESCRIPTION
Recently google changed how they store the cluster endpoint in the default namespace to point to the internal cluster IP. This breaks our logic to infer the cluster public endpoint.

We have to document how to configure this value as we do for other providers