### PR TITLE
Update Getting Started with Okteto tutorial with instructions for how  to fix the error when there is no storage left on the okteto cloud

### DIFF
--- a/versioned_docs/version-1.0/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.0/tutorials/getting-started-with-okteto.mdx
@@ -252,8 +252,8 @@ cindy:hello-world app>
 ```
 **Note:** If you come across the following error `couldn't activate your development container\n  
 error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
-this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
-storage on your okteto cloud and try running `okteto up` again.
+this means that there is no space left on your current namespace at okteto cloud to deploy other application. It is recommended to allot
+storage to your current namespace and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.0/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.0/tutorials/getting-started-with-okteto.mdx
@@ -250,6 +250,10 @@ $ okteto up
 Welcome to your development container. Happy coding!
 cindy:hello-world app>
 ```
+**Note:** If you come across the following error `couldn't activate your development container\n  
+error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
+this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
+storage on your okteto cloud and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.1/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.1/tutorials/getting-started-with-okteto.mdx
@@ -252,8 +252,8 @@ cindy:hello-world app>
 ```
 **Note:** If you come across the following error `couldn't activate your development container\n  
 error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
-this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
-storage on your okteto cloud and try running `okteto up` again.
+this means that there is no space left in your current namespace at okteto cloud to deploy other application. It is recommended to allot
+storage in your current working namespace and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.1/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.1/tutorials/getting-started-with-okteto.mdx
@@ -250,6 +250,10 @@ $ okteto up
 Welcome to your development container. Happy coding!
 cindy:hello-world app>
 ```
+**Note:** If you come across the following error `couldn't activate your development container\n  
+error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
+this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
+storage on your okteto cloud and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.2/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.2/tutorials/getting-started-with-okteto.mdx
@@ -252,8 +252,8 @@ cindy:hello-world app>
 ```
 **Note:** If you come across the following error `couldn't activate your development container\n  
 error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
-this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
-storage on your okteto cloud and try running `okteto up` again.
+this means that there is no space left in your current namespace at okteto cloud to deploy other application. It is recommended to allot
+storage in your current working namespace and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.2/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.2/tutorials/getting-started-with-okteto.mdx
@@ -250,6 +250,10 @@ $ okteto up
 Welcome to your development container. Happy coding!
 cindy:hello-world app>
 ```
+**Note:** If you come across the following error `couldn't activate your development container\n  
+error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
+this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
+storage on your okteto cloud and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.3/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.3/tutorials/getting-started-with-okteto.mdx
@@ -252,8 +252,8 @@ cindy:hello-world app>
 ```
 **Note:** If you come across the following error `couldn't activate your development container\n  
 error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
-this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
-storage on your okteto cloud and try running `okteto up` again.
+this means that there is no space left in your current namespace at okteto cloud to deploy other application. It is recommended to allot
+storage in your current working namespace and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.3/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.3/tutorials/getting-started-with-okteto.mdx
@@ -250,6 +250,10 @@ $ okteto up
 Welcome to your development container. Happy coding!
 cindy:hello-world app>
 ```
+**Note:** If you come across the following error `couldn't activate your development container\n  
+error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
+this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
+storage on your okteto cloud and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.4/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.4/tutorials/getting-started-with-okteto.mdx
@@ -252,8 +252,8 @@ cindy:hello-world app>
 ```
 **Note:** If you come across the following error `couldn't activate your development container\n  
 error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
-this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
-storage on your okteto cloud and try running `okteto up` again.
+this means that there is no space left in your current namespace at okteto cloud to deploy other application. It is recommended to allot
+storage in your current working namespace and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.4/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.4/tutorials/getting-started-with-okteto.mdx
@@ -250,6 +250,10 @@ $ okteto up
 Welcome to your development container. Happy coding!
 cindy:hello-world app>
 ```
+**Note:** If you come across the following error `couldn't activate your development container\n  
+error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
+this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
+storage on your okteto cloud and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.5/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.5/tutorials/getting-started-with-okteto.mdx
@@ -252,8 +252,8 @@ cindy:hello-world app>
 ```
 **Note:** If you come across the following error `couldn't activate your development container\n  
 error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
-this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
-storage on your okteto cloud and try running `okteto up` again.
+this means that there is no space left in your current namespace at okteto cloud to deploy other application. It is recommended to allot
+storage in your current working namespace and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:

--- a/versioned_docs/version-1.5/tutorials/getting-started-with-okteto.mdx
+++ b/versioned_docs/version-1.5/tutorials/getting-started-with-okteto.mdx
@@ -250,6 +250,10 @@ $ okteto up
 Welcome to your development container. Happy coding!
 cindy:hello-world app>
 ```
+**Note:** If you come across the following error `couldn't activate your development container\n  
+error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota:`, 
+this means that there is no storage left on your okteto cloud to deploy other application. It is recommended to remove the
+storage on your okteto cloud and try running `okteto up` again.
 
 Working in your development container is the same as working on your local machine.
 Start the application by running the following command:


### PR DESCRIPTION
The [Getting Started with Okteto](https://www.okteto.com/docs/tutorials/getting-started-with-okteto/) is a great place to learn about the use of Okteto and Okteto manifest. However, When we try to run `okteto up`, it should work fine. However, sometimes we come across errors like:

> couldn't activate your development container\n    error creating kubernetes volume claim: persistentvolumeclaims \"hello-world-okteto\" is forbidden: exceeded quota: nitishkumar06, requested: requests.storage=2Gi, used: requests.storage=5Gi, limited: requests.storage=5Gi" action=711c3401-9ccc-41df-b192-a68113a9aa4f version=2.12.1

Although this error is easy to solve, just delete the unused volume/storage on okteto cloud. However, I believe this would be much better if we mentioned the solution to this error in the docs.