### PR TITLE
Move self-hosted configuration to the first level

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -111,13 +111,13 @@ module.exports = {
           "self-hosted/gke"
         ]
       },
+      "self-hosted/administration/configuration",
       {
         "type": "category",
-        "label": "Configuration",
+        "label": "Administration",
         "items": [
           "self-hosted/administration/certificates",
           "self-hosted/administration/custom-installer-image",
-          "self-hosted/administration/configuration",
           "self-hosted/administration/github",
           "self-hosted/administration/volume-snapshots"
         ]

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuration Settings
 description: List of configuration settings for Okteto
+sidebar_label: Configuration
 id: configuration
 ---
 


### PR DESCRIPTION
Self-hosted configuration is one of the most visited paged by our users, but it takes three clicks on the left menu to get there. This PR puts the self-hosted configuration doc one level up