### PR TITLE
Add redirect for versions home page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,8 +14,8 @@
   status = 301
 
 [[redirects]]
-  from = "/docs/*"
-  to = "/docs/:splat/welcome/overview/"
+  from = "/docs/0.11/"
+  to = "/docs/0.11/welcome/overview/"
   status = 301
   
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,12 @@
   from = "/docs/enterprise/*"
   to = "/docs/self-hosted/:splat"
   status = 301
+
+
+[[redirects]]
+  from = "/docs/*/"
+  to = "/docs/:splat/welcome/overview/"
+  status = 301
   
 [[redirects]]
   from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,13 +14,13 @@
   status = 301
 
 [[redirects]]
-  from = "/docs/0.*"
-  to = "/docs/0.:splat/welcome/overview/"
+  from = "/docs/0.:version/*"
+  to = "/docs/0.:version/welcome/overview/"
   status = 301
 
 [[redirects]]
-  from = "/docs/1.*"
-  to = "/docs/1.:splat/welcome/overview/"
+  from = "/docs/1.:version/*"
+  to = "/docs/1.:version/welcome/overview/"
   status = 301
   
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,8 +14,13 @@
   status = 301
 
 [[redirects]]
-  from = "/docs/0.11/"
-  to = "/docs/0.11/welcome/overview/"
+  from = "/docs/0.*/"
+  to = "/docs/0.:splat/welcome/overview/"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.*/"
+  to = "/docs/1.:splat/welcome/overview/"
   status = 301
   
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,9 +13,8 @@
   to = "/docs/self-hosted/:splat"
   status = 301
 
-
 [[redirects]]
-  from = "/docs/*/"
+  from = "/docs/*"
   to = "/docs/:splat/welcome/overview/"
   status = 301
   

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,13 +14,13 @@
   status = 301
 
 [[redirects]]
-  from = "/docs/0.:version/*"
-  to = "/docs/0.:version/welcome/overview/"
+  from = "/docs/:version/*"
+  to = "/docs/:version/welcome/overview/"
   status = 301
 
 [[redirects]]
-  from = "/docs/1.:version/*"
-  to = "/docs/1.:version/welcome/overview/"
+  from = "/docs/:version/*"
+  to = "/docs/:version/welcome/overview/"
   status = 301
   
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,16 +14,14 @@
   status = 301
 
 [[redirects]]
-  from = "/docs/0.*/"
+  from = "/docs/0.*"
   to = "/docs/0.:splat/welcome/overview/"
   status = 301
-  force = true
 
 [[redirects]]
-  from = "/docs/1.*/"
+  from = "/docs/1.*"
   to = "/docs/1.:splat/welcome/overview/"
   status = 301
-  force = true
   
 [[redirects]]
   from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,11 +17,13 @@
   from = "/docs/0.*/"
   to = "/docs/0.:splat/welcome/overview/"
   status = 301
+  force = true
 
 [[redirects]]
   from = "/docs/1.*/"
   to = "/docs/1.:splat/welcome/overview/"
   status = 301
+  force = true
   
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Fix https://github.com/okteto/docs/issues/289
 
We should be able to link to https://www.okteto.com/docs/xxx/ and it redirects to https://www.okteto.com/docs/xxx/welcome/overview

## Test plan

These should all work:

https://deploy-preview-296--okteto-docs.netlify.app/docs/0.11
https://deploy-preview-296--okteto-docs.netlify.app/docs/0.12
https://deploy-preview-296--okteto-docs.netlify.app/docs/0.13
https://deploy-preview-296--okteto-docs.netlify.app/docs/0.14
https://deploy-preview-296--okteto-docs.netlify.app/docs/0.15
https://deploy-preview-296--okteto-docs.netlify.app/docs/1.1
https://deploy-preview-296--okteto-docs.netlify.app/docs/1.2
https://deploy-preview-296--okteto-docs.netlify.app/docs/1.3
https://deploy-preview-296--okteto-docs.netlify.app/docs/1.4