### PR TITLE
Release notes for release 1.6

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -26,7 +26,13 @@ This guide will assume that your domain is registered in [AzureDNS](https://docs
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
+We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
+Okteto supports Kubernetes versions 1.22 through 1.24.
+
+We recommend the following specs:
+- v1.23
+- A pool with at least 3 `Standard D4` nodes
+- 250 GB per Standard SSD Managed Disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -26,13 +26,7 @@ This guide will assume that your domain is registered in [AzureDNS](https://docs
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
-Okteto supports Kubernetes versions 1.21 through 1.23.
-
-We recommend the following specs:
-- v1.23
-- A pool with at least 3 `Standard D4` nodes
-- 250 GB per Standard SSD Managed Disk
+We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -29,7 +29,14 @@ In the rest of this guide, we will refer to this subdomain as `DOMAIN`.
 
 ### Deploy a Kubernetes cluster
 
-If you are not familiar with this step, we recommend that you follow DigitalOcean's [cluster creation guide](https://www.digitalocean.com/docs/kubernetes/how-to/create-clusters/) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
+If you are not familiar with this step, we recommend that you follow DigitalOcean's [cluster creation guide](https://www.digitalocean.com/docs/kubernetes/how-to/create-clusters/).
+Okteto supports Kubernetes versions 1.22 through 1.24.
+
+To get started with Okteto, follow these specs:
+
+- v1.23
+- A pool with at least 2 nodes (4CPUs and 16GBs each) without autoscalability
+- 250 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -29,14 +29,7 @@ In the rest of this guide, we will refer to this subdomain as `DOMAIN`.
 
 ### Deploy a Kubernetes cluster
 
-If you are not familiar with this step, we recommend that you follow DigitalOcean's [cluster creation guide](https://www.digitalocean.com/docs/kubernetes/how-to/create-clusters/).
-Okteto supports Kubernetes versions 1.21 through 1.23.
-
-To get started with Okteto, follow these specs:
-
-- v1.23
-- A pool with at least 2 nodes (4CPUs and 16GBs each) without autoscalability
-- 250 GB per disk
+If you are not familiar with this step, we recommend that you follow DigitalOcean's [cluster creation guide](https://www.digitalocean.com/docs/kubernetes/how-to/create-clusters/) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -27,7 +27,13 @@ This guide will assume that your domain is registered in [Amazon Route53](https:
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
+We recommend that you follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).
+Okteto supports Kubernetes versions 1.22 through 1.24.
+
+We recommend the following specs:
+- v1.23
+- A pool with at least 3 `m4.xlarge` nodes
+- 250 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -27,13 +27,7 @@ This guide will assume that your domain is registered in [Amazon Route53](https:
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).
-Okteto supports Kubernetes versions 1.21 through 1.23.
-
-We recommend the following specs:
-- v1.23
-- A pool with at least 3 `m4.xlarge` nodes
-- 250 GB per disk
+We recommend that you follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -27,7 +27,13 @@ This guide will assume that your domain is registered in Google's [Cloud DNS](ht
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Google's [GKE cluster creation guide](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
+We recommend that you follow Google's [GKE cluster creation guide](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster).
+Okteto supports Kubernetes versions 1.22 through 1.24.
+
+We recommend the following specs:
+- v1.23
+- A pool with at least 3 `n1-standard-4` nodes
+- 250 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -27,13 +27,7 @@ This guide will assume that your domain is registered in Google's [Cloud DNS](ht
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Google's [GKE cluster creation guide](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster).
-Okteto supports Kubernetes versions 1.21 through 1.23.
-
-We recommend the following specs:
-- v1.23
-- A pool with at least 3 `n1-standard-4` nodes
-- 250 GB per disk
+We recommend that you follow Google's [GKE cluster creation guide](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:

--- a/src/content/self-hosted/install/preparation.mdx
+++ b/src/content/self-hosted/install/preparation.mdx
@@ -36,8 +36,8 @@ Okteto supports Kubernetes versions 1.22 through 1.24.
 
 We recommend the following specs:
 - v1.23
-- A pool with at least 3 nodes with a minimum of 4CPUs and 16 GB of Memory
-- 100 GB per disk
+- A pool with at least 3 nodes with a minimum of 4CPUs and 32 GB of Memory
+- 250 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 

--- a/src/content/self-hosted/install/preparation.mdx
+++ b/src/content/self-hosted/install/preparation.mdx
@@ -36,8 +36,8 @@ Okteto supports Kubernetes versions 1.22 through 1.24.
 
 We recommend the following specs:
 - v1.23
-- A pool with at least 3 nodes with a minimum of 4CPUs and 32 GB of Memory
-- 250 GB per disk
+- A pool with at least 3 nodes with a minimum of 4CPUs and 16 GB of Memory
+- 100 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 

--- a/src/content/self-hosted/install/preparation.mdx
+++ b/src/content/self-hosted/install/preparation.mdx
@@ -32,7 +32,7 @@ Follow [this guide](self-hosted/administration/certificates.mdx) if you want to 
 ### Deploy a Kubernetes cluster
 
 We recommend that you follow your cloud provider's Kubernetes cluster creation guide.
-Okteto supports Kubernetes versions 1.21 through 1.23.
+Okteto supports Kubernetes versions 1.22 through 1.24.
 
 We recommend the following specs:
 - v1.23
@@ -42,7 +42,7 @@ We recommend the following specs:
 You'll be using the cluster's API server endpoint when configuring Okteto.
 
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
- 
+
 ### Installing kubectl
 
 Follow the official Kubernetes documentation for [installing kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -39,7 +39,8 @@ In some cases, there is a race condition recreating the controller pods in which
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
 - Public override support for self-signed certificates and bring your own certificate
-- The wake operation will now wake up dependent services first, following the same order as when the environment was created. 
+- The wake operation will now wake up dependent services first, following the same order as when the environment was created.
+- Add support for [dynamic endpoints for external resources](reference/manifest#use-dynamic-endpoints-for-an-external-url)
 
 ### Improvements
 

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -5,6 +5,46 @@ sidebar_label: Release Notes
 id: releases
 ---
 
+## 1.6.0
+13 March, 2023
+
+### Deprecation Notice
+- Support for Kubernetes [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md) has been deprecated and will be removed next release.
+
+### Features
+
+- Update okteto cli version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
+- Default ingress class for ingresses managed by okteto is `okteto-nginx`. All ingresses managed by okteto are migrated automatically during the upgrade
+- Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
+- Public override support for self-signed certificates and bring your own certificate
+
+### Improvements
+
+- Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
+- Several improvements in the UI to keep the status updated accordingly with the status in user's dev environments
+- Allow users to access to namespaces that are being terminated to see the operation logs
+- Wake operation takes into account dependencies between dev environments to wake dependant environments first
+- Added input autofocus in several dialogs
+- Improve experience in "New namespace" dialog to enable faster the button
+- Filter branches results by search term in GitHub deploy dialog
+- Remove redundant headers in "Settings" view
+- Include public override domain to self-signed wildcard certificate
+- Do not autodestroy GC job when it ends
+- Private endpoints cookie is now set in the backend and specified as "httpOnly"
+- GC deletes pods stuck in `Failed` phase with `NodeAffinity` reason
+- Upgrade Reloader dependency to [1.0.5](https://github.com/stakater/Reloader/releases/tag/v1.0.5)
+
+### Bugfixes
+
+- Skip volume snapshots deletion as part of destroy all operation if "include volumes" check is not selected
+- Fix "Destroy all", "Delete namespace" and "Wake namespace" operations when using private CAs or self-signed certificates
+- Display the correct operation name in logs when deleting a namespace or destroying all resources within a namespace
+- Avoid duplicated log lines when the browser visibility changes
+- Self-signed certificate is recreated when subdomain or public override changes after an upgrade
+- Fixed view transition when a destroy namespace operation is retried
+- Fixed missing custom icons on external resources
+- Fixed autofocus on confirm dialogs
+
 ## 1.5.1
 6 March, 2023
 
@@ -39,8 +79,8 @@ id: releases
 - "Get Started" button is not active while running a "destroy all" job
 - Fix namespace wake up when endpoint requests is sent to paths other than root.
 - Keep ingress class on wake if ingress class is different than "sleeping"
-- Ignore read only Kubernetes API Extension Servers (e.g. metrics.k8s.io) if unavailable on destroy all job runs. 
-- When using Divert, some scenarios may cause its ingress configuration to be dropped 
+- Ignore read only Kubernetes API Extension Servers (e.g. metrics.k8s.io) if unavailable on destroy all job runs.
+- When using Divert, some scenarios may cause its ingress configuration to be dropped
 - Don't show a pointer cursor type in log lines
 - Autopreviews are now being deleted when PR is merged or closed
 - Correctly alignment of non private/divert endpoints and repository at resource details section.

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -38,7 +38,7 @@ In some cases, there is a race condition recreating the controller pods in which
 - Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
-- [Public override support](self-hosted/administration/configuration.mdx#publicOverride) for self-signed certificates and bring your own certificate
+- [Public override support](self-hosted/administration/configuration.mdx#publicoverride) for self-signed certificates and bring your own certificate
 - The wake operation will now wake up dependent services first, following the same order as when the environment was created.
 - Add support for [dynamic endpoints for external resources](reference/manifest.mdx#use-dynamic-endpoints-for-an-external-url)
 
@@ -60,7 +60,7 @@ In some cases, there is a race condition recreating the controller pods in which
 - Fix "Destroy all", "Delete namespace" and "Wake namespace" operations when using private CAs or self-signed certificates
 - Display the correct operation name in logs when deleting a namespace or destroying all resources within a namespace
 - Avoid duplicated log lines when the browser visibility changes
-- Self-signed certificate is recreated when [subdomain](self-hosted/administration/configuration.mdx#subdomain) or [publicOverride](self-hosted/administration/configuration.mdx#publicOverride) changes after an upgrade
+- Self-signed certificate is recreated when [subdomain](self-hosted/administration/configuration.mdx#subdomain) or [publicOverride](self-hosted/administration/configuration.mdx#publicoverride) changes after an upgrade
 - Fixed view transition when a destroy namespace operation is retried
 - Fixed missing [custom icons on external resources](reference/manifest.mdx#icon-string-optional)
 - Fixed autofocus on confirm dialogs

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -10,7 +10,9 @@ id: releases
 
 ### Breaking changes
 
-This version comes with a breaking change. The default ingress class for ingresses managed by okteto is `okteto-nginx` instead of `nginx` to prevent colissions with other controllers that might be already installed in the cluster. All ingresses managed by Okteto will be automatically updated. No action is required from the user. If you want to keep the previous value (`nginx`), you would need to set the following values in your helm values file:
+This version comes with a breaking change. The default ingress class for ingresses managed by okteto changed from `nginx` to `okteto-nginx`  to prevent collisions with other controllers that might be already installed in the cluster. There is no action required from the user,  all ingresses managed by Okteto will be automatically updated as part of the upgrade.
+
+If you want to continue to use the previous value (`nginx`), you can do it by setting the following values in your helm values file:
 
 ```yaml
 ingress:
@@ -37,16 +39,16 @@ In some cases, there is a race condition recreating the controller pods in which
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
 - Public override support for self-signed certificates and bring your own certificate
-- Wake operation takes into account dependencies between dev environments to wake dependant environments first
+- The wake operation will now wake up dependent services first, following the same order as when the environment was created. 
 
 ### Improvements
 
 - Several improvements in the UI to keep the status updated accordingly with the status in user's dev environments
 - Allow users to access to namespaces that are being terminated to see the operation logs
 - Added input autofocus in several dialogs
-- Improve experience in "New namespace" dialog to enable faster the button
-- Filter branches results by search term in GitHub deploy dialog
-- Remove redundant headers in "Settings" view
+- The "Create Namespace" button is now enabled immediately after you start writing the name of the namespace in the "New Namespace" dialog.
+- You can now filter the available branches in the GitHub deploy dialog
+- Simplified the admin dashboard by removing duplicated titles in every section.
 - Do not autodestroy GC job when it ends. Last 3 executions of the job will be kept, so job logs can be accessed
 - Private endpoints cookie is now set in the backend and specified as "httpOnly"
 - Upgrade Reloader dependency to [1.0.5](https://github.com/stakater/Reloader/releases/tag/v1.0.5)

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -38,9 +38,9 @@ In some cases, there is a race condition recreating the controller pods in which
 - Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
-- Public override support for self-signed certificates and bring your own certificate
+- [Public override support](self-hosted/administration/configuration.mdx#publicOverride) for self-signed certificates and bring your own certificate
 - The wake operation will now wake up dependent services first, following the same order as when the environment was created.
-- Add support for [dynamic endpoints for external resources](reference/manifest#use-dynamic-endpoints-for-an-external-url)
+- Add support for [dynamic endpoints for external resources](reference/manifest.mdx#use-dynamic-endpoints-for-an-external-url)
 
 ### Improvements
 

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -8,7 +8,21 @@ id: releases
 ## 1.6.0
 13 March, 2023
 
-This version comes with a breaking change. The default ingress class for ingresses managed by okteto is `okteto-nginx` instead of `nginx` to prevent colissions with other controllers that might be already installed in the cluster. All ingresses managed by Okteto will be automatically updated. No action is required from the user. If you want to keep the previous value (`nginx`), you would need to set the keys `ingress.oktetoIngressClass` and `ingress.class` to `nginx` in your helm values file before upgrading Okteto.
+This version comes with a breaking change. The default ingress class for ingresses managed by okteto is `okteto-nginx` instead of `nginx` to prevent colissions with other controllers that might be already installed in the cluster. All ingresses managed by Okteto will be automatically updated. No action is required from the user. If you want to keep the previous value (`nginx`), you would need to set the following values in your helm values file:
+
+```yaml
+ingress:
+  class: nginx
+  oktetoIngressClass: nginx
+ingress-nginx:
+  controller:
+    ingressClass: nginx
+    ingressClassResource:
+      name: nginx
+      controllerValue: "k8s.io/ingress-nginx"
+```
+
+
 
 In some cases, there is a race condition recreating the controller pods in which a controller pod starts before the new ingress class is created in the cluster and that generates 404 errors when accessing Okteto or dev environments. If that happens, a rollout of the controller deployment fixes the issue (`kubectl rollout restart deployment <ingress-controller-deployment-name> -n okteto`).
 

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -8,6 +8,8 @@ id: releases
 ## 1.6.0
 13 March, 2023
 
+### Breaking changes
+
 This version comes with a breaking change. The default ingress class for ingresses managed by okteto is `okteto-nginx` instead of `nginx` to prevent colissions with other controllers that might be already installed in the cluster. All ingresses managed by Okteto will be automatically updated. No action is required from the user. If you want to keep the previous value (`nginx`), you would need to set the following values in your helm values file:
 
 ```yaml
@@ -24,7 +26,7 @@ ingress-nginx:
 
 
 
-In some cases, there is a race condition recreating the controller pods in which a controller pod starts before the new ingress class is created in the cluster and that generates 404 errors when accessing Okteto or dev environments. If that happens, a rollout of the controller deployment fixes the issue (`kubectl rollout restart deployment <ingress-controller-deployment-name> -n okteto`).
+In some cases, there is a race condition recreating the controller pods in which a controller pod starts before the new ingress class is created in the cluster and that generates 404 errors when accessing Okteto or dev environments. For that reason, we recommend to rollout the ingress controller deployment to avoid this issue (`kubectl rollout restart deployment <ingress-controller-deployment-name> -n okteto`).
 
 ### Deprecation Notice
 - Support for Kubernetes [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md) has been deprecated and will be removed next release.

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -13,17 +13,17 @@ id: releases
 
 ### Features
 
+- Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
 - Default ingress class for ingresses managed by okteto is `okteto-nginx`. All ingresses managed by okteto are migrated automatically during the upgrade
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
 - Public override support for self-signed certificates and bring your own certificate
+- Wake operation takes into account dependencies between dev environments to wake dependant environments first
 
 ### Improvements
 
-- Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
 - Several improvements in the UI to keep the status updated accordingly with the status in user's dev environments
 - Allow users to access to namespaces that are being terminated to see the operation logs
-- Wake operation takes into account dependencies between dev environments to wake dependant environments first
 - Added input autofocus in several dialogs
 - Improve experience in "New namespace" dialog to enable faster the button
 - Filter branches results by search term in GitHub deploy dialog

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -8,6 +8,10 @@ id: releases
 ## 1.6.0
 13 March, 2023
 
+This version comes with a breaking change. The default ingress class for ingresses managed by okteto is `okteto-nginx` instead of `nginx` to prevent colissions with other controllers that might be already installed in the cluster. All ingresses managed by Okteto will be automatically updated. No action is required from the user. If you want to keep the previous value (`nginx`), you would need to set the keys `ingress.oktetoIngressClass` and `ingress.class` to `nginx` in your helm values file before upgrading Okteto.
+
+In some cases, there is a race condition recreating the controller pods in which a controller pod starts before the new ingress class is created in the cluster and that generates 404 errors when accessing Okteto or dev environments. If that happens, a rollout of the controller deployment fixes the issue (`kubectl rollout restart deployment <ingress-controller-deployment-name> -n okteto`).
+
 ### Deprecation Notice
 - Support for Kubernetes [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md) has been deprecated and will be removed next release.
 
@@ -15,7 +19,6 @@ id: releases
 
 - Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
-- Default ingress class for ingresses managed by okteto is `okteto-nginx`. All ingresses managed by Okteto will be automatically updated. No action is required from the user
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
 - Public override support for self-signed certificates and bring your own certificate
 - Wake operation takes into account dependencies between dev environments to wake dependant environments first

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -13,7 +13,7 @@ id: releases
 
 ### Features
 
-- Update okteto cli version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
+- Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
 - Default ingress class for ingresses managed by okteto is `okteto-nginx`. All ingresses managed by okteto are migrated automatically during the upgrade
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
 - Public override support for self-signed certificates and bring your own certificate
@@ -28,7 +28,6 @@ id: releases
 - Improve experience in "New namespace" dialog to enable faster the button
 - Filter branches results by search term in GitHub deploy dialog
 - Remove redundant headers in "Settings" view
-- Include public override domain to self-signed wildcard certificate
 - Do not autodestroy GC job when it ends
 - Private endpoints cookie is now set in the backend and specified as "httpOnly"
 - GC deletes pods stuck in `Failed` phase with `NodeAffinity` reason

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -15,7 +15,7 @@ id: releases
 
 - Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
-- Default ingress class for ingresses managed by okteto is `okteto-nginx`. All ingresses managed by okteto are migrated automatically during the upgrade
+- Default ingress class for ingresses managed by okteto is `okteto-nginx`. All ingresses managed by Okteto will be automatically updated. No action is required from the user
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
 - Public override support for self-signed certificates and bring your own certificate
 - Wake operation takes into account dependencies between dev environments to wake dependant environments first
@@ -28,9 +28,8 @@ id: releases
 - Improve experience in "New namespace" dialog to enable faster the button
 - Filter branches results by search term in GitHub deploy dialog
 - Remove redundant headers in "Settings" view
-- Do not autodestroy GC job when it ends
+- Do not autodestroy GC job when it ends. Last 3 executions of the job will be kept, so job logs can be accessed
 - Private endpoints cookie is now set in the backend and specified as "httpOnly"
-- GC deletes pods stuck in `Failed` phase with `NodeAffinity` reason
 - Upgrade Reloader dependency to [1.0.5](https://github.com/stakater/Reloader/releases/tag/v1.0.5)
 
 ### Bugfixes
@@ -39,10 +38,11 @@ id: releases
 - Fix "Destroy all", "Delete namespace" and "Wake namespace" operations when using private CAs or self-signed certificates
 - Display the correct operation name in logs when deleting a namespace or destroying all resources within a namespace
 - Avoid duplicated log lines when the browser visibility changes
-- Self-signed certificate is recreated when subdomain or public override changes after an upgrade
+- Self-signed certificate is recreated when [subdomain](self-hosted/administration/configuration.mdx#subdomain) or [publicOverride](self-hosted/administration/configuration.mdx#publicOverride) changes after an upgrade
 - Fixed view transition when a destroy namespace operation is retried
-- Fixed missing custom icons on external resources
+- Fixed missing [custom icons on external resources](reference/manifest.mdx#icon-string-optional)
 - Fixed autofocus on confirm dialogs
+- GC deletes pods stuck in `Failed` phase with `NodeAffinity` reason
 
 ## 1.5.1
 6 March, 2023

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -26,13 +26,7 @@ This guide will assume that your domain is registered in [AzureDNS](https://docs
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
-Okteto supports Kubernetes versions 1.21 through 1.23.
-
-We recommend the following specs:
-- v1.23
-- A pool with at least 3 `Standard D4` nodes
-- 250 GB per Standard SSD Managed Disk
+We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 Run the following command to obtain your cluster's API server endpoint:


### PR DESCRIPTION
Release notes for `1.6`

There is a couple of things left:
* Documentation for 2 features: The default ingress class we have changed in `1.6` and the public override public availability and the changes related to the private endpoints handler. @jpf-okteto is working on them. The idea would be to include a link to those documents in the corresponding feature point
* CVE fixes included in the release. There were several but I'm not sure which ones. @jpf-okteto once you finish the other documentation tasks, can you include those points in the release notes?