### PR TITLE
Added missing bug fix on release-1.4. Fixed host aliases inject in installer pods to ensure the communication with Okteto's API and registry is done internally

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -32,11 +32,12 @@ January 19, 2023
 
 ### Bugfixes
 - The branch selector in the Deploy dialog doesn't flicker when the branch is not found
-- Fixed issue that prevented private repositories of individual GitHub accounts to bee correctly displayed in the Deploy dialog
+- Fixed issue that prevented private repositories of individual GitHub accounts to be correctly displayed in the Deploy dialog
 - Fixed compatibility issues with Azure Active Directory
 - Fixed blank screen that sometimes appeared when clicking the "Stop development" button
 - Fixed race condition when trying to deploy a development environment that was removed from the catalog
 - Ingresses that are not managed for Okteto won't be deleted when a namespace is put to sleep
+- Fixed how host aliases are injected in the installer pods as the connection to Okteto's API and registry was not using the internal IPs in some scenarios
 
 
 ## 1.3.0

--- a/versioned_docs/version-1.4/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.4/self-hosted/install/releases.mdx
@@ -32,11 +32,12 @@ January 19, 2023
 
 ### Bugfixes
 - The branch selector in the Deploy dialog doesn't flicker when the branch is not found
-- Fixed issue that prevented private repositories of individual GitHub accounts to bee correctly displayed in the Deploy dialog
+- Fixed issue that prevented private repositories of individual GitHub accounts to be correctly displayed in the Deploy dialog
 - Fixed compatibility issues with Azure Active Directory
 - Fixed blank screen that sometimes appeared when clicking the "Stop development" button
 - Fixed race condition when trying to deploy a development environment that was removed from the catalog
 - Ingresses that are not managed for Okteto won't be deleted when a namespace is put to sleep
+- Fixed how host aliases are injected in the installer pods as the connection to Okteto's API and registry was not using the internal IPs in some scenarios
 
 
 ## 1.3.0


### PR DESCRIPTION
Added missing bug fix on release-1.4. Fixed host aliases inject in installer pods to ensure the communication with Okteto's API and registry is done internally

Signed-off-by: Ignacio Fuertes <nacho@okteto.com>