### PR TITLE
Add root path redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -68,6 +68,11 @@
   status = 301
 
 [[redirects]]
+  from = "/"
+  to = "/docs"
+  status = 301
+
+[[redirects]]
   from = "/*"
   to = "/docs/404.html"
   status = 404


### PR DESCRIPTION
Redirects `/` to `/docs` so if you try to access the deploy preview URL, you won’t see a 404

### Test plan

https://deploy-preview-349--okteto-docs.netlify.app/ should redirect to https://deploy-preview-349--okteto-docs.netlify.app/docs