### PR TITLE
Fix search input overlapping CTA

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -298,3 +298,18 @@ h1, h2, h3, h4, h5, h6 {
 .dropdown__menu li:last-child {
   display: block;
 }
+
+@media (max-width: 996px) {
+  .searchBox_qEbK,
+  div[class*="searchBox"] {
+    position: relative;
+    margin-left: auto;
+  }
+}
+
+
+@media (max-width: 500px) {
+  .navbar__items--right {
+    display: none;
+  }
+}


### PR DESCRIPTION
Make sure the search input doesn’t overlap the "Get Free Trial" CTA in the header



## Screenshots


### Before

<img width="789" alt="Screenshot 2023-02-20 at 2 01 06 PM" src="https://user-images.githubusercontent.com/6691035/220182271-639c628f-7b9f-4d32-805e-6f4d969aa0ef.png">


### After
<img width="976" alt="Screenshot 2023-02-20 at 2 00 02 PM" src="https://user-images.githubusercontent.com/6691035/220182193-9e3cde0a-c089-4b2d-9322-5cb8d9cc7b82.png">
<img width="589" alt="Screenshot 2023-02-20 at 2 00 08 PM" src="https://user-images.githubusercontent.com/6691035/220182194-e8027cb8-59c6-4944-af1e-cef7e91ed772.png">

