### PR TITLE
Document the tasks done by daemonset on each node

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -461,7 +461,16 @@ The daemonset automatically configures every node of your cluster to work better
 - `extraEnv`: Environment variables to be set on the daemonset containers.
 - `labels`: Labels to add to the daemonset pods.
 - `image`: Container image used by the daemonset pods.
-- `initContainers.privateCA.image`: InitContainer image used by the daemon pods. Defaults to `busybox`
+
+The daemonset does the following tasks on each node:
+
+- [Overrides](self-hosted/administration/configuration.mdx#overrideregistryresolution) the Okteto Registry hostname resolution to use internal IPs.
+- [Overrides](self-hosted/administration/configuration.mdx#overridefilewatchers) the default kernel values for file watchers on every node.
+- Configures the kubelet with registry credentials for [private registries](self-hosted/administration/configuration.mdx#privateregistry).
+- Installs your CA if `wildcardCertificate.privateCA` is enabled.
+- Installs a CA if using self-signed certificates (`wildcardCertificate.create: true`).
+
+You can restrict the nodes where the daemonset is deployed using the `tolerations.devPool` field.
 
 ### frontend
 

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -462,7 +462,7 @@ The daemonset automatically configures every node of your cluster to work better
 - `labels`: Labels to add to the daemonset pods.
 - `image`: Container image used by the daemonset pods.
 
-The daemonset does the following tasks on each node:
+The daemonset performs the following tasks on each node:
 
 - [Overrides](self-hosted/administration/configuration.mdx#overrideregistryresolution) the Okteto Registry hostname resolution to use internal IPs.
 - [Overrides](self-hosted/administration/configuration.mdx#overridefilewatchers) the default kernel values for file watchers on every node.
@@ -470,7 +470,12 @@ The daemonset does the following tasks on each node:
 - Installs your CA if `wildcardCertificate.privateCA` is enabled.
 - Installs a CA if using self-signed certificates (`wildcardCertificate.create: true`).
 
-You can restrict the nodes where the daemonset is deployed using the `tolerations.devPool` field.
+You can restrict the nodes where the daemonset is deployed using [tolerations](self-hosted/administration/configuration.mdx#tolerations):
+
+```
+tolerations:
+  devPool: dev
+```
 
 ### frontend
 

--- a/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
@@ -461,7 +461,16 @@ The daemonset automatically configures every node of your cluster to work better
 - `extraEnv`: Environment variables to be set on the daemonset containers.
 - `labels`: Labels to add to the daemonset pods.
 - `image`: Container image used by the daemonset pods.
-- `initContainers.privateCA.image`: InitContainer image used by the daemon pods. Defaults to `busybox`
+
+The daemonset does the following tasks on each node:
+
+- [Overrides](self-hosted/administration/configuration.mdx#overrideregistryresolution) the Okteto Registry hostname resolution to use internal IPs.
+- [Overrides](self-hosted/administration/configuration.mdx#overridefilewatchers) the default kernel values for file watchers on every node.
+- Configures the kubelet with registry credentials for [private registries](self-hosted/administration/configuration.mdx#privateregistry).
+- Installs your CA if `wildcardCertificate.privateCA` is enabled.
+- Installs a CA if using self-signed certificates (`wildcardCertificate.create: true`).
+
+You can restrict the nodes where the daemonset is deployed using the `tolerations.devPool` field.
 
 ### frontend
 

--- a/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
@@ -462,7 +462,7 @@ The daemonset automatically configures every node of your cluster to work better
 - `labels`: Labels to add to the daemonset pods.
 - `image`: Container image used by the daemonset pods.
 
-The daemonset does the following tasks on each node:
+The daemonset performs the following tasks on each node:
 
 - [Overrides](self-hosted/administration/configuration.mdx#overrideregistryresolution) the Okteto Registry hostname resolution to use internal IPs.
 - [Overrides](self-hosted/administration/configuration.mdx#overridefilewatchers) the default kernel values for file watchers on every node.
@@ -470,7 +470,12 @@ The daemonset does the following tasks on each node:
 - Installs your CA if `wildcardCertificate.privateCA` is enabled.
 - Installs a CA if using self-signed certificates (`wildcardCertificate.create: true`).
 
-You can restrict the nodes where the daemonset is deployed using the `tolerations.devPool` field.
+You can restrict the nodes where the daemonset is deployed using [tolerations](self-hosted/administration/configuration.mdx#tolerations):
+
+```
+tolerations:
+  devPool: dev
+```
 
 ### frontend
 


### PR DESCRIPTION
Several customers are asking about the tasks done by our daemonset on every node.
I document it in a single place, when talking abouf the daemonset. I also added a reference to tolerations, because they can be used to limit the scope of the nodes where the daemonset is deployed