### PR TITLE
Update volume snapshot guides

### DIFF
--- a/src/content/cloud/volume-snapshots.mdx
+++ b/src/content/cloud/volume-snapshots.mdx
@@ -31,10 +31,7 @@ Use a storage class provisioned by a CSI driver that [supports volume snapshots]
 <TabItem value="saas">
 If your instance is hosted by Okteto, Volume Snapshots are enabled by default.
 
-Use one of the following storage classes for the source persistent volume of your volume snapshots:
-
-- `csi-okteto-standard`: backed by standard hard disk drives (HDD)
-- `csi-okteto-ssd`: backed by solid-state drives (SDD)
+**Important**: you need to use the `csi-okteto` storage classes for the source persistent volume of your volume snapshots.
 
 </TabItem>
 </Tabs>
@@ -51,6 +48,7 @@ In order to use volume snapshots with your development environment you need to:
 - [Consume the volume snapshot in a new persistent volume](cloud/volume-snapshots.mdx#consuming-a-volume-snapshot)
 
 ### Creating the Source Persistent Volume
+
 First, create the source persistent volume. This is the data that you want to be able to clone into your development environment.  In the example below we use a database, but this could be anything that uses a volume for storage: databases, ML models, images, etc...
 > If the default storage class of your cluster doesn't support volume snapshots, make sure you set the storage class to one that is compatible when creating your persistent volume.
 Check the [requirements](cloud/volume-snapshots.mdx#requirements) section to learn more about the available storage classes in Okteto.
@@ -71,7 +69,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pvc
 spec:
-  storageClassName: csi-okteto-standard
+  storageClassName: csi-okteto
   accessModes:
   - ReadWriteOnce
   resources:
@@ -92,7 +90,7 @@ services:
 volumes:
   mysql-pvc:
     driver_opts:
-      class: csi-okteto-standard
+      class: csi-okteto
 ```
 
 </TabItem>

--- a/src/content/self-hosted/administration/volume-snapshots.mdx
+++ b/src/content/self-hosted/administration/volume-snapshots.mdx
@@ -43,7 +43,7 @@ The following manifest is an example of a VolumeSnapshotClass:
 
 ```yaml
 # okteto-snapshot-class.yaml
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: okteto-snapshot-class
@@ -56,7 +56,7 @@ deletionPolicy: Delete
 
 ```yaml
 # okteto-snapshot-class.yaml
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: okteto-snapshot-class
@@ -70,7 +70,7 @@ deletionPolicy: Delete
 
 ```yaml
 # okteto-snapshot-class.yaml
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: okteto-snapshot-class
@@ -202,76 +202,6 @@ volumeSnapshots:
 
 By default, all users in your cluster will be able to use any of the available snapshots as a data source for their development environments. You can limit this via the `enableNamespaceAccessValidation` key in the `volumeSnapshots` section of the configuration, value of `true` will enable the validation.
 
-## Using Storage Snapshots in your Development Environment
+## Using Volume Snapshots in your Development Environment
 
-If your data source is not on Kubernetes, you can instead create a storage snapshot directly from your cloud provider (consult your cloud provider's documentation on how to generate a volume snapshot).
-
-Use the `dev.okteto.com/from-snapshot-id` annotation on any persistent volume claim to tell Okteto to initialize your persistent volume claim from a storage snapshot created in your cloud provider, as shown below:
-
-<Tabs
-  defaultValue="aws-ebs"
-  values={[
-    { label: 'Amazon EBS', value: 'aws-ebs', },
-    { label: 'GCE Persistent Disk ', value: 'gce-pd', },
-    { label: 'DigitalOcean Block Storage', value: 'do', },
-  ]}
->
-<TabItem value="aws-ebs">
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  annotations:
-    dev.okteto.com/from-snapshot-id: snapshot-8dc4bb4c
-  name: pvc-from-snapshot
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
-```
-
-</TabItem>
-<TabItem value="gce-pd">
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  annotations:
-    dev.okteto.com/from-snapshot-id: projects/my-project/global/snapshots/snapshot-8dc4bb4c-c76e-bb03-ff17-1d83e07a6804
-  name: pvc-from-snapshot
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
-```
-
-</TabItem>
-<TabItem value="do">
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  annotations:
-    dev.okteto.com/from-snapshot-id: volume-8dc4bb4c
-  name: pvc-from-snapshot
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
-```
-
-</TabItem>
-</Tabs>
-
-As part of the creation of the persistent volume claim, Okteto will import the specified snapshot into your cluster using a `VolumeSnapshotContent` and will set the source of your persistent volume claim to this [VolumeSnapshotContent](https://kubernetes.io/docs/concepts/storage/volume-snapshots/), ready to be used by your development environment.
-
-By default, anyone can use any of your cloud provider's snapshot ID as a data source. You can disable this by changing the configuration `allowIDAnnotation ` to `false` in the `volumeSnapshots` section of the configuration.
+Follow [this guide](cloud/volume-snapshots.mdx/#using-volume-snapshots-in-your-development-environment) to use Volume Snapshots in your development environment.


### PR DESCRIPTION
Updating the guides to reflect the following changes:
- Move from `v1beta1` version to `v1`
- Use the storage class `csi-okteto` in SaaS samples. We don't expose `standard` vs `ssd` options anymore
- From the admin guide, link to the dev guide. The dev sample in the admin guide was incomplete