### PR TITLE
Add a note for git submodules when using GitLab preview environments

### DIFF
--- a/src/content/cloud/preview-environments/gitlab.mdx
+++ b/src/content/cloud/preview-environments/gitlab.mdx
@@ -101,6 +101,7 @@ A few recommendations when creating your preview environment:
 - Create a preview environment per branch/merge request to keep things isolated. We use both `$CI_BUILD_REF_NAME` and `$OKTETO_USERNAME` in the name to ensure the namespace is unique and that we only create one per branch.
 - Pass the URL of your preview environment using the `environment.url` key. That way, the reviewers can directly go to the preview environment from GitLab.
 - Delete both the preview environment, and the namespace when the branch is deleted to cut down on manual deletion.
+- Overwrite `CI_REPOSITORY_URL` with the git SSH URL of your repo, and configure [SSH access to your private repos](administration/private-repositories/ssh-key.mdx). This is especially relevant if your repo has private git submodules.
 
 > Learn more about [the okteto CLI here](reference/cli.mdx).
 


### PR DESCRIPTION
Users need to use the git SSH URL of their repos in order to make it work with git submodules.
We should fix this at the product level, but in the meantime, we can document it as a recommendation