### PR TITLE
docs: add healthcheck docs about x-okteto healthchecks

### DIFF
--- a/src/content/reference/docker-compose.mdx
+++ b/src/content/reference/docker-compose.mdx
@@ -208,6 +208,8 @@ either a string or a list. If it's a list, the first item must be either `NONE`,
 If it's a string, it's equivalent to specifying `CMD-SHELL` followed by that string.
 - `http` (object): Defines the path and port that has to be tested on the container to set
  the healthcheck as successful
+- `x-okteto-readiness` (bool): Defines if the probe should be a readiness probe
+- `x-okteto-liveness` (bool): Defines if the probe should be a liveness probe
  
 ```yaml
 healthcheck:

--- a/src/content/reference/docker-compose.mdx
+++ b/src/content/reference/docker-compose.mdx
@@ -209,7 +209,7 @@ If it's a string, it's equivalent to specifying `CMD-SHELL` followed by that str
 - `http` (object): Defines the path and port that has to be tested on the container to set
  the healthcheck as successful
 - `x-okteto-readiness` (bool): Defines if the probe should be a readiness probe (default: `true`). 
-- `x-okteto-liveness` (bool): Defines if the probe should be a liveness probe (default: `true`).
+- `x-okteto-liveness` (bool): Defines if the probe should be a liveness probe (default: `false`).
  
 ```yaml
 healthcheck:

--- a/src/content/reference/docker-compose.mdx
+++ b/src/content/reference/docker-compose.mdx
@@ -208,8 +208,8 @@ either a string or a list. If it's a list, the first item must be either `NONE`,
 If it's a string, it's equivalent to specifying `CMD-SHELL` followed by that string.
 - `http` (object): Defines the path and port that has to be tested on the container to set
  the healthcheck as successful
-- `x-okteto-readiness` (bool): Defines if the probe should be a readiness probe
-- `x-okteto-liveness` (bool): Defines if the probe should be a liveness probe
+- `x-okteto-readiness` (bool): Defines if the probe should be a readiness probe (default: `true`). 
+- `x-okteto-liveness` (bool): Defines if the probe should be a liveness probe (default: `true`).
  
 ```yaml
 healthcheck:


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Adds documentation about `x-okteto-readiness` and `x-okteto-liveness`