### PR TITLE
Add replicas field in Services field

### DIFF
--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -707,7 +707,6 @@ For `services`, `command` defaults to the command specified in your deployment, 
 `labels` and `name` are mutually exclusive (for the main container, `name` is mandatory).
 `replicas` specifies the number of replicas for service dev containers.
 If `replicas` is not specified, it defaults to the original deployment replicas.
-If original deployment replicas are zero, it defaults to one replica.
 
 #### sync ([string], required)
 

--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -707,6 +707,7 @@ For `services`, `command` defaults to the command specified in your deployment, 
 `labels` and `name` are mutually exclusive (for the main container, `name` is mandatory).
 `replicas` specifies the number of replicas for service dev containers.
 If `replicas` is not specified, it defaults to the original deployment replicas.
+If original deployment replicas are zero, it defaults to one replica.
 
 #### sync ([string], required)
 

--- a/src/content/reference/manifest.mdx
+++ b/src/content/reference/manifest.mdx
@@ -665,7 +665,7 @@ serviceAccount: default
 
 #### services ([object], optional)
 
-A list of services that you want to put on developer mode along your your development container.
+A list of services that you want to put on developer mode along your development container.
 The services work just like the development container, with one exception: they won't be able to start an interactive session.
 
 For example, imagine that you have a python-based application with an API and a Worker service. If you define the manifest as shown below, running `okteto up` would give you a remote terminal into the web development container, while synchronizing your changes with both web and worker.
@@ -678,6 +678,7 @@ dev:
       - .:/app
     services:
       - name: worker
+        replicas: 2
         command: ["celery", "worker", "-A", "myproject.celeryconf", "-Q", "default", "-n", "default@%h"]
         sync:
           - .:/app
@@ -699,10 +700,13 @@ The supported keys for containers defined in this section are:
 1. `sync`
 1. `tolerations`
 1. `workdir`
+1. `replicas`
 
 They work the same as for the main container, except for the `command` and `name` keys.
 For `services`, `command` defaults to the command specified in your deployment, instead of `sh`.
 `labels` and `name` are mutually exclusive (for the main container, `name` is mandatory).
+`replicas` specifies the number of replicas for service dev containers.
+If `replicas` is not specified, it defaults to the original deployment replicas.
 
 #### sync ([string], required)
 


### PR DESCRIPTION
Add replicas field in Services to specify the required replicas for services.
[https://github.com/okteto/okteto/pull/3556](https://github.com/okteto/okteto/pull/3556)