### PR TITLE
Use full URL instead of relative URL for config files

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -102,7 +102,7 @@ Create a Kubernetes secret with the Storage Account Access Key you created befor
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
-Download a copy of the [Okteto AKS configuration file](/docs/self-hosted/aks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -84,7 +84,7 @@ $ kubectl create namespace okteto
 
 ### Configuring your Okteto instance
 
-Download a copy of the [Okteto Civo configuration file](/docs/self-hosted/civo/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -144,7 +144,7 @@ Create a Kubernetes secret with the IAM User's Access secret key you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=IAM_ACCESS_SECRET
 ```
 
-Download a copy of the [Okteto EKS configuration file](/docs/self-hosted/eks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -113,7 +113,7 @@ Create a Kubernetes secret with the `Service Account` key you created before:
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-file=key=$PATH_TO_KEY_FILE
 ```
 
-Download a copy of the [Okteto GKE configuration file](/docs/self-hosted/gke/config.yaml), open it, and set the following values:
+Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-0.11/enterprise/aks.mdx
+++ b/versioned_docs/version-0.11/enterprise/aks.mdx
@@ -119,7 +119,7 @@ Create a Kubernetes secret with the Service Principal's Password you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY --from-literal=token=SERVICE_PRINCIPAL_PASSWORD
 ```
 
-Download a copy of the [Okteto Enterprise AKS configuration file](/docs/self-hosted/aks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Enterprise AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.11/enterprise/civo.mdx
+++ b/versioned_docs/version-0.11/enterprise/civo.mdx
@@ -103,7 +103,7 @@ Create a Kubernetes secret with the Civo API key:
 $ kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=$API_KEY
 ```
 
-Download a copy of the [Okteto Enterprise Civo configuration file](/docs/self-hosted/civo/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Enterprise Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-0.11/enterprise/eks.mdx
+++ b/versioned_docs/version-0.11/enterprise/eks.mdx
@@ -161,7 +161,7 @@ Create a Kubernetes secret with the IAM User's Access secret key you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=IAM_ACCESS_SECRET
 ```
 
-Download a copy of the [Okteto Enterprise EKS configuration file](/docs/self-hosted/eks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Enterprise EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.11/enterprise/gke.mdx
+++ b/versioned_docs/version-0.11/enterprise/gke.mdx
@@ -117,7 +117,7 @@ Create a Kubernetes secret with the `Service Account` key you created before:
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-file=key=$PATH_TO_KEY_FILE
 ```
 
-Download a copy of the [Okteto Enterprise GKE configuration file](/docs/self-hosted/gke/config.yaml), open it, and set the following values:
+Download a copy of the [Okteto Enterprise GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.12/enterprise/aks.mdx
+++ b/versioned_docs/version-0.12/enterprise/aks.mdx
@@ -119,7 +119,7 @@ Create a Kubernetes secret with the Service Principal's Password you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY --from-literal=token=SERVICE_PRINCIPAL_PASSWORD
 ```
 
-Download a copy of the [Okteto Enterprise AKS configuration file](/docs/self-hosted/aks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Enterprise AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.12/enterprise/civo.mdx
+++ b/versioned_docs/version-0.12/enterprise/civo.mdx
@@ -103,7 +103,7 @@ Create a Kubernetes secret with the Civo API key:
 $ kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=$API_KEY
 ```
 
-Download a copy of the [Okteto Enterprise Civo configuration file](/docs/self-hosted/civo/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Enterprise Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-0.12/enterprise/eks.mdx
+++ b/versioned_docs/version-0.12/enterprise/eks.mdx
@@ -161,7 +161,7 @@ Create a Kubernetes secret with the IAM User's Access secret key you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=IAM_ACCESS_SECRET
 ```
 
-Download a copy of the [Okteto Enterprise EKS configuration file](/docs/self-hosted/eks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Enterprise EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.12/enterprise/gke.mdx
+++ b/versioned_docs/version-0.12/enterprise/gke.mdx
@@ -117,7 +117,7 @@ Create a Kubernetes secret with the `Service Account` key you created before:
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-file=key=$PATH_TO_KEY_FILE
 ```
 
-Download a copy of the [Okteto Enterprise GKE configuration file](/docs/self-hosted/gke/config.yaml), open it, and set the following values:
+Download a copy of the [Okteto Enterprise GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.13/enterprise/aks.mdx
+++ b/versioned_docs/version-0.13/enterprise/aks.mdx
@@ -119,7 +119,7 @@ Create a Kubernetes secret with the Service Principal's Password you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY --from-literal=token=SERVICE_PRINCIPAL_PASSWORD
 ```
 
-Download a copy of the [Okteto AKS configuration file](/docs/self-hosted/aks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.13/enterprise/civo.mdx
+++ b/versioned_docs/version-0.13/enterprise/civo.mdx
@@ -103,7 +103,7 @@ Create a Kubernetes secret with the Civo API key:
 $ kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=$API_KEY
 ```
 
-Download a copy of the [Okteto Civo configuration file](/docs/self-hosted/civo/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-0.13/enterprise/eks.mdx
+++ b/versioned_docs/version-0.13/enterprise/eks.mdx
@@ -163,7 +163,7 @@ Create a Kubernetes secret with the IAM User's Access secret key you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=IAM_ACCESS_SECRET
 ```
 
-Download a copy of the [Okteto EKS configuration file](/docs/self-hosted/eks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.13/enterprise/gke.mdx
+++ b/versioned_docs/version-0.13/enterprise/gke.mdx
@@ -117,7 +117,7 @@ Create a Kubernetes secret with the `Service Account` key you created before:
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-file=key=$PATH_TO_KEY_FILE
 ```
 
-Download a copy of the [Okteto GKE configuration file](/docs/self-hosted/gke/config.yaml), open it, and set the following values:
+Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.14/enterprise/aks.mdx
+++ b/versioned_docs/version-0.14/enterprise/aks.mdx
@@ -119,7 +119,7 @@ Create a Kubernetes secret with the Service Principal's Password you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY --from-literal=token=SERVICE_PRINCIPAL_PASSWORD
 ```
 
-Download a copy of the [Okteto AKS configuration file](/docs/self-hosted/aks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.14/enterprise/civo.mdx
+++ b/versioned_docs/version-0.14/enterprise/civo.mdx
@@ -103,7 +103,7 @@ Create a Kubernetes secret with the Civo API key:
 $ kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=$API_KEY
 ```
 
-Download a copy of the [Okteto Civo configuration file](/docs/self-hosted/civo/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-0.14/enterprise/eks.mdx
+++ b/versioned_docs/version-0.14/enterprise/eks.mdx
@@ -163,7 +163,7 @@ Create a Kubernetes secret with the IAM User's Access secret key you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=IAM_ACCESS_SECRET
 ```
 
-Download a copy of the [Okteto EKS configuration file](/docs/self-hosted/eks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-0.14/enterprise/gke.mdx
+++ b/versioned_docs/version-0.14/enterprise/gke.mdx
@@ -117,7 +117,7 @@ Create a Kubernetes secret with the `Service Account` key you created before:
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-file=key=$PATH_TO_KEY_FILE
 ```
 
-Download a copy of the [Okteto GKE configuration file](/docs/self-hosted/gke/config.yaml), open it, and set the following values:
+Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
 - Your `email`
 - Your `license` (optional)
 - A `subdomain`

--- a/versioned_docs/version-1.0/self-hosted/aks.mdx
+++ b/versioned_docs/version-1.0/self-hosted/aks.mdx
@@ -103,7 +103,7 @@ Create a Kubernetes secret with the Storage Account Access Key you created befor
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
-Download a copy of the [Okteto AKS configuration file](/docs/self-hosted/aks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-1.0/self-hosted/civo.mdx
+++ b/versioned_docs/version-1.0/self-hosted/civo.mdx
@@ -85,7 +85,7 @@ $ kubectl create namespace okteto
 
 ### Configuring your Okteto instance
 
-Download a copy of the [Okteto Civo configuration file](/docs/self-hosted/civo/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-1.0/self-hosted/eks.mdx
+++ b/versioned_docs/version-1.0/self-hosted/eks.mdx
@@ -145,7 +145,7 @@ Create a Kubernetes secret with the IAM User's Access secret key you created bef
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-literal=key=IAM_ACCESS_SECRET
 ```
 
-Download a copy of the [Okteto EKS configuration file](/docs/self-hosted/eks/config.yaml), open it, and update the following values:
+Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
 
 - Your `email`
 - Your `license` (optional)

--- a/versioned_docs/version-1.0/self-hosted/gke.mdx
+++ b/versioned_docs/version-1.0/self-hosted/gke.mdx
@@ -114,7 +114,7 @@ Create a Kubernetes secret with the `Service Account` key you created before:
 kubectl create secret generic okteto-cloud-secret --namespace=okteto --from-file=key=$PATH_TO_KEY_FILE
 ```
 
-Download a copy of the [Okteto GKE configuration file](/docs/self-hosted/gke/config.yaml), open it, and set the following values:
+Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
 
 - Your `email`
 - Your `license` (optional)


### PR DESCRIPTION
Docusaurus adds a trailing slash by default to all links for better SEO with the [trailingSlash config](https://docusaurus.io/docs/api/docusaurus-config#trailingSlash).

Problem: It also adds a trailing slash to links that shouldn’t have them like `.yaml` files.

Solution: Use full URLs instead of relative URLs to avoid Docusaurus transformation.