### PR TITLE
A general pass to the volume snapshots feature

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -42,6 +42,7 @@ module.exports = {
       },
       "cloud/build",
       "cloud/registry",
+      "cloud/volume-snapshots",
       "cloud/namespaces",
       "cloud/credentials",
       "cloud/personal-access-tokens",
@@ -105,7 +106,7 @@ module.exports = {
           "self-hosted/administration/custom-installer-image",
           "self-hosted/administration/configuration",
           "self-hosted/administration/github",
-          "self-hosted/administration/volume-snapshots"
+          "self-hosted/administration/enable-volume-snapshots"
         ]
       }
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -42,7 +42,7 @@ module.exports = {
       },
       "cloud/build",
       "cloud/registry",
-      "cloud/volume-snapshots",
+      "cloud/use-volume-snapshots",
       "cloud/namespaces",
       "cloud/credentials",
       "cloud/personal-access-tokens",
@@ -106,7 +106,7 @@ module.exports = {
           "self-hosted/administration/custom-installer-image",
           "self-hosted/administration/configuration",
           "self-hosted/administration/github",
-          "self-hosted/administration/enable-volume-snapshots"
+          "self-hosted/administration/volume-snapshots"
         ]
       }
     ],

--- a/src/content/cloud/volume-snapshots.mdx
+++ b/src/content/cloud/volume-snapshots.mdx
@@ -35,7 +35,7 @@ If your instance is hosted by Okteto, Volume Snapshots are enabled by default.
 
 ### Creating a Volume Snapshot
 
-Okteto allows developers to initialize persistent volume claims with the contents of any preexisting volume snapshot.
+Okteto enables developers to initialize persistent volume claims with the contents of a pre-existing volume snapshot.
 The volume snapshot is created from a persistent volume claim and it can contain database backups, big files, images, a copy of your staging data, etc.
 
 The source persistent volume claim must have a storage class that supports volume snapshots. For Okteto SaaS users that means `csi-okteto-standard` or `csi-okteto-ssd`:

--- a/src/content/cloud/volume-snapshots.mdx
+++ b/src/content/cloud/volume-snapshots.mdx
@@ -38,6 +38,51 @@ If your instance is hosted by Okteto, Volume Snapshots are enabled by default.
 Okteto allows developers to initialize persistent volume claims with the contents of any preexisting volume snapshot.
 The volume snapshot is created from a persistent volume claim and it can contain database backups, big files, images, a copy of your staging data, etc.
 
+The source persistent volume claim must have a storage class that supports volume snapshots. For Okteto SaaS users that means `csi-okteto-standard` or `csi-okteto-ssd`:
+
+<Tabs
+  defaultValue="kubernetes"
+  values={[
+    { label: 'Kubernetes', value: 'kubernetes', },
+    { label: 'Compose', value: 'compose', },
+  ]}
+>
+<TabItem value="kubernetes">
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc
+spec:
+  storageClassName: csi-okteto-standard
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+</TabItem>
+<TabItem value="compose">
+
+```yaml
+services:
+  mysql:
+    image: mysql
+    volumes:
+      - mysql-pvc:/var/lib/mysql
+
+volumes:
+  mysql-pvc:
+    driver_opts:
+      class: csi-okteto-standard
+```
+
+</TabItem>
+</Tabs>
+
+
 The following manifest creates a volume snapshot from the `mysql-pvc` persistent volume claim:
 
 ```yaml
@@ -86,13 +131,13 @@ spec:
 ```yaml
 services:
   mongodb:
-    image: mongodb
+    image: mysql
     volumes:
-      - data:/mongodb
+      - data:/var/lib/mysql
 
 volumes:
   data:
-    annotations:
+    labels:
       dev.okteto.com/from-snapshot-name: mysql-snapshot
       dev.okteto.com/from-snapshot-namespace: staging
 ```

--- a/src/content/cloud/volume-snapshots.mdx
+++ b/src/content/cloud/volume-snapshots.mdx
@@ -1,0 +1,105 @@
+---
+title: Volume Snapshots
+description: Use volume snapshots in your development environments
+sidebar_label: Volume Snapshots
+id: volume-snapshots
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Volume snapshots allows you to initialize persistent volume claims with the contents of a preexisting volume snapshot.
+Use volume snapshots when working with large datasets or if you want to create development environments with real data coming from your production or staging environments.
+
+## Requirements
+
+<Tabs
+  defaultValue="self-hosted"
+  values={[
+    { label: 'Self-Hosted', value: 'self-hosted', },
+    { label: 'SaaS', value: 'saas', },
+  ]}
+>
+<TabItem value="self-hosted">
+
+Follow [this guide](/docs/self-hosted/administration/volume-snapshots/) to enable Volume Snapshots in your cluster.
+
+</TabItem>
+
+<TabItem value="saas">
+If your instance is hosted by Okteto, Volume Snapshots are enabled by default.
+</TabItem>
+</Tabs>
+
+## Using Volume Snapshots in your Development Environment
+
+### Creating a Volume Snapshot
+
+Okteto allows developers to initialize persistent volume claims with the contents of any preexisting volume snapshot.
+The volume snapshot is created from a persistent volume claim and it can contain database backups, big files, images, a copy of your staging data, etc.
+
+The following manifest creates a volume snapshot from the `mysql-pvc` persistent volume claim:
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: mysql-snapshot
+spec:
+  volumeSnapshotClassName: okteto-snapshot-class
+  source:
+    persistentVolumeClaimName: mysql-pvc
+```
+
+### Consuming a Volume Snapshot created in Kubernetes
+
+Use the `dev.okteto.com/from-snapshot-name` and `dev.okteto.com/from-snapshot-namespace` annotations on any persistent volume claim to tell Okteto to initialize your persistent volume claim from an existing volume snapshot, as shown below:
+
+<Tabs
+  defaultValue="kubernetes"
+  values={[
+    { label: 'Kubernetes', value: 'kubernetes', },
+    { label: 'Compose', value: 'compose', },
+  ]}
+>
+<TabItem value="kubernetes">
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    dev.okteto.com/from-snapshot-name: mysql-snapshot
+    dev.okteto.com/from-snapshot-namespace: staging
+  name: pvc-from-snapshot
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+</TabItem>
+<TabItem value="compose">
+
+```yaml
+services:
+  mongodb:
+    image: mongodb
+    volumes:
+      - data:/mongodb
+
+volumes:
+  data:
+    annotations:
+      dev.okteto.com/from-snapshot-name: mysql-snapshot
+      dev.okteto.com/from-snapshot-namespace: staging
+```
+
+</TabItem>
+</Tabs>
+
+If the annotation `dev.okteto.com/from-snapshot-namespace` is not defined, Okteto will default to the namespace of the new persistent volume claim.
+
+Use the annotation `dev.okteto.com/skip-snapshot-if-same-namespace: "true"` to skip the data cloning operation if the source snapshot and the new persistent volume claim are in the same namespace.

--- a/src/content/cloud/volume-snapshots.mdx
+++ b/src/content/cloud/volume-snapshots.mdx
@@ -31,7 +31,7 @@ Use a storage class provisioned by a CSI driver that [supports volume snapshots]
 <TabItem value="saas">
 If your instance is hosted by Okteto, Volume Snapshots are enabled by default.
 
-Use one of the following storage classes for the source of your volume snapshots:
+Use one of the following storage classes for the source persistent volume of your volume snapshots:
 
 - `csi-okteto-standard`: backed by standard hard disk drives (HDD)
 - `csi-okteto-ssd`: backed by solid-state drives (SDD)

--- a/src/content/cloud/volume-snapshots.mdx
+++ b/src/content/cloud/volume-snapshots.mdx
@@ -2,7 +2,7 @@
 title: Volume Snapshots
 description: Use volume snapshots in your development environments
 sidebar_label: Volume Snapshots
-id: volume-snapshots
+id: use-volume-snapshots
 ---
 
 import Tabs from '@theme/Tabs';
@@ -24,21 +24,38 @@ Use volume snapshots when working with large datasets or if you want to create d
 
 Follow [this guide](/docs/self-hosted/administration/volume-snapshots/) to enable Volume Snapshots in your cluster.
 
+Use a storage class provisioned by a CSI driver that [supports volume snapshots](https://kubernetes-csi.github.io/docs/snapshot-restore-feature.html) for the source persistent volumes of your volume snapshots.
+
 </TabItem>
 
 <TabItem value="saas">
 If your instance is hosted by Okteto, Volume Snapshots are enabled by default.
+
+Use one of the following storage class for the source persistent volumes of your volume snapshots:
+
+- `csi-okteto-standard`: backed by standard hard disk drives (HDD)
+- `csi-okteto-ssd`: backed by solid-state drives (SDD)
+
 </TabItem>
 </Tabs>
 
 ## Using Volume Snapshots in your Development Environment
 
-### Creating a Volume Snapshot
-
 Okteto enables developers to initialize persistent volume claims with the contents of a pre-existing volume snapshot.
 The volume snapshot is created from a persistent volume claim and it can contain database backups, big files, images, a copy of your staging data, etc.
 
-The source persistent volume claim must have a storage class that supports volume snapshots. For Okteto SaaS users that means `csi-okteto-standard` or `csi-okteto-ssd`:
+The steps to clone the data of an existing persistent volume into your develepment environment are:
+
+- [Create the source persistent volume with the right storage class](/docs/cloud/use-volume-snapshots/#creating-the-persistent-volume)
+- [Create a volume snapshot of the source persistent volume](/docs/cloud/use-volume-snapshots/#creating-a-volume-snapshot)
+- [Consume the volume snapshot in a new persistent volume](/docs/cloud/use-volume-snapshots/#consuming-a-volume-snapshot)
+
+### Creating the Persistent Volume
+
+If the default storage class of your cluster doesn't support volume snapshots, make sure to pick the right storage class when creating your persistent volume.
+Check the [requirements](/docs/cloud/use-volume-snapshots/#requirements) section to know more about available storage classes in Okteto.
+
+This is a sample using Kubernetes manifests or Docker Compose files:
 
 <Tabs
   defaultValue="kubernetes"
@@ -83,6 +100,12 @@ volumes:
 </Tabs>
 
 
+### Creating a Volume Snapshot
+
+Volume snapshots are created with the content of the persistent volume at time of creating the volume snapshot. Further updates on the persistent volume aren't reflected in the volume snapshot content.
+
+This step is independent of whether you created your persistent volume with Kubernetes manifests or a Docker Compose file:
+
 The following manifest creates a volume snapshot from the `mysql-pvc` persistent volume claim:
 
 ```yaml
@@ -96,7 +119,7 @@ spec:
     persistentVolumeClaimName: mysql-pvc
 ```
 
-### Consuming a Volume Snapshot created in Kubernetes
+### Consuming a Volume Snapshot
 
 Use the `dev.okteto.com/from-snapshot-name` and `dev.okteto.com/from-snapshot-namespace` annotations on any persistent volume claim to tell Okteto to initialize your persistent volume claim from an existing volume snapshot, as shown below:
 
@@ -148,3 +171,8 @@ volumes:
 If the annotation `dev.okteto.com/from-snapshot-namespace` is not defined, Okteto will default to the namespace of the new persistent volume claim.
 
 Use the annotation `dev.okteto.com/skip-snapshot-if-same-namespace: "true"` to skip the data cloning operation if the source snapshot and the new persistent volume claim are in the same namespace.
+
+For a full end to end sample, check the following resources:
+
+- [How to Create a Development Environment with Realistic Data in Okteto Cloud](https://www.okteto.com/blog/how-to-create-and-use-data-clones-in-okteto-cloud/) blog post
+- [How to Create and Use Data Clones in Okteto](https://www.okteto.com/blog/how-to-create-and-use-data-clones-in-okteto-video/) video tutorial

--- a/src/content/cloud/volume-snapshots.mdx
+++ b/src/content/cloud/volume-snapshots.mdx
@@ -24,14 +24,14 @@ Use volume snapshots when working with large datasets or if you want to create d
 
 Follow [this guide](/docs/self-hosted/administration/volume-snapshots/) to enable Volume Snapshots in your cluster.
 
-Use a storage class provisioned by a CSI driver that [supports volume snapshots](https://kubernetes-csi.github.io/docs/snapshot-restore-feature.html) for the source persistent volumes of your volume snapshots.
+Use a storage class provisioned by a CSI driver that [supports volume snapshots](https://kubernetes-csi.github.io/docs/snapshot-restore-feature.html) for the source persistent volume of your volume snapshots. 
 
 </TabItem>
 
 <TabItem value="saas">
 If your instance is hosted by Okteto, Volume Snapshots are enabled by default.
 
-Use one of the following storage class for the source persistent volumes of your volume snapshots:
+Use one of the following storage classes for the source of your volume snapshots:
 
 - `csi-okteto-standard`: backed by standard hard disk drives (HDD)
 - `csi-okteto-ssd`: backed by solid-state drives (SDD)
@@ -44,18 +44,17 @@ Use one of the following storage class for the source persistent volumes of your
 Okteto enables developers to initialize persistent volume claims with the contents of a pre-existing volume snapshot.
 The volume snapshot is created from a persistent volume claim and it can contain database backups, big files, images, a copy of your staging data, etc.
 
-The steps to clone the data of an existing persistent volume into your develepment environment are:
+In order to use volume snapshots with your development environment you need to:
 
-- [Create the source persistent volume with the right storage class](/docs/cloud/use-volume-snapshots/#creating-the-persistent-volume)
+- [Create the source persistent volume](/docs/cloud/use-volume-snapshots/#creating-the-persistent-volume)
 - [Create a volume snapshot of the source persistent volume](/docs/cloud/use-volume-snapshots/#creating-a-volume-snapshot)
 - [Consume the volume snapshot in a new persistent volume](/docs/cloud/use-volume-snapshots/#consuming-a-volume-snapshot)
 
-### Creating the Persistent Volume
+### Creating the Source Persistent Volume
+First, create the source persistent volume. This is the data that you want to be able to clone into your development environment.  In the example below we use a database, but this could be anything that uses a volume for storage: databases, ML models, images, etc...
+> If the default storage class of your cluster doesn't support volume snapshots, make sure you set the storage class to one that is compatible when creating your persistent volume.
+Check the [requirements](/docs/cloud/use-volume-snapshots/#requirements) section to learn more about the available storage classes in Okteto.
 
-If the default storage class of your cluster doesn't support volume snapshots, make sure to pick the right storage class when creating your persistent volume.
-Check the [requirements](/docs/cloud/use-volume-snapshots/#requirements) section to know more about available storage classes in Okteto.
-
-This is a sample using Kubernetes manifests or Docker Compose files:
 
 <Tabs
   defaultValue="kubernetes"
@@ -102,7 +101,7 @@ volumes:
 
 ### Creating a Volume Snapshot
 
-Volume snapshots are created with the content of the persistent volume at time of creating the volume snapshot. Further updates on the persistent volume aren't reflected in the volume snapshot content.
+After creating the source persistent volume, the next step is to create the Volume Snapshot. Volume snapshots are created with the content of the persistent volume at the time of creating the volume snapshot. Further updates on the persistent volume aren't reflected in the volume snapshot content.
 
 This step is independent of whether you created your persistent volume with Kubernetes manifests or a Docker Compose file:
 
@@ -120,7 +119,7 @@ spec:
 ```
 
 ### Consuming a Volume Snapshot
-
+Finally, you can use the volume snapshot created in the previous step to populate a new persistent volume. 
 Use the `dev.okteto.com/from-snapshot-name` and `dev.okteto.com/from-snapshot-namespace` annotations on any persistent volume claim to tell Okteto to initialize your persistent volume claim from an existing volume snapshot, as shown below:
 
 <Tabs

--- a/src/content/self-hosted/administration/volume-snapshots.mdx
+++ b/src/content/self-hosted/administration/volume-snapshots.mdx
@@ -2,7 +2,7 @@
 title: Volume Snapshots
 description: Enable volume snapshots in Okteto
 sidebar_label: Volume Snapshots
-id: enable-volume-snapshots
+id: volume-snapshots
 ---
 
 import Tabs from '@theme/Tabs';

--- a/src/content/self-hosted/administration/volume-snapshots.mdx
+++ b/src/content/self-hosted/administration/volume-snapshots.mdx
@@ -1,15 +1,15 @@
 ---
 title: Volume Snapshots
-description: Use volume snapshots in your development environments
+description: Enable volume snapshots in Okteto
 sidebar_label: Volume Snapshots
-id: volume-snapshots
+id: enable-volume-snapshots
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Use volume snapshots to enable your users to initialize persistent volume claims with the contents of a preexisting storage snapshot. Use volume snapshots when working with large datasets or if you want to create development environments with real data coming from your production or staging environments.
-
+Volume snapshots allows you to initialize persistent volume claims with the contents of a preexisting volume snapshot.
+Use volume snapshots when working with large datasets or if you want to create development environments with real data coming from your production or staging environments.
 ## Requirements
 
 To use the Volume Snapshots feature, you must install a CSI driver that supports snapshots and create the corresponding `VolumeSnapshotClass`.
@@ -199,47 +199,6 @@ volumeSnapshots:
 
 </TabItem>
 </Tabs>
-
-## Using Volume Snapshots in your Development Environment
-
-### Creating a Volume Snapshot
-
-Volume Snapshots allow developers to initialize persistent volume claims with the contents of any preexisting storage snapshot. The snapshot can contain database backups, big files, images, a copy of your staging data, etc.
-
-```yaml
-apiVersion: snapshot.storage.k8s.io/v1beta1
-kind: VolumeSnapshot
-metadata:
-  name: mysql-snapshot
-spec:
-  volumeSnapshotClassName: okteto-snapshot-class
-  source:
-    persistentVolumeClaimName: mysql-snapshot
-```
-
-### Consuming a Volume Snapshot created in Kubernetes
-
-Use the `dev.okteto.com/from-snapshot-name` and `dev.okteto.com/from-snapshot-namespace` annotations on any persistent volume claim to tell Okteto to initialize your persistent volume claim from a VolumeSnapshot Kubernetes object, as shown below:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  annotations:
-    dev.okteto.com/from-snapshot-name: mysql-snapshot
-    dev.okteto.com/from-snapshot-namespace: staging
-  name: pvc-from-snapshot
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
-```
-
-If the annotation `dev.okteto.com/from-snapshot-namespace` is not defined, Okteto will default to the namespace of the new persistent volume claim.
-
-Use the annotation `dev.okteto.com/skip-snapshot-if-same-namespace: "true"` to skip the data cloning operation if the source snapshot and the new PVC are in the same namespace.
 
 By default, all users in your cluster will be able to use any of the available snapshots as a data source for their development environments. You can limit this via the `enableNamespaceAccessValidation` key in the `volumeSnapshots` section of the configuration, value of `true` will enable the validation.
 


### PR DESCRIPTION
After helping a few users to configure volume snapshots, I have done several changes to the docs to make this feature more discoverable.

- Add a section under `Development Environments` explaining how to use this feature from a developer's point of view. This feature is available in Cloud and SaaS by default.
- Add a sample for Compose.
- Keep the doc under `Self-Hosted/Configuration` just with the configuration steps to enable this feature in Self-Hosted.