### PR TITLE
Fix "build_args" docs

### DIFF
--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -52,7 +52,7 @@ build:
     dockerfile: Dockerfile
     target: dev
     depends_on: base
-    build_args:
+    args:
       SOURCE_IMAGE: ${OKTETO_BUILD_BASE_IMAGE}
 ```
 

--- a/versioned_docs/version-1.2/reference/manifest.mdx
+++ b/versioned_docs/version-1.2/reference/manifest.mdx
@@ -52,7 +52,7 @@ build:
     dockerfile: Dockerfile
     target: dev
     depends_on: base
-    build_args:
+    args:
       SOURCE_IMAGE: ${OKTETO_BUILD_BASE_IMAGE}
 ```
 

--- a/versioned_docs/version-1.3/reference/manifest.mdx
+++ b/versioned_docs/version-1.3/reference/manifest.mdx
@@ -52,7 +52,7 @@ build:
     dockerfile: Dockerfile
     target: dev
     depends_on: base
-    build_args:
+    args:
       SOURCE_IMAGE: ${OKTETO_BUILD_BASE_IMAGE}
 ```
 


### PR DESCRIPTION
`build_args` is referred in the sample, but the right field name is `args`