### PR TITLE
Update mount secrets to use "target" instead of "dst"

### DIFF
--- a/src/content/administration/dashboard.mdx
+++ b/src/content/administration/dashboard.mdx
@@ -85,7 +85,7 @@ build:
 You can refer to this secret from your Dockerfile using the syntax below:
 
 ```
-RUN --mount=type=secret,id=my_env,dst=/etc/secrets/.env cat /etc/secrets/.env
+RUN --mount=type=secret,id=my_env,target=/etc/secrets/.env cat /etc/secrets/.env
 ```
 
 The content of the `.env` file would be:


### PR DESCRIPTION
Although `dst` keeps working, docker/buildkit updated the docs to use `target`:
https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypesecret