### PR TITLE
docs: add release notes for 1.5.1 and 1.4.3

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -5,6 +5,13 @@ sidebar_label: Release Notes
 id: releases
 ---
 
+## 1.5.1
+6 March, 2023
+
+### Bugfixes
+
+- Fixed an issue that prevented users from authenticating against the registry when using a custom secret (`.Values.registry.ingress.tlsSecret`).
+
 ## 1.5.0
 14 February, 2023
 
@@ -41,6 +48,13 @@ id: releases
 - Fixed issue in the OpenID configuration that prevented using ADFS as the identity provider
 - Get claims from access token when `ADFS` resource is given
 - Added support for volume snapshots in EKS 1.23
+
+## 1.4.3
+6 March, 2023
+
+### Bugfixes
+
+- Fixed an issue that prevented users from authenticating against the registry when using a custom secret (`.Values.registry.ingress.tlsSecret`).
 
 ## 1.4.2
 February 7, 2023

--- a/versioned_docs/version-1.4/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.4/self-hosted/install/releases.mdx
@@ -5,6 +5,13 @@ sidebar_label: Release Notes
 id: releases
 ---
 
+## 1.4.3
+6 March, 2023
+
+### Bugfixes
+
+- Fixed an issue that prevented users from authenticating against the registry when using a custom secret (`.Values.registry.ingress.tlsSecret`).
+
 ## 1.4.2
 February 7, 2023
 

--- a/versioned_docs/version-1.5/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.5/self-hosted/install/releases.mdx
@@ -5,6 +5,13 @@ sidebar_label: Release Notes
 id: releases
 ---
 
+## 1.5.1
+6 March, 2023
+
+### Bugfixes
+
+- Fixed an issue that prevented users from authenticating against the registry when using a custom secret (`.Values.registry.ingress.tlsSecret`).
+
 ## 1.5.0
 14 February, 2023
 
@@ -41,6 +48,13 @@ id: releases
 - Fixed issue in the OpenID configuration that prevented using ADFS as the identity provider
 - Get claims from access token when `ADFS` resource is given
 - Added support for volume snapshots in EKS 1.23
+
+## 1.4.3
+6 March, 2023
+
+### Bugfixes
+
+- Fixed an issue that prevented users from authenticating against the registry when using a custom secret (`.Values.registry.ingress.tlsSecret`).
 
 ## 1.4.2
 February 7, 2023


### PR DESCRIPTION
This PR adds release notes for 1.5.1 and 1.4.3, which contains bugfix
for registry authentication when using a custom secret.