### PR TITLE
Remove "email" from helm values file, it's comes from the "license"

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -6,14 +6,6 @@ id: configuration
 
 ## General Settings
 
-### email
-
-The email of the application owner.
-
-```yaml
-email: "admin@example.com"
-```
-
 ### cluster
 
 - `endpoint`: The public endpoint of your Kubernetes cluster. It will be used by Okteto when generating `Kubeconfig` credentials for your users.

--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -114,7 +114,6 @@ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-l
 
 Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 
-- Your `email`
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the OAuth Application you created
@@ -126,7 +125,6 @@ Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/do
 For example:
 
 ```yaml
-email: admin@example.com
 license: 1234567890ABCD==
 subdomain: dev.example.com
 cluster:

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -1,5 +1,3 @@
-email: 
-
 license: 
 
 subdomain: 

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -90,7 +90,6 @@ $ kubectl create namespace okteto
 
 Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
 
-- Your `email`
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the GitHub OAuth Application you created
@@ -99,7 +98,6 @@ Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/d
 For example:
 
 ```yaml
-email: admin@example.com
 license: 1234567890ABCD==
 subdomain: dev.example.com
 auth:

--- a/src/content/self-hosted/civo/config.yaml
+++ b/src/content/self-hosted/civo/config.yaml
@@ -1,5 +1,3 @@
-email:
-
 license:
 
 subdomain: 

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -110,7 +110,6 @@ $ kubectl create secret generic okteto-registry-secret --namespace=okteto --from
 
 Using these values:
 
-- Your email: `$EMAIL`
 - Your license (optional): `$LICENSE`
 - Your subdomain: `$SUBDOMAIN`
 - Your cluster's API server endpoint
@@ -122,7 +121,6 @@ Using these values:
 create the following `config.yml` file to configure the Okteto Helm chart:
 
 ```yaml
-email: "$EMAIL"
 license: "$LICENSE"
 subdomain: "$SUBDOMAIN"
 

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -1,5 +1,3 @@
-email:
-
 license:
 
 subdomain: 

--- a/src/content/self-hosted/digitalocean/marketplace.md
+++ b/src/content/self-hosted/digitalocean/marketplace.md
@@ -26,7 +26,6 @@ Use the admin token you retrieved on the first step to log in to the admin scree
 
 Once you log in to the admin page, you'll need to provide the following values to complete Okteto's initial configuration.
 
-1. The email of the owner of the application
 1. A [dedicated subdomain](#Subdomain) for your Okteto instance
 1. Your Kubernetes cluster's [public endpoint](#Cluster-Public-Endpoint)
 1. Your [Okteto license](#License) (optional)

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -152,7 +152,6 @@ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-l
 
 Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
 
-- Your `email`
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the OAuth Application you created
@@ -166,7 +165,6 @@ Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/do
 For example:
 
 ```yaml
-email: admin@example.com
 license: 1234567890ABCD==
 subdomain: dev.example.com
 cluster:

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -1,5 +1,3 @@
-email:
-
 license:
 
 subdomain: 

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -124,7 +124,6 @@ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-f
 
 Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
 
-- Your `email`
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the OAuth 2.0 Client you created
@@ -135,7 +134,6 @@ Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/do
 For example:
 
 ```yaml
-email: admin@example.com
 license: 1234567890ABCD==
 subdomain: dev.example.com
 

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -1,5 +1,3 @@
-email:
-
 license:
 
 subdomain: 

--- a/src/content/self-hosted/install/deployment.mdx
+++ b/src/content/self-hosted/install/deployment.mdx
@@ -22,14 +22,6 @@ Before running `helm install`, we recommend that you create a yaml configuration
 
 You can use [this sample configuration file](https://charts.okteto.com/config.yaml) as a starting point. The different configuration settings are explained below.
 
-### Email
-
-You'll need to provide the email of the application owner.
-
-```yaml
-email: "admin@example.com"
-```
-
 ### Cluster Endpoint
 
 This is the public endpoint of your Kubernetes cluster. It will be used by Okteto when generating `Kubeconfig` credentials for your users.

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -108,7 +108,6 @@ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-l
 
 Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
 
-- Your `email`
 - Your `license` (optional)
 - A `subdomain`
 - `clientId` and `clientSecret` of the OAuth Application you created
@@ -120,7 +119,6 @@ Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/do
 For example:
 
 ```yaml
-email: admin@example.com
 license: 1234567890ABCD==
 subdomain: dev.example.com
 cluster:


### PR DESCRIPTION
The `email` field is no longer needed, and by removing it, we simplify our installation guides