### PR TITLE
chore: use collocated asset links for 1.5.0

### DIFF
--- a/src/content/cloud/preview-environments/github.mdx
+++ b/src/content/cloud/preview-environments/github.mdx
@@ -13,7 +13,7 @@ This section will show you how to automatically create a preview environment for
 - An Okteto account
 - A [GitHub account](https://github.com)
 
-For this tutorial, we'll be using our sample [movies rental application](https://github.com/okteto/movies). If you're using your own application to follow along, please ensure you have your [Okteto Manifest](../../../reference/manifest) configured.
+For this tutorial, we'll be using our sample [movies rental application](https://github.com/okteto/movies). If you're using your own application to follow along, please ensure you have your [Okteto Manifest](reference/manifest.mdx) configured.
 
 ## Step 1: Create the GitHub Workflow
 

--- a/src/content/cloud/preview-environments/gitlab.mdx
+++ b/src/content/cloud/preview-environments/gitlab.mdx
@@ -13,7 +13,7 @@ This section will show you how to automatically create a preview environment for
 - An Okteto account
 - A [GitLab Account](https://gitlab.com)
 
-For this tutorial, we'll be using our sample [movies rental application](https://gitlab.com/okteto/preview-environments). If you're using your own application to follow along, please ensure you have your [Okteto Manifest](../../../reference/manifest) configured.
+For this tutorial, we'll be using our sample [movies rental application](https://gitlab.com/okteto/preview-environments). If you're using your own application to follow along, please ensure you have your [Okteto Manifest](reference/manifest.mdx) configured.
 
 ## Step 1: Configure your Okteto API Token
 

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -10,11 +10,11 @@ id: releases
 
 ### Features
 
-- You can now define an [icon for every endpoint in your external resources list](../../../reference/manifest#icon-string-optional)
-- Add support for AWS ECR pushing/pulling with IAM Roles for Service Accounts through [installer.buildCredentialHelpers](../../administration/configuration/#installer)
+- You can now define an [icon for every endpoint in your external resources list](reference/manifest.mdx#icon-string-optional)
+- Add support for AWS ECR pushing/pulling with IAM Roles for Service Accounts through [installer.buildCredentialHelpers](self-hosted/administration/configuration.mdx#installer)
 - Add support for registry cloud provider storage using:
-  - [GCP Workload Identity](../../administration/configuration/#workload-identity)
-  - [AWS IAM Roles for Service Accounts](../../administration/configuration/#iam-role-for-service-account-irsa)
+  - [GCP Workload Identity](self-hosted/administration/configuration.mdx#workload-identity)
+  - [AWS IAM Roles for Service Accounts](self-hosted/administration/configuration.mdx#iam-role-for-service-account-irsa)
 
 ### Improvements
 
@@ -22,8 +22,8 @@ id: releases
 - Filter repositories results by search term
 - Delete button is now disabled in the personal namespace
 - Reduced load time when opening Github redeploy dialog
-- Added antiAffinity [configuration](../../administration/configuration/#userpodaffinity) for PODs with label `dev.okteto.com/affinity`
-- Added granular definition support for [networkPolicies](../../administration/configuration/#networkpolicies) created by Okteto.
+- Added antiAffinity [configuration](self-hosted/administration/configuration.mdx#userpodaffinity) for PODs with label `dev.okteto.com/affinity`
+- Added granular definition support for [networkPolicies](self-hosted/administration/configuration.mdx#networkpolicies) created by Okteto.
 
 ### Bugfixes
 


### PR DESCRIPTION
This PR changes absolute links to collocated asset for better version management.