### PR TITLE
Add links to community guides for aws manages certificates and godaddy

### DIFF
--- a/src/content/self-hosted/administration/certificates.mdx
+++ b/src/content/self-hosted/administration/certificates.mdx
@@ -34,7 +34,7 @@ ingress-nginx:
 
 You can use any certificate provider you are familiar with if it's compatible with the x.509 and PKCS1 standards. Our community maintains guides for the following certificate providers:
 
-- [Amazon Managed Certificates](https://community.okteto.com/t/how-do-i-configure-okteto-with-aws-certificate-manager/272)
+- [AWS Certificate Manager](https://community.okteto.com/t/how-do-i-configure-okteto-with-aws-certificate-manager/272)
 - [GoDaddy](https://community.okteto.com/t/how-do-i-bring-my-godaddy-certificate-to-okteto/578/1)
 
 If you are using [cert-manager](https://cert-manager.io/), you need to use a [DNS01](https://cert-manager.io/docs/configuration/acme/dns01/#delegated-domains-for-dns01) auth method in your [Issuer](https://cert-manager.io/docs/concepts/issuer/).

--- a/src/content/self-hosted/administration/certificates.mdx
+++ b/src/content/self-hosted/administration/certificates.mdx
@@ -32,7 +32,7 @@ ingress-nginx:
       default-ssl-certificate: $(POD_NAMESPACE)/your-ssl-certificate-secret
 ```
 
-We have community guides for the following certificate providers:
+You can use any certificate provider you are familiar with if it's compatible with the x.509 and PKCS1 standards. Our community maintains guides for the following certificate providers:
 
 - [Amazon Managed Certificates](https://community.okteto.com/t/how-do-i-configure-okteto-with-aws-certificate-manager/272)
 - [GoDaddy](https://community.okteto.com/t/how-do-i-bring-my-godaddy-certificate-to-okteto/578/1)

--- a/src/content/self-hosted/administration/certificates.mdx
+++ b/src/content/self-hosted/administration/certificates.mdx
@@ -39,7 +39,7 @@ You can use any certificate provider you are familiar with if it's compatible wi
 
 If you are using [cert-manager](https://cert-manager.io/), you need to use a [DNS01](https://cert-manager.io/docs/configuration/acme/dns01/#delegated-domains-for-dns01) auth method in your [Issuer](https://cert-manager.io/docs/concepts/issuer/).
 Check the list of supported providers [here](https://cert-manager.io/docs/configuration/acme/dns01/) for more information.
-There are community guides for using cert-manager to generate your Okteto certificcate in the following Cloud Providers:
+Our community maintains guides on how to use cert-manager together with different Cloud Providers to generate certificates for Okteto:
 
 - [Amazon Route53](https://community.okteto.com/t/how-do-i-configure-okteto-with-cert-manager-and-aws-route53/273/2)
 - [Google Cloud DNS](https://community.okteto.com/t/how-do-i-configure-okteto-with-cert-manager-and-google-cloud-dns/274/2)

--- a/src/content/self-hosted/administration/certificates.mdx
+++ b/src/content/self-hosted/administration/certificates.mdx
@@ -32,9 +32,14 @@ ingress-nginx:
       default-ssl-certificate: $(POD_NAMESPACE)/your-ssl-certificate-secret
 ```
 
+We have community guides for the following certificate providers:
+
+- [Amazon Managed Certificates](https://community.okteto.com/t/how-do-i-configure-okteto-with-aws-certificate-manager/272)
+- [GoDaddy](https://community.okteto.com/t/how-do-i-bring-my-godaddy-certificate-to-okteto/578/1)
+
 If you are using [cert-manager](https://cert-manager.io/), you need to use a [DNS01](https://cert-manager.io/docs/configuration/acme/dns01/#delegated-domains-for-dns01) auth method in your [Issuer](https://cert-manager.io/docs/concepts/issuer/).
 Check the list of supported providers [here](https://cert-manager.io/docs/configuration/acme/dns01/) for more information.
-There are community guides for the following Cloud Providers:
+There are community guides for using cert-manager to generate your Okteto certificcate in the following Cloud Providers:
 
 - [Amazon Route53](https://community.okteto.com/t/how-do-i-configure-okteto-with-cert-manager-and-aws-route53/273/2)
 - [Google Cloud DNS](https://community.okteto.com/t/how-do-i-configure-okteto-with-cert-manager-and-google-cloud-dns/274/2)


### PR DESCRIPTION
Adding links to our community blog posts for aws managed certificates and godaddy to improve the discoverability of this guides