### PR TITLE
docs: add missing release dates to release notes

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -6,6 +6,7 @@ id: releases
 ---
 
 ## 1.3.0
+23 December, 2022
 
 ### Features
 
@@ -21,6 +22,7 @@ id: releases
 - Fix wrong "Last updated" time for development environments in the Okteto UI
 
 ## 1.2.0
+25 November, 2022
 
 ### Features
 
@@ -46,6 +48,7 @@ id: releases
 - Virtual services are now correctly displayed in the dashboard
 
 ## 1.1.0
+2 November, 2022
 
 ### Features
 - Allow members of a namespace to share it.

--- a/versioned_docs/version-1.1/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.1/self-hosted/install/releases.mdx
@@ -6,6 +6,7 @@ id: releases
 ---
 
 ## 1.1.0
+2 November, 2022
 
 ### Features
 - Allow members of a namespace to share it.

--- a/versioned_docs/version-1.2/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.2/self-hosted/install/releases.mdx
@@ -6,6 +6,7 @@ id: releases
 ---
 
 ## 1.2.0
+25 November, 2022
 
 ### New Feature
 
@@ -31,6 +32,7 @@ id: releases
 - Virtual services are now correctly displayed in the dashboard
 
 ## 1.1.0
+2 November, 2022
 
 ### Features
 - Allow members of a namespace to share it.

--- a/versioned_docs/version-1.3/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.3/self-hosted/install/releases.mdx
@@ -6,6 +6,7 @@ id: releases
 ---
 
 ## 1.3.0
+23 December, 2022
 
 ### Features
 
@@ -21,6 +22,7 @@ id: releases
 - Fix wrong "Last updated" time for development environments in the Okteto UI
 
 ## 1.2.0
+25 December, 2022
 
 ### Features
 
@@ -46,6 +48,7 @@ id: releases
 - Virtual services are now correctly displayed in the dashboard
 
 ## 1.1.0
+2 November, 2022
 
 ### Features
 - Allow members of a namespace to share it.


### PR DESCRIPTION
Some release notes versions don't have a release date since 1.0.0. This
PR addresses that in current and versioned docs.