### PR TITLE
docs: add icon documentation

### DIFF
--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -728,11 +728,13 @@ A list of external resources that are part of your development environment.  Use
 external:
   db:
     notes: docs/database.md
+    icon: database
     endpoints:
     - name: db
       url: https://localhost:3306
   functions:
     notes: docs/lambdas.md
+    icon: function
     endpoints:
     - name: data-aggregator
       url: https://fake-id.lambda-url.us-east-1.on.aws
@@ -743,6 +745,18 @@ external:
 #### endpoints ([object], required)
 
 Endpoints contain information on how to access the external resource.
+
+#### icon (string, optional)
+
+ Sets the icon that will be shown in the UI. The supported values for icons are:
+
+ - `container`
+ - `dashboard`
+ - `database`
+ - `default`
+ - `function`
+ - `graph`
+ - `storage`
 
 ##### name (string, required)
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Add documentation for external resources icons