### PR TITLE
chore: add build credential helpers

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -477,6 +477,18 @@ installer:
   sshSecretName: "okteto-ssh"
 ```
 
+- `buildCredentialHelpers`: Mapping of registry hostnames as keys to credential helpers as values. Disabled if `privateRegistry` is defined. Registry hostnames must be Fully Qualified Domain Names. Credential helper names must be accessible at installer job pod `$PATH` as `docker-credential-$NAME`.
+
+```yaml
+installer:
+  buildCredentialHelpers:
+    111122223333.dkr.ecr.eu-central-1.amazonaws.com: ecr-login
+user:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: 'arn:aws:iam::111122223333:role/okteto-installer-role-name'
+```
+
 ### registry
 
 The private container registry.


### PR DESCRIPTION
Add example for installer.buildCredentials with IAM Roles for Service Accounts.