### PR TITLE
Fixes minor missing code snippet in all version

### DIFF
--- a/src/content/cloud/okteto-cli.mdx
+++ b/src/content/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-0.11/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-0.11/cloud/okteto-cli.mdx
@@ -59,7 +59,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-0.12/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-0.12/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-0.13/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-0.13/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-0.14/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-0.14/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-0.15/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-0.15/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-1.0/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-1.0/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-1.1/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-1.1/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-1.2/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-1.2/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-1.3/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-1.3/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables

--- a/versioned_docs/version-1.4/cloud/okteto-cli.mdx
+++ b/versioned_docs/version-1.4/cloud/okteto-cli.mdx
@@ -58,7 +58,7 @@ dev:
 ```
 
 This example shows how to `build` the container image of the **api** microservice, how to `deploy` the application using its helm chart,
-and how to `dev`elop on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
+and how to `develop` on the **api** microservice by synchronizing the local filesystem on the container path `/usr/src/app`.
 If you want to learn more about what all you can configure in this manifest, head over to the [Okteto Manifest Reference](reference/manifest.mdx).
 
 ### Built-in Environment Variables


### PR DESCRIPTION
[Okteto Manifests](https://www.okteto.com/docs/cloud/okteto-cli/#okteto-manifest) section misses a minor code snippet in the following line:

_This example shows how to `build` the container image of the api microservice, how to `deploy` the application using its helm chart, and how to `dev`elop on the api microservice by synchronizing the local filesystem on the container path `/usr/src/app`._

Notice the use of `dev`elop. It should be `develop`.