### PR TITLE
fix: private endpoints compose examples

### DIFF
--- a/src/content/cloud/private-endpoints.mdx
+++ b/src/content/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```

--- a/versioned_docs/version-0.11/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.11/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```

--- a/versioned_docs/version-0.12/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.12/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```

--- a/versioned_docs/version-0.13/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.13/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```

--- a/versioned_docs/version-0.14/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.14/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```

--- a/versioned_docs/version-0.15/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-0.15/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```

--- a/versioned_docs/version-1.0/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-1.0/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```

--- a/versioned_docs/version-1.1/cloud/private-endpoints.mdx
+++ b/versioned_docs/version-1.1/cloud/private-endpoints.mdx
@@ -106,8 +106,8 @@ services:
   hello-world:
     labels:
       dev.okteto.com/private: "true"
-    build: hello
-    port:
+    image: nginx
+    ports:
       - 8080:8080
 ```
 
@@ -126,7 +126,7 @@ endpoints:
       port: 8080
 services:
   hello-world:
-    build: hello
+    image: nginx
     expose:
       - 8080
 ```


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Use a image instead of a build since we don't have a `Dockerfile` defined or repo linked

Replace `port` into `ports` 