### PR TITLE
Add a note about how to use "okteto build" without an okteto manifest

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -67,8 +67,6 @@ Build and push the images defined in the `build` section of your okteto manifest
 $ okteto build [service...]
 ```
 
->  You can also use the `-f` to point to a Dockerfile. In this mode, `okteto build` will ignore your Okteto manifest, and directly build the image defined in the Dockerfile. Use this to build images that are not defined on your [Okteto manifest](https://www.okteto.com/docs/reference/manifest/). 
-
 If your [okteto context](/docs/reference/cli/#context) points to an Okteto URL, images are built using the [Okteto Build Service](/docs/cloud/build/).
 Otherwise, images are built using your local Docker daemon. If you want to use another BuildKit instance, set the variable `BUILDKIT_HOST` to point to its address, using the format `HOST:PORT`. 
 
@@ -81,6 +79,8 @@ The following flags can be used (very similar to `docker build`):
 | _--secret_       |  (list)  | Secret files exposed to the build. Format: `id=mysecret,src=/local/secret` |
 | _--export-cache_ | (string) | Image tag for exported cache when build (optional)                         |
 | _--cache-from_   |  (list)  | List of cache source images (optional)                                     |
+
+>  You can also use the `-f` to point to a Dockerfile. In this mode, `okteto build` will ignore your Okteto manifest, and directly build the image defined in the Dockerfile. Use this to build images that are not defined on your [Okteto manifest](https://www.okteto.com/docs/reference/manifest/).
 
 ### context
 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -67,7 +67,7 @@ Build and push the images defined in the `build` section of your okteto manifest
 $ okteto build [service...]
 ```
 
-> You can use the `-f` flag to refer to a Dockerfile. In this mode, `okteto build` works without having an okteto manifest, in a similar way to `docker build`.
+> You can use the `-f` flag to refer to a Dockerfile. In this mode, `okteto build` works without having an [Okteto manifest](https://www.okteto.com/docs/reference/manifest/), in a similar way to `docker build`.
 
 If your [okteto context](/docs/reference/cli/#context) points to an Okteto URL, images are built using the [Okteto Build Service](/docs/cloud/build/).
 Otherwise, images are built using your local Docker daemon. If you want to use another BuildKit instance, set the variable `BUILDKIT_HOST` to point to its address, using the format `HOST:PORT`. 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -67,7 +67,7 @@ Build and push the images defined in the `build` section of your okteto manifest
 $ okteto build [service...]
 ```
 
-> You can use the `-f` flag to refer to a Dockerfile. In this mode, `okteto build` works without having an [Okteto manifest](https://www.okteto.com/docs/reference/manifest/), in a similar way to `docker build`.
+>  You can also use the `-f` to point to a Dockerfile. In this mode, `okteto build` will ignore your Okteto manifest, and directly build the image defined in the Dockerfile. Use this to build images that are not defined on your [Okteto manifest](https://www.okteto.com/docs/reference/manifest/). 
 
 If your [okteto context](/docs/reference/cli/#context) points to an Okteto URL, images are built using the [Okteto Build Service](/docs/cloud/build/).
 Otherwise, images are built using your local Docker daemon. If you want to use another BuildKit instance, set the variable `BUILDKIT_HOST` to point to its address, using the format `HOST:PORT`. 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -67,6 +67,8 @@ Build and push the images defined in the `build` section of your okteto manifest
 $ okteto build [service...]
 ```
 
+> You can use the `-f` flag to refer to a Dockerfile. In this mode, `okteto build` works without having an okteto manifest, in a similar way to `docker build`.
+
 If your [okteto context](/docs/reference/cli/#context) points to an Okteto URL, images are built using the [Okteto Build Service](/docs/cloud/build/).
 Otherwise, images are built using your local Docker daemon. If you want to use another BuildKit instance, set the variable `BUILDKIT_HOST` to point to its address, using the format `HOST:PORT`. 
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

`okteto build` can be used without an okteto manifest. This is useful when you want to build dynamic images not defined in your okteto manifest.