### PR TITLE
Specify which service accounts are associated to "globalClusterRole"

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -633,7 +633,9 @@ There is only one exception where this storage class is overwritten. In case of 
 
 ### globalClusterRole
 
-Okteto assings this cluster role to every user via a cluster role binding. By default, this behavior is disabled.
+Okteto assings this cluster role to every user via a cluster role binding.
+The cluster role binding is created for the user service account in the `okteto` namespace, and the `default` service account on every user namespace.
+By default, this behavior is disabled.
 This can be useful to give access to cluster level resources to every developer account, like accessing the Node API.
 
 ```yaml


### PR DESCRIPTION
One of our users was asking about which service account they need on their pods to get access to the "globalClusterRole". This PR addresses that feedback