### PR TITLE
Added destroy flag and info to namespace and preview destroy

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -249,6 +249,7 @@ $ okteto destroy
 | _--volumes_                              |  (bool)  | Destroy the persistent volumes created by the development environment (defaults to `false`)                                                             |
 | _--wait_                                 |  (bool)  | Wait until the development environment is destroyed (defaults to `false`)                                                                               |
 | _--no-bash_                              |  (bool)  | Execute the command using the container's default shell instead of bash (defaults to false)                                                             |
+| _--all_                                  |  (bool)  | Destroy everything at the current namespace (defaults to `false`)                                                                                       |
 
 > Executed commands will be executed using bash unless the `--no-bash` flag has been specified.
 
@@ -397,7 +398,7 @@ $ okteto namespace create test-cindy
 
 #### delete
 
-Delete a namespace.
+Delete a namespace. When `destroy` commands are defined at the development environments of the namespace, this will be executed.
 
 > This command is only available in clusters that have Okteto installed.
 
@@ -539,6 +540,7 @@ Run `okteto preview destroy` to destroy a given preview environment.
 
 You need to be [logged in](/docs/reference/cli/#context) to Okteto before running this command.
 Only users with administration privileges can destroy a global preview environment.
+When `destroy` commands are defined at the development environment of the preview, this will be executed.
 
 #### endpoints
 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -249,7 +249,7 @@ $ okteto destroy
 | _--volumes_                              |  (bool)  | Destroy the persistent volumes created by the development environment (defaults to `false`)                                                             |
 | _--wait_                                 |  (bool)  | Wait until the development environment is destroyed (defaults to `false`)                                                                               |
 | _--no-bash_                              |  (bool)  | Execute the command using the container's default shell instead of bash (defaults to false)                                                             |
-| _--all_                                  |  (bool)  | Destroy everything at the current namespace (defaults to `false`)                                                                                       |
+| _--all_                                  |  (bool)  | Destroy everything (defaults to `false`)                                                                                       |
 
 > Executed commands will be executed using bash unless the `--no-bash` flag has been specified.
 
@@ -398,7 +398,7 @@ $ okteto namespace create test-cindy
 
 #### delete
 
-Delete a namespace. When `destroy` commands are defined at the development environments of the namespace, this will be executed.
+Delete a namespace. If the manifest includes `destroy` commands, they will be executed as part of this command.
 
 > This command is only available in clusters that have Okteto installed.
 
@@ -540,7 +540,7 @@ Run `okteto preview destroy` to destroy a given preview environment.
 
 You need to be [logged in](/docs/reference/cli/#context) to Okteto before running this command.
 Only users with administration privileges can destroy a global preview environment.
-When `destroy` commands are defined at the development environment of the preview, this will be executed.
+If the manifest includes `destroy` commands, they will be executed as part of this command.
 
 #### endpoints
 


### PR DESCRIPTION
Release https://github.com/okteto/okteto/releases/tag/2.11.0 introduced the flag `--all` into the command `okteto destroy` in order to delete all the resources that are present at the current namespace.

Also, `okteto preview destroy` and `okteto namespace destroy` now execute the commands that are defined under the `destroy` section of the okteto manifest.