### PR TITLE
Document upgrade to Kubernetes 1.25 process

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -9,7 +9,7 @@ id: releases
 TBD
 
 ### Features
-- Add support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md)
+- Add support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md). Follow [this guide](self-hosted/install/upgrade.mdx/#upgrade-to-kubernetes-125) to upgrade Kubernetes to 1.25 in an existing Okteto instance.
 - Support for custom [labels and annotations](self-hosted/administration/configuration.mdx#namespace) in ingresses managed by Okteto.
 
 ### Breaking changes

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -8,15 +8,15 @@ id: releases
 ## 1.8.0
 TBD
 
-### Features
-- Add support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md). Follow [this guide](self-hosted/install/upgrade.mdx/#upgrade-to-kubernetes-125) to upgrade Kubernetes to 1.25 in an existing Okteto instance.
-- Support for custom [labels and annotations](self-hosted/administration/configuration.mdx#namespace) in ingresses managed by Okteto.
-
 ### Breaking changes
-- The default value for the buildkit service session affinity is now `None`. To keep using `ClientIP` as `sessionAffinity` you need to set this value in your [buildkit configuration](self-hosted/administration/configuration.mdx#buildkit).
+- The default value for the buildkit service session affinity is now `None`. To keep using `ClientIP` as `sessionAffinity` you need to set `service.sessionAffinity: ClientIP` in your [buildkit configuration](self-hosted/administration/configuration.mdx#buildkit).
 
 ### Deprecation Notice
-- Support for Kubernetes [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) has been deprecated and will be removed next release.
+- Support for Kubernetes [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) has been deprecated and will be removed in the next release.
+
+### Features
+- Kubernetes supported versions: [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) ([upgrade guide](self-hosted/install/upgrade.mdx/#upgrade-to-kubernetes-125)), [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md) and [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md).
+- Support for custom [labels and annotations](self-hosted/administration/configuration.mdx#namespace) in ingresses managed by Okteto.
 
 ## 1.7.1
 21 April, 2023
@@ -38,6 +38,7 @@ The `cloud.provider` and `cloud.secret` keys in the Helm chart are now deprecate
 
 ### Features
 
+- Kubernetes supported versions: [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md), [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md) and [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md).
 - Support for the annotation [dev.okteto.com/endpoints](cloud/ssl.mdx#customizing-the-endpoints-shown-in-the-okteto-ui) to customize the endpoints shown in the Okteto UI.
 - Support for configuring the [service account](self-hosted/administration/configuration.mdx#buildkit) of buildkit.
 - Support for [token-based authentication](self-hosted/administration/configuration.mdx#token) to simplify the installation of Okteto Self-Hosted.
@@ -95,7 +96,7 @@ In some cases, there is a race condition recreating the controller pods in which
 
 ### Features
 
-- Add support for Kubernetes [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md)
+- Kubernetes supported versions: [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md), [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md) and [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md).
 - Update the Okteto CLI version to [2.13.0](https://github.com/okteto/okteto/releases/tag/2.13.0)
 - Support [custom quotas](self-hosted/administration/configuration.mdx#quotas) for node port and load balancer service types
 - [Public override support](self-hosted/administration/configuration.mdx#publicoverride) for self-signed certificates and bring your own certificate
@@ -138,6 +139,7 @@ In some cases, there is a race condition recreating the controller pods in which
 
 ### Features
 
+- Kubernetes supported versions: [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md), [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) and [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md).
 - You can now define an [icon for every endpoint in your external resources list](reference/manifest.mdx#icon-string-optional)
 - Add support for registry cloud provider storage using:
   - [GCP Workload Identity](self-hosted/administration/configuration.mdx#workload-identity)
@@ -193,6 +195,7 @@ February 1, 2023
 January 19, 2023
 
 ### Features
+- Kubernetes supported versions: [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md), [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) and [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md).
 - You can now define [external resources](reference/manifest.mdx#external-object-optional) in your Okteto manifest. Use this to include resources that exist outside of your Okteto namespace like databases, message brokers, serverless functions, dashboards, etc.
 - You can now show [virtual services](self-hosted/administration/configuration.mdx#virtualservices) endpoints in the Okteto UI
 - Update okteto cli version to [2.11.1](https://github.com/okteto/okteto/releases/tag/2.11.1)
@@ -227,6 +230,7 @@ December 23, 2022
 
 ### Features
 
+- Kubernetes supported versions: [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md), [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) and [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md).
 - [Catalog](administration/catalog.mdx) to provide predefined development environments to every developer
 - Remove CLI tab from Okteto UI deploy
 
@@ -243,17 +247,16 @@ November 25, 2022
 
 ### Features
 
+- Kubernetes supported versions: [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md), [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) and [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md).
 - Update okteto cli version to [2.9.0](https://github.com/okteto/okteto/releases/tag/2.9.0)
 - Support for self-signed certificates and private CA with Docker
 - Buildkit port is now [configurable](self-hosted/administration/configuration.mdx#buildkit)
 - Save costs by allowing to scale down to zero nodes if no user pods are running
 - Added [configuration to set PSP and AppArmor](self-hosted/administration/configuration.mdx#podSecurityPolicy)
 
-
 ### Improvements
 - UI pagination support for GitHub branches list
 - Populate oauth errors to the user
-
 
 ### Bugfixes
 
@@ -272,6 +275,7 @@ November 25, 2022
 November 2, 2022
 
 ### Features
+- Kubernetes supported versions: [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md), [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) and [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md).
 - Allow members of a namespace to share it.
 
 ### Improvements
@@ -302,12 +306,12 @@ The 1.0.0 comes with two breaking changes, follow our [upgrade guide to 1.x](sel
 - Support for Kubernetes [1.20](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md) has been deprecated and will be removed next release.
 
 ### Features
+- Kubernetes supported versions: [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md), [1.22](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) and [1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md).
 - Okteto UI now allows users to specify the manifest path when launching a dev environment.
 
 ### Improvements
 - Chart has been renamed from "Okteto Enterprise" to "Okteto".
 - The cert-manager chart is no longer bundled with Okteto and is no longer installed by default. Okteto now uses a self-signed certificate by default.
-- Add support for Kubernetes [1.23](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md).
 - Upgrade ingress-nginx to [4.2.1](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.2.1).
 - Exposed gRPC connection configuration for the BuildKit gRPC [server](/self-hosted/administration/configuration.mdx#buildkit).
 

--- a/src/content/self-hosted/install/upgrade.mdx
+++ b/src/content/self-hosted/install/upgrade.mdx
@@ -154,3 +154,23 @@ helm install cert-manager jetstack/cert-manager --namespace=okteto --version=v1.
 Once installed, cert-manager will continue to renew your existing certificates.
 Please refer to [their docs](https://cert-manager.io/docs/) if you run into any installation or certificate renewal issues.
 
+## Upgrade to Kubernetes 1.25
+
+Kubernetes version 1.25 no longer supports pod security policies.
+If you are running Okteto in Kubernetes < 1.25, the default installation of Okteto creates pod security policies.
+If you upgrade Kubernetes to version 1.25 before upgrading Okteto, you will encounter the following error during the upgrade process:
+
+```
+Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: [resource mapping not found for name: "okteto-permissive" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
+ensure CRDs are installed first, resource mapping not found for name: "okteto-restrictive" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
+ensure CRDs are installed first]
+```
+
+> You can find more information about how to recover from this state in this [community link](https://community.okteto.com/t/upgrade-failed-with-no-matches-for-kind-podsecuritypolicy-in-version-policy-v1beta1/802).
+
+To avoid this issue, upgrade Okteto before upgrading Kubernetes to version 1.25 and add the following configuration to your helm values file:
+
+```
+podSecurityPolicy:
+   enabled: false
+```


### PR DESCRIPTION
Document clean upgrade to Kubernetes 1.25 by disabling pod security policies first