### PR TITLE
Added documentation for the `--command` flag

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -665,7 +665,7 @@ Therefore, the development deployment uses the same service account, environment
 | _--env_       |  (list)  | Set environment variable in the dev container.                                                       |
 | _--deploy_    |  (bool)  | Force execution of the commands in the `deploy` section of the okteto manifest (defaults to `false`) |
 | _--reset_     |  (bool)  | Resets the file synchronization service. Use it if the file synchronization service stops working.   |
-| _--command_   |  (list)  | Provide additional commands to override the ones specified under the dev field in the manifest       |
+| _--command_   |  (list)  | The command to execute in the dev container. This overrides the command specified in the `dev` section of the manifest      |
 
 ### version
 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -662,9 +662,10 @@ Therefore, the development deployment uses the same service account, environment
 | _--file_      | (string) | The path to the manifest file (default "okteto.yml")                                                 |
 | _--namespace_ | (string) | The namespace to use (defaults to the current okteto namespace)                                      |
 | _--context_   | (string) | The context to use (defaults to the current okteto context)                                          |
+| _--env_       |  (list)  | Set environment variable in the dev container.                                                       |
 | _--deploy_    |  (bool)  | Force execution of the commands in the `deploy` section of the okteto manifest (defaults to `false`) |
 | _--reset_     |  (bool)  | Resets the file synchronization service. Use it if the file synchronization service stops working.   |
-| _--env_       |  (list)  | Set environment variable in the dev container.                                                            |
+| _--command_   |  (list)  | Provide additional commands to override the ones specified under the dev field in the manifest       |
 
 ### version
 


### PR DESCRIPTION
Reference pr: https://github.com/okteto/okteto/pull/3215. I also changed the position of the `--env` flag to match the [`up.go`](https://github.com/okteto/okteto/blob/master/cmd/up/up.go#L366) file 

Signed-off-by: Abhisman Sarkar <abhisman.sarkar@gmail.com>