### PR TITLE
Enable flask development mode on `okteto up`

### DIFF
--- a/src/content/samples/python.mdx
+++ b/src/content/samples/python.mdx
@@ -69,6 +69,8 @@ The [dev](/docs/reference/manifest/#dev-object-optional) section defines how to 
 dev:
   hello-world:
     command: bash
+    environment:
+      - FLASK_ENV=development
     sync:
       - .:/usr/src/app
     reverse:


### PR DESCRIPTION
PR already merged in the sample repo:
https://github.com/okteto/python-getting-started/pull/12