### PR TITLE
Change messages to use php 8

### DIFF
--- a/src/content/samples/php.mdx
+++ b/src/content/samples/php.mdx
@@ -117,7 +117,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 ```
 
 ```console
-[Tue Jul  5 21:04:55 2022] PHP 7.4.30 Development Server (http://0.0.0.0:8080) started
+[Tue Jul  5 21:04:55 2022] PHP 8.2.0 Development Server (http://0.0.0.0:8080) started
 ```
 
 Go back to the browser, and reload the page to test that your application is running.

--- a/versioned_docs/version-0.13/samples/php.mdx
+++ b/versioned_docs/version-0.13/samples/php.mdx
@@ -117,7 +117,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 ```
 
 ```console
-[Tue Jul  5 21:04:55 2022] PHP 7.4.30 Development Server (http://0.0.0.0:8080) started
+[Tue Jul  5 21:04:55 2022] PHP 8.2.0 Development Server (http://0.0.0.0:8080) started
 ```
 
 Go back to the browser, and reload the page to test that your application is running.

--- a/versioned_docs/version-0.14/samples/php.mdx
+++ b/versioned_docs/version-0.14/samples/php.mdx
@@ -117,7 +117,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 ```
 
 ```console
-[Tue Jul  5 21:04:55 2022] PHP 7.4.30 Development Server (http://0.0.0.0:8080) started
+[Tue Jul  5 21:04:55 2022] PHP 8.2.0 Development Server (http://0.0.0.0:8080) started
 ```
 
 Go back to the browser, and reload the page to test that your application is running.

--- a/versioned_docs/version-0.15/samples/php.mdx
+++ b/versioned_docs/version-0.15/samples/php.mdx
@@ -117,7 +117,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 ```
 
 ```console
-[Tue Jul  5 21:04:55 2022] PHP 7.4.30 Development Server (http://0.0.0.0:8080) started
+[Tue Jul  5 21:04:55 2022] PHP 8.2.0 Development Server (http://0.0.0.0:8080) started
 ```
 
 Go back to the browser, and reload the page to test that your application is running.

--- a/versioned_docs/version-1.0/samples/php.mdx
+++ b/versioned_docs/version-1.0/samples/php.mdx
@@ -117,7 +117,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 ```
 
 ```console
-[Tue Jul  5 21:04:55 2022] PHP 7.4.30 Development Server (http://0.0.0.0:8080) started
+[Tue Jul  5 21:04:55 2022] PHP 8.2.0 Development Server (http://0.0.0.0:8080) started
 ```
 
 Go back to the browser, and reload the page to test that your application is running.

--- a/versioned_docs/version-1.1/samples/php.mdx
+++ b/versioned_docs/version-1.1/samples/php.mdx
@@ -117,7 +117,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 ```
 
 ```console
-[Tue Jul  5 21:04:55 2022] PHP 7.4.30 Development Server (http://0.0.0.0:8080) started
+[Tue Jul  5 21:04:55 2022] PHP 8.2.0 Development Server (http://0.0.0.0:8080) started
 ```
 
 Go back to the browser, and reload the page to test that your application is running.

--- a/versioned_docs/version-1.2/samples/php.mdx
+++ b/versioned_docs/version-1.2/samples/php.mdx
@@ -117,7 +117,7 @@ cindy:hello-world app> php -S 0.0.0.0:8080
 ```
 
 ```console
-[Tue Jul  5 21:04:55 2022] PHP 7.4.30 Development Server (http://0.0.0.0:8080) started
+[Tue Jul  5 21:04:55 2022] PHP 8.2.0 Development Server (http://0.0.0.0:8080) started
 ```
 
 Go back to the browser, and reload the page to test that your application is running.


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

We need to update PHP server start messages to use PHP 8 instead of PHP 7