### PR TITLE
Add explanation about using ":" or "@" for componing the OKTETO_BUILD…

### DIFF
--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -76,6 +76,11 @@ In order to refer to images in the `build` section of the Okteto Manifest, you c
 - `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)
 - `${OKTETO_BUILD_<service>_IMAGE}`: the full image reference (using its SHA)
 
+`${OKTETO_BUILD_<service>_IMAGE}` is equivalent to any of the following:
+- `${OKTETO_BUILD_<service>_REGISTRY}`/`${OKTETO_BUILD_<service>_REPOSITORY}`@`${OKTETO_BUILD_<service>_TAG}`
+- `${OKTETO_BUILD_<service>_REGISTRY}`/`${OKTETO_BUILD_<service>_REPOSITORY}`:okteto@`${OKTETO_BUILD_<service>_TAG}`
+
+
 ### Built-in Tools When Deploying To Okteto Cloud
 
 When launching a development environment [from a Git Repository](/docs/cloud/deploy-from-git/), Okteto will run an installation job that clones the Git repository, checks out the selected branch, builds the images defined in the `build` section of your Okteto Manifest, and executes the sequence of `deploy` commands. The job will fail if any of the commands in the `deploy` list fails.

--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -63,12 +63,16 @@ Each image supports the following fields:
 
 In order to refer to these images from anywhere in your [Okteto Manifest](/docs/cloud/okteto-cli/#okteto-manifest), you can use the following environment variables:
 
+You can build all these images by running `okteto build`, or `okteto build xxx` to build a single one.
+
 - `${OKTETO_BUILD_<service>_IMAGE}`: the full image reference (using its SHA)
 - `${OKTETO_BUILD_<service>_REGISTRY}`: the registry URL where the image was pushed
 - `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)
 - `${OKTETO_BUILD_<service>_TAG}`: SHA for the last image build at the registry
 
-You can build all these images by running `okteto build`, or `okteto build xxx` to build a single one.
+`${OKTETO_BUILD_<service>_IMAGE}` is equivalent to any of the following:
+- `${OKTETO_BUILD_<service>_REGISTRY}`/`${OKTETO_BUILD_<service>_REPOSITORY}`@`${OKTETO_BUILD_<service>_TAG}`
+- `${OKTETO_BUILD_<service>_REGISTRY}`/`${OKTETO_BUILD_<service>_REPOSITORY}`:okteto@`${OKTETO_BUILD_<service>_TAG}`
 
 > if a `<service>` name includes the symbol `-`, in the corresponding `OKTETO_BUILD_<service>` environment variables, the symbol `-` will be replaced by `_`.  For example, if `<service>` is `name-with-hyphen`, the environment variable names will start with `$OKTETO_BUILD_NAME_WITH_HYPHEN_`.
 


### PR DESCRIPTION
…_XXX envvars

Many helm charts have different fields to define the registry, repo and tag of a given deployment. This is way we have the following ennvars:

- `${OKTETO_BUILD_<service>_TAG}`: SHA for the last image build at the registry
- `${OKTETO_BUILD_<service>_REGISTRY}`: the registry URL where the image was pushed
- `${OKTETO_BUILD_<service>_REPOSITORY}`: the name of the image that was pushed (`namespace/_<service>`)

It's common in helm that the image of the deployment is specified like this:

```
image: {{ .Values.registry}}/{{.Values.repository}}:{{.Values.tag}}
```
but this will fail because after `:` you need to specify the tag name, not the tag sha. In order to specify the sha you need to use `@` instead of `:`. In order to fix this, you can set `.Values.tag` to `okteto@${OKTETO_BUILD_<service>_TAG}`.
