### PR TITLE
Proposal for removing kubernetes supported versions for public guides

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -26,8 +26,7 @@ This guide will assume that your domain is registered in [AzureDNS](https://docs
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 We recommend the following specs:
 - v1.23

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -29,8 +29,7 @@ In the rest of this guide, we will refer to this subdomain as `DOMAIN`.
 
 ### Deploy a Kubernetes cluster
 
-If you are not familiar with this step, we recommend that you follow DigitalOcean's [cluster creation guide](https://www.digitalocean.com/docs/kubernetes/how-to/create-clusters/).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+If you are not familiar with this step, we recommend that you follow DigitalOcean's [cluster creation guide](https://www.digitalocean.com/docs/kubernetes/how-to/create-clusters/) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 To get started with Okteto, follow these specs:
 

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -27,8 +27,7 @@ This guide will assume that your domain is registered in [Amazon Route53](https:
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+We recommend that you follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 We recommend the following specs:
 - v1.23

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -27,8 +27,7 @@ This guide will assume that your domain is registered in Google's [Cloud DNS](ht
 
 ### Deploy a Kubernetes cluster
 
-We recommend that you follow Google's [GKE cluster creation guide](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+We recommend that you follow Google's [GKE cluster creation guide](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
 We recommend the following specs:
 - v1.23

--- a/src/content/self-hosted/install/preparation.mdx
+++ b/src/content/self-hosted/install/preparation.mdx
@@ -36,8 +36,8 @@ Okteto supports Kubernetes versions 1.22 through 1.24.
 
 We recommend the following specs:
 - v1.23
-- A pool with at least 3 nodes with a minimum of 4CPUs and 16 GB of Memory
-- 100 GB per disk
+- A pool with at least 3 nodes with a minimum of 4CPUs and 32 GB of Memory
+- 250 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.
 


### PR DESCRIPTION
This PR come from a comment in the PR for the release notes for `1.6.0` version: https://github.com/okteto/docs/pull/339#discussion_r1134394072

More context: In one nexus we commented about changing the supported Kubernetes version in our docs and we realized we have that information "duplicated" in several places. We commented about leaving that information only in the preparation page and link it in the public guides. Also, the same for the technical specs. In fact, we already have some discrepancy there because in the preparation guide we mention `100GB` for the storage but `250GB` in the providers public guides. So, with that purpose, we included those changes.

Finally, those changes were reverted from the release notes PRs and I opened this PR to have that conversation here. 

In this case, I just removed from the public guides the Kubernetes supported versions but I left the technical specs and @rberrelleza  had a point on mentioning that tech spec could mean different things in each Cloud Provider.

Anyways, I opened the PR to follow up the PR comment but I know there will be some changes in the public guides and we might close this one and include it in those improvements