### PR TITLE
fix: download link windows

### DIFF
--- a/src/content/getting-started.mdx
+++ b/src/content/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-0.11/getting-started.mdx
+++ b/versioned_docs/version-0.11/getting-started.mdx
@@ -31,7 +31,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-0.12/getting-started.mdx
+++ b/versioned_docs/version-0.12/getting-started.mdx
@@ -31,7 +31,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-0.13/getting-started.mdx
+++ b/versioned_docs/version-0.13/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-0.14/getting-started.mdx
+++ b/versioned_docs/version-0.14/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-0.15/getting-started.mdx
+++ b/versioned_docs/version-0.15/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-1.0/getting-started.mdx
+++ b/versioned_docs/version-1.0/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-1.1/getting-started.mdx
+++ b/versioned_docs/version-1.1/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-1.2/getting-started.mdx
+++ b/versioned_docs/version-1.2/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-1.3/getting-started.mdx
+++ b/versioned_docs/version-1.3/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-1.4/getting-started.mdx
+++ b/versioned_docs/version-1.4/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-1.5/getting-started.mdx
+++ b/versioned_docs/version-1.5/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 


### PR DESCRIPTION
Download link in windows was pointing to previous release process. Now the user should write what is the channel he wants to download it from.
Fixes https://github.com/okteto/okteto/issues/3562