### PR TITLE
Update documentation for buildkit

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -445,9 +445,14 @@ The build service. It's used in combination with `okteto build` to build contain
 - `podManagementPolicy`: The [podManagementPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) of the buildkit pods. Defaults to `Parallel`.
 - `replicaCount`: The number of buildkit pods. It defaults to 1.
 - `resources`: The resources for the buildkit pods.
-- `storage.class`: The storage class of the volume attached to every buildkit pod to persist the buildkit cache.
-- `storage.size`: The size of the volume attached to every buildkit pod to persist the buildkit cache.
-- `storage.cache`: The size of the buildkit cache to store image caches. It should be 30Gi smaller than `storage.size`.
+- `serviceAccount.create`: create a service account for buildkit. True by default.
+- `serviceAccount.name`: Buildkit service account name. Defaults to `okteto-buildkit`.
+- `serviceAccount.annotations`: Annotations for the buildkit service account.
+- `serviceAccount.labels`: Labels for the buildkit service account.
+- `persistency.enabled`: Configures a persistence volume for buildkit. False by default.
+- `persistency.storageClass`: The storage class of the persistence volume attached to every buildkit pod.
+- `persistency.size`: The size of the persistence volume attached to every buildkit pod.
+- `persistency.cache`: The size of the buildkit cache to store image caches. It should be around 30Gi smaller than `storage.size`.
 
 ```yaml
 buildkit:
@@ -456,8 +461,9 @@ buildkit:
     - name: NO_PROXY
       value: ".example.com"
   replicaCount: 1
-  storage:
-    class: ssd
+  persistency:
+    enabled: true
+    storageClass: ssd
     size: 180Gi
     cache: 150000
 ```

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -449,10 +449,10 @@ The build service. It's used in combination with `okteto build` to build contain
 - `serviceAccount.name`: Buildkit service account name. Defaults to `okteto-buildkit`.
 - `serviceAccount.annotations`: Annotations for the buildkit service account.
 - `serviceAccount.labels`: Labels for the buildkit service account.
-- `persistency.enabled`: Configures a persistence volume for buildkit. False by default.
-- `persistency.storageClass`: The storage class of the persistence volume attached to every buildkit pod.
-- `persistency.size`: The size of the persistence volume attached to every buildkit pod.
-- `persistency.cache`: The size of the buildkit cache to store image caches. It should be around 30Gi smaller than `storage.size`.
+- `persistence.enabled`: Configures a persistence volume for buildkit. False by default.
+- `persistence.storageClass`: The storage class of the persistence volume attached to every buildkit pod.
+- `persistence.size`: The size of the persistence volume attached to every buildkit pod.
+- `persistence.cache`: The size of the buildkit cache to store image caches. It should be around 30Gi smaller than `storage.size`.
 
 ```yaml
 buildkit:
@@ -461,7 +461,7 @@ buildkit:
     - name: NO_PROXY
       value: ".example.com"
   replicaCount: 1
-  persistency:
+  persistence:
     enabled: true
     storageClass: ssd
     size: 180Gi

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -451,8 +451,8 @@ The build service. It's used in combination with `okteto build` to build contain
 - `serviceAccount.labels`: Labels for the buildkit service account.
 - `persistence.enabled`: Configures a persistence volume for buildkit. False by default.
 - `persistence.storageClass`: The storage class of the persistence volume attached to every buildkit pod.
-- `persistence.size`: The size of the persistence volume attached to every buildkit pod.
-- `persistence.cache`: The size of the buildkit cache to store image caches. It should be around 30Gi smaller than `storage.size`.
+- `persistence.size`: The size of the persistence volume attached to every buildkit pod. Defaults to `750Gi`.
+- `persistence.cache`: The size (in Mi) of the buildkit cache to store image caches. It should be around 30Gi smaller than `storage.size`. Defaults to 500Gi.
 
 ```yaml
 buildkit:

--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -152,6 +152,9 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true
+
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -152,7 +152,7 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true
 
 ```

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -27,3 +27,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -27,5 +27,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -122,7 +122,7 @@ registry:
         size: 100Gi
 
 buildkit:
-  persistency:
+  persistence:
     enabled: true
 ```
 

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -120,6 +120,10 @@ registry:
       enabled: true
       persistence:
         size: 100Gi
+
+buildkit:
+  persistency:
+    enabled: true
 ```
 
 ### Adding the Okteto Helm repository

--- a/src/content/self-hosted/civo/config.yaml
+++ b/src/content/self-hosted/civo/config.yaml
@@ -1,6 +1,6 @@
-email: 
+email:
 
-license: 
+license:
 
 subdomain: 
 
@@ -24,5 +24,5 @@ registry:
         size: 100Gi
 
 buildkit:
-  persistency:
+  persistence:
     enabled: true

--- a/src/content/self-hosted/civo/config.yaml
+++ b/src/content/self-hosted/civo/config.yaml
@@ -22,3 +22,7 @@ registry:
       enabled: true
       persistence:
         size: 100Gi
+
+buildkit:
+  persistency:
+    enabled: true

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -152,7 +152,7 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true
 ```
 

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -152,6 +152,8 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true
 ```
 
 ### Adding the Okteto Helm repository

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -1,6 +1,6 @@
-email: 
+email:
 
-license: 
+license:
 
 subdomain: 
 
@@ -31,5 +31,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -31,3 +31,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -193,7 +193,7 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true
 ```
 

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -193,6 +193,8 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -1,6 +1,6 @@
-email: 
+email:
 
-license: 
+license:
 
 subdomain: 
 
@@ -29,5 +29,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -29,3 +29,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -160,7 +160,7 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true
 ```
 

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -160,6 +160,8 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -25,3 +25,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -25,5 +25,5 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -11,6 +11,7 @@ TBD
 ### Features
 
 - Support for the annotation [dev.okteto.com/endpoints](cloud/ssl.mdx#customizing-the-endpoints-shown-in-the-okteto-ui) to customize the endpoints shown in the Okteto UI.
+- Support for configuring the [service account](self-hosted/administration/configuration.mdx#buildkit) of buildkit.
 
 ## 1.6.0
 15 March, 2023

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -146,6 +146,8 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
+  persistency:
+    enabled: true
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -146,7 +146,7 @@ buildkit:
     enabled: false
   service:
     type: LoadBalancer
-  persistency:
+  persistence:
     enabled: true
 ```
 


### PR DESCRIPTION
The default installation for buildkit won't use a PVC anymore. The PVC must be enabled explicitly.

This PR covers the following changes related to buildkit:

- Document the new buildkit fields
- Update our cloud provider guides to enable buildkit persistance
- Update the release notes


**Note**: this isn't a breaking change. Existing installation will keep using the existing PVC

@maroshii @teresaromero mention you to approve the tech docs since you have worked on this