### PR TITLE
Fix broken image on GitHub Integration

### DIFF
--- a/src/content/self-hosted/administration/github.mdx
+++ b/src/content/self-hosted/administration/github.mdx
@@ -114,6 +114,6 @@ helm install okteto okteto/okteto -f config.yaml --namespace=okteto
 
 If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
 
-<p align="center"><Image src="/docs/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
+<p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 
 When you click on it, you should see the list of repositories that you added in the previous step. [This document](/docs/cloud/private-repositories/) has further information on how to deploy a private repository.

--- a/versioned_docs/version-0.11/enterprise/administration/private-repositories/github-application.mdx
+++ b/versioned_docs/version-0.11/enterprise/administration/private-repositories/github-application.mdx
@@ -120,7 +120,7 @@ If you select repositories from a different organization (or user account) than 
 
 If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
 
-<p align="center"><Image src="/docs/0.11/enterprise/administration/private-repositories/images/verify-installation.png" alt="verify your installation" width="650" /></p>
+<p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 
 When you click on it, you should see the list of repositories that you added in the previous step. [This document](/docs/cloud/private-repositories/) has further information on how to deploy a private repository.
 

--- a/versioned_docs/version-0.11/enterprise/administration/private-repositories/github-application.mdx
+++ b/versioned_docs/version-0.11/enterprise/administration/private-repositories/github-application.mdx
@@ -112,7 +112,7 @@ You can update or revoke the permissions over your private repositories or organ
 
 Click on the `Configure GitHub` button to add or remove repositories. This will open a configuration dialog from GitHub. From there, you'll be able to add or remove repositories from any organization you belong to.
 
-<p align="center"><Image src="/docs/0.11/enterprise/administration/private-repositories/images/private-repositories-enable.png" alt="add repositories to Okteto Enterprise" width="650" /></p>
+<p align="center"><Image src="/docs/administration/private-repositories/images/private-repositories-enable.png" alt="add repositories to Okteto Enterprise" width="650" /></p>
 
 If you select repositories from a different organization (or user account) than the one you used to create the GitHub Application, GitHub will prompt you to install the application in the GitHub organization. Only organization administrators can complete this action. 
 

--- a/versioned_docs/version-0.12/enterprise/administration/private-repositories/github-application.mdx
+++ b/versioned_docs/version-0.12/enterprise/administration/private-repositories/github-application.mdx
@@ -120,7 +120,7 @@ If you select repositories from a different organization (or user account) than 
 
 If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
 
-<p align="center"><Image src="/docs/0.12/enterprise/administration/private-repositories/images/verify-installation.png" alt="verify your installation" width="650" /></p>
+<p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 
 When you click on it, you should see the list of repositories that you added in the previous step. [This document](/docs/cloud/private-repositories/) has further information on how to deploy a private repository.
 

--- a/versioned_docs/version-0.12/enterprise/administration/private-repositories/github-application.mdx
+++ b/versioned_docs/version-0.12/enterprise/administration/private-repositories/github-application.mdx
@@ -112,7 +112,7 @@ You can update or revoke the permissions over your private repositories or organ
 
 Click on the `Configure GitHub` button to add or remove repositories. This will open a configuration dialog from GitHub. From there, you'll be able to add or remove repositories from any organization you belong to.
 
-<p align="center"><Image src="/docs/0.12/enterprise/administration/private-repositories/images/private-repositories-enable.png" alt="add repositories to Okteto Enterprise" width="650" /></p>
+<p align="center"><Image src="/docs/administration/private-repositories/images/private-repositories-enable.png" alt="add repositories to Okteto Enterprise" width="650" /></p>
 
 If you select repositories from a different organization (or user account) than the one you used to create the GitHub Application, GitHub will prompt you to install the application in the GitHub organization. Only organization administrators can complete this action. 
 

--- a/versioned_docs/version-0.13/enterprise/administration/github.mdx
+++ b/versioned_docs/version-0.13/enterprise/administration/github.mdx
@@ -114,7 +114,7 @@ helm install okteto okteto/okteto-enterprise -f config.yaml --namespace=okteto
 
 If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
 
-<p align="center"><Image src="/docs/0.13/enterprise/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
+<p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 
 When you click on it, you should see the list of repositories that you added in the previous step. [This document](/docs/cloud/private-repositories/) has further information on how to deploy a private repository.
 

--- a/versioned_docs/version-0.14/enterprise/administration/github.mdx
+++ b/versioned_docs/version-0.14/enterprise/administration/github.mdx
@@ -114,7 +114,7 @@ helm install okteto okteto/okteto-enterprise -f config.yaml --namespace=okteto
 
 If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
 
-<p align="center"><Image src="/docs/0.14/enterprise/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
+<p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 
 When you click on it, you should see the list of repositories that you added in the previous step. [This document](/docs/cloud/private-repositories/) has further information on how to deploy a private repository.
 

--- a/versioned_docs/version-0.15/enterprise/administration/github.mdx
+++ b/versioned_docs/version-0.15/enterprise/administration/github.mdx
@@ -114,7 +114,7 @@ helm install okteto okteto/okteto-enterprise -f config.yaml --namespace=okteto
 
 If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
 
-<p align="center"><Image src="/docs/enterprise/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
+<p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 
 When you click on it, you should see the list of repositories that you added in the previous step. [This document](/docs/cloud/private-repositories/) has further information on how to deploy a private repository.
 

--- a/versioned_docs/version-1.0/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.0/self-hosted/administration/github.mdx
@@ -114,6 +114,6 @@ helm install okteto okteto/okteto -f config.yaml --namespace=okteto
 
 If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
 
-<p align="center"><Image src="/docs/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
+<p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 
 When you click on it, you should see the list of repositories that you added in the previous step. [This document](/docs/cloud/private-repositories/) has further information on how to deploy a private repository.


### PR DESCRIPTION
Fix the broken image URL at the bottom of the page

### Test plan

1. Visit https://deploy-preview-235--okteto-docs.netlify.app/docs/self-hosted/administration/github/#verifying-your-installation and the image should display correctly