### PR TITLE
Support kubernetes 1.25

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -27,10 +27,10 @@ You can use any DNS service you prefer, but this guide focuses specifically on A
 ### Deploy a Kubernetes cluster
 
 We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+Okteto supports Kubernetes versions 1.23 through 1.25.
 
 We recommend the following specs:
-- v1.24
+- v1.25
 - A pool with at least 3 `Standard D4` nodes
 - 250 GB per Standard SSD Managed Disk
 

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -27,11 +27,11 @@ You can use any DNS service you prefer, but this guide focuses specifically on D
 ### Deploy a Kubernetes cluster
 
 If you are not familiar with this step, we recommend that you follow DigitalOcean's [cluster creation guide](https://www.digitalocean.com/docs/kubernetes/how-to/create-clusters/).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+Okteto supports Kubernetes versions 1.23 through 1.25.
 
 To get started with Okteto, follow these specs:
 
-- v1.23
+- v1.25
 - A pool with at least 3 nodes (4CPUs and 16GBs each)
 - 250 GB per disk
 

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -27,10 +27,10 @@ You can use any DNS service you prefer, but this guide focuses specifically on A
 ### Deploy a Kubernetes cluster
 
 We recommend that you follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+Okteto supports Kubernetes versions 1.23 through 1.25.
 
 We recommend the following specs:
-- v1.23
+- v1.25
 - A pool with at least 3 `m4.xlarge` nodes
 - 250 GB per disk
 

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -27,10 +27,10 @@ You can use any DNS service you prefer, but this guide focuses specifically on G
 ### Deploy a Kubernetes cluster
 
 We recommend that you follow Google's [GKE cluster creation guide](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster).
-Okteto supports Kubernetes versions 1.22 through 1.24.
+Okteto supports Kubernetes versions 1.23 through 1.25.
 
 We recommend the following specs:
-- v1.24
+- v1.25
 - A pool with at least 3 `n1-standard-4` nodes
 - 250 GB per disk
 

--- a/src/content/self-hosted/install/preparation.mdx
+++ b/src/content/self-hosted/install/preparation.mdx
@@ -26,10 +26,10 @@ By default, all endpoints created by Okteto for your development environments wi
 ### Deploy a Kubernetes cluster
 
 We recommend that you follow your cloud provider's Kubernetes cluster creation guide.
-Okteto supports Kubernetes versions 1.22 through 1.24.
+Okteto supports Kubernetes versions 1.23 through 1.25.
 
 We recommend the following specs:
-- v1.24
+- v1.25
 - A pool with at least 3 nodes with a minimum of 4CPUs and 16 GB of Memory
 - 250 GB per disk
 

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -9,6 +9,7 @@ id: releases
 TBD
 
 ### Features
+- Add support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md)
 - Support for custom [labels and annotations](self-hosted/administration/configuration.mdx#namespace) in ingresses managed by Okteto.
 
 ### Breaking changes

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -15,6 +15,9 @@ TBD
 ### Breaking changes
 - The default value for the buildkit service session affinity is now `None`. To keep using `ClientIP` as `sessionAffinity` you need to set this value in your [buildkit configuration](self-hosted/administration/configuration.mdx#buildkit).
 
+### Deprecation Notice
+- Support for Kubernetes [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) has been deprecated and will be removed next release.
+
 ## 1.7.1
 21 April, 2023
 


### PR DESCRIPTION
We are supporting 1.25 for release 1.8.

- Update versions at self-hosted installation guides
- Added info at release notes for new version support and deprecation notice