### PR TITLE
Add docs for maxServices, maxLoadBalancers and maxNodePorts

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -969,6 +969,9 @@ Enables [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-qu
   - `maxPods`: Maximum number of pods per namespace.
   - `maxReplicationControllers`: Maximum number of replication controllers per namespace.
   - `maxSecrets`: Maximum number of secrets per namespace.
+  - `maxServices`: Maximum number of services per namespace.
+  - `maxLoadBalancers`: Maximum number of services of type `LoadBalancer` per namespace.
+  - `maxNodePorts`: Maximum number of services of type `NodePort` per namespace.
   - `maxConfigMaps`: Maximum number of config maps per namespace.
   - `maxPVCs`: Maximum number of persistent volume claims per namespace.
   - `maxVolumeSnapshots`: Maximum number of volume snapshots per namespace.


### PR DESCRIPTION
Chart 1.6.0 comes with the ability to define quotas for max services, load balancers and node ports