### PR TITLE
Fix wrong Okteto Cloud docs link

### DIFF
--- a/src/content/cloud/preview-environments/overview.mdx
+++ b/src/content/cloud/preview-environments/overview.mdx
@@ -12,7 +12,7 @@ Preview environments allow you to include a live preview of your changes on ever
 <p align="center"><Image src="/docs/cloud/preview-environments/images/preview-environments.png" alt="Preview Environments" /></p>
 
 Okteto's preview environments are powered by Kubernetes and easily integrate with your favorite source control and CI/CD provider. They work using the [Okteto manifest](/docs/cloud/okteto-cli/#okteto-manifest), so are very simple to get started with.
-You can use Preview Environments with either [Okteto Cloud](/docs/cloud) or with [Okteto Self-Hosted](/docs/self-hosted/) if you want to run them on your Kubernetes infrastructure.
+You can use Preview Environments with either [Okteto Cloud](/docs/cloud/) or with [Okteto Self-Hosted](/docs/self-hosted/) if you want to run them on your Kubernetes infrastructure.
 
 - [GitHub](/docs/cloud/preview-environments/preview-environments-github/)
 - [GitLab](/docs/cloud/preview-environments/preview-environments-gitlab/)


### PR DESCRIPTION
As reported here: https://okteto.slack.com/archives/C02SX9665RP/p1673533384864009