### PR TITLE
docs: add documentation about update policy annotation

### DIFF
--- a/src/content/reference/docker-compose.mdx
+++ b/src/content/reference/docker-compose.mdx
@@ -563,3 +563,34 @@ endpoints:
       service: backend
       port: 8080
 ```
+
+### update (annotation, optional)
+
+You can set the update policy of a service by setting the annotation `dev.okteto.com/update`. 
+
+Depending on the kind of resource the acceptance values are different:
+- rolling: Will deploy a service with 0 downtime. Allowed on deployments and statefulsets.
+- recreate: Will wait until the current pod is deleted to start creating the new one. Allowed on deployments
+- on-delete: Will wait until the current pod is deleted to start creating the new one. Allowed on statefulset
+
+```yaml
+services:
+  deployment:
+    image: python:alpine
+    labels:
+      "dev.okteto.com/update": rolling
+    entrypoint: python -m http.server 8080
+    ports:
+      - 8080:8080
+  sfs:
+    image: python:alpine
+    labels:
+      "dev.okteto.com/update": on-delete
+    entrypoint: python -m http.server 8080
+    ports:
+      - 8080:8080
+    volumes:
+    - /usr/src
+```
+
+> Remember that if you are on a docker-compose file the labels are translated into kubernetes annotations.

--- a/src/content/reference/docker-compose.mdx
+++ b/src/content/reference/docker-compose.mdx
@@ -569,9 +569,9 @@ endpoints:
 You can set the update policy of a service by setting the annotation `dev.okteto.com/update`. 
 
 Depending on the kind of resource the acceptance values are different:
-- rolling: Will deploy a service with 0 downtime. Allowed on deployments and statefulsets.
-- recreate: Will wait until the current pod is deleted to start creating the new one. Allowed on deployments
-- on-delete: Will wait until the current pod is deleted to start creating the new one. Allowed on statefulset
+- rolling:  Will deploy a service with zero downtime. Only allowed for deployments and stateful sets.
+- recreate: Will wait until the current pod is deleted to start creating the new one. Only allowed on deployments.
+- on-delete: Will wait until the current pod is deleted to start creating the new one. Only allowed on stateful sets.
 
 ```yaml
 services:


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Adds documentation about the update policy annotation on compose