### PR TITLE
Add caveat for scoop upgrades

### DIFF
--- a/src/content/getting-started.mdx
+++ b/src/content/getting-started.mdx
@@ -45,6 +45,8 @@ You can also install it via [scoop](https://scoop.sh/) by running:
 $ scoop install okteto
 ```
 
+> For updating okteto with scoop, you might need to `scoop unhold okteto & scoop update okteto` or `scoop uninstall okteto & scoop install okteto`
+
 ### GitHub
 
 Alternatively, you can directly download the binary [from GitHub](https://github.com/okteto/okteto/releases) or build it directly from the source code.


### PR DESCRIPTION
Turns out scoop hand `hold` your package and will tell you it's upgraded even though it's not