### PR TITLE
Document virtual services

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -1019,7 +1019,7 @@ userPodAffinity:
 
 ### virtualServices
 
-When enabled the Okteto UI will show the public endpoints associated to [Istio Virtual Services](https://istio.io/latest/docs/reference/config/networking/virtual-service/) (default: `false`).
+When enabled, the Okteto UI will show the public endpoints associated with [Istio Virtual Services](https://istio.io/latest/docs/reference/config/networking/virtual-service/) (default: `false`).
 
 ```yaml
 virtualServices:

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -1017,6 +1017,15 @@ userPodAffinity:
   enabled: true
 ```
 
+### virtualServices
+
+When enabled the Okteto UI will show the public endpoints associated to [Istio Virtual Services](https://istio.io/latest/docs/reference/config/networking/virtual-service/) (default: `false`).
+
+```yaml
+virtualServices:
+  enabled: false
+```
+
 ### volumes
 
 Allows you to specify different settings for volumes.

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -11,7 +11,7 @@ January 19, 2023
 
 ### Features
 - You can now define [external resources](/docs/reference/manifest/#external-object-optional) in your Okteto manifest. Use this to include resources that exist outside of your Okteto namespace like databases, message brokers, serverless functions, dashboards, etc.
-- You can now include `virtual services` in your development environment
+- You can now show [virtual services](/docs/self-hosted/administration/configuration/#virtualservices) endpoints in the Okteto UI
 - Update okteto cli version to [2.11.1](https://github.com/okteto/okteto/releases/tag/2.11.1)
 
 ### Improvements

--- a/versioned_docs/version-1.4/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.4/self-hosted/administration/configuration.mdx
@@ -1019,7 +1019,7 @@ userPodAffinity:
 
 ### virtualServices
 
-When enabled the Okteto UI will show the public endpoints associated to [Istio Virtual Services](https://istio.io/latest/docs/reference/config/networking/virtual-service/) (default: `false`).
+When enabled, the Okteto UI will show the public endpoints associated with [Istio Virtual Services](https://istio.io/latest/docs/reference/config/networking/virtual-service/) (default: `false`).
 
 ```yaml
 virtualServices:

--- a/versioned_docs/version-1.4/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.4/self-hosted/administration/configuration.mdx
@@ -1017,6 +1017,15 @@ userPodAffinity:
   enabled: true
 ```
 
+### virtualServices
+
+When enabled the Okteto UI will show the public endpoints associated to [Istio Virtual Services](https://istio.io/latest/docs/reference/config/networking/virtual-service/) (default: `false`).
+
+```yaml
+virtualServices:
+  enabled: false
+```
+
 ### volumes
 
 Allows you to specify different settings for volumes.

--- a/versioned_docs/version-1.4/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.4/self-hosted/install/releases.mdx
@@ -11,7 +11,7 @@ January 19, 2023
 
 ### Features
 - You can now define [external resources](/docs/reference/manifest/#external-object-optional) in your Okteto manifest. Use this to include resources that exist outside of your Okteto namespace like databases, message brokers, serverless functions, dashboards, etc.
-- You can now include `virtual services` in your development environment
+- You can now show [virtual services](/docs/self-hosted/administration/configuration/#virtualservices) endpoints in the Okteto UI
 - Update okteto cli version to [2.11.1](https://github.com/okteto/okteto/releases/tag/2.11.1)
 
 ### Improvements


### PR DESCRIPTION
Virtual services moved from `unsupported.virtualServices.enabled` to `virtualServices.enabled`