### PR TITLE
docs: fix windows download link

### DIFF
--- a/versioned_docs/version-1.6/getting-started.mdx
+++ b/versioned_docs/version-1.6/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 

--- a/versioned_docs/version-1.7/getting-started.mdx
+++ b/versioned_docs/version-1.7/getting-started.mdx
@@ -37,7 +37,7 @@ $ brew install okteto
 
 ### Windows
 
-Download https://downloads.okteto.com/cli/okteto.exe and add it to your `$PATH`.
+Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
 
 You can also install it via [scoop](https://scoop.sh/) by running:
 


### PR DESCRIPTION
Versioned docs at 1.6 and 1.7 contain a wrong Windows Okteto CLI
download link.

Related to:
- https://github.com/okteto/docs/pull/371