### PR TITLE
Added a paragraph to recommend users to set explicitly the setting buildkit.persistence.enabled: true before upgrading to 1.7

### DIFF
--- a/src/content/self-hosted/install/upgrade.mdx
+++ b/src/content/self-hosted/install/upgrade.mdx
@@ -25,7 +25,15 @@ Please review [the release notes](self-hosted/install/releases.mdx) before upgra
 
 ## Upgrading to Okteto 1.7.x
 
-As part of [1.7.0](self-hosted/install/releases.mdx#170), we moved the configuration settings needed to configure the external storage for the registry. Before, it was configured under `cloud` key and now it has to be configured under `registry` key.
+As part of [1.7.0](self-hosted/install/releases.mdx#170), we have changed the default behavior of BuildKit to don't use a persistent volume. You have to include the following setting in your configuration file to keep using persistency:
+
+```yaml
+buildkit:
+  persistence:
+    enabled: true
+```
+
+We have also moved the configuration settings needed to configure the external storage for the registry. Before, it was configured under `cloud` key and now it has to be configured under `registry` key.
 
 So, before `1.7.X`, the configuration to configure external storage would look like this:
 
@@ -60,14 +68,6 @@ registry:
 > If you didn't override a value for `cloud.secret`, you need to include the `registry.secret` section as posted in the previous snippet to keep working with the previous default values specified by the Okteto chart.
 >
 > If you had a custom value for `cloud.secret`, you need to specify the right values under `registry.secret` key.
-
-Also, we have changed the default behavior of BuildKit to don't use a persistent volume. If your BuildKit instance was already using a PVC, it should be kept but we recommend you to include the following key in the configuration file:
-
-```yaml
-buildkit:
-  persistence:
-    enabled: true
-```
 
 ## Upgrading from Okteto 0.x to 1.x
 

--- a/src/content/self-hosted/install/upgrade.mdx
+++ b/src/content/self-hosted/install/upgrade.mdx
@@ -61,6 +61,13 @@ registry:
 >
 > If you had a custom value for `cloud.secret`, you need to specify the right values under `registry.secret` key.
 
+Also, we have changed the default behavior of BuildKit to don't use a persistent volume. If your BuildKit instance was already using a PVC, it should be kept but we recommend you to include the following key in the configuration file:
+
+```yaml
+buildkit:
+  persistence:
+    enabled: true
+```
 
 ## Upgrading from Okteto 0.x to 1.x
 

--- a/versioned_docs/version-1.7/self-hosted/install/upgrade.mdx
+++ b/versioned_docs/version-1.7/self-hosted/install/upgrade.mdx
@@ -25,7 +25,15 @@ Please review [the release notes](self-hosted/install/releases.mdx) before upgra
 
 ## Upgrading to Okteto 1.7.x
 
-As part of [1.7.0](self-hosted/install/releases.mdx#170), we moved the configuration settings needed to configure the external storage for the registry. Before, it was configured under `cloud` key and now it has to be configured under `registry` key.
+As part of [1.7.0](self-hosted/install/releases.mdx#170), we have changed the default behavior of BuildKit to don't use a persistent volume. You have to include the following setting in your configuration file to keep using persistency:
+
+```yaml
+buildkit:
+  persistence:
+    enabled: true
+```
+
+We have also moved the configuration settings needed to configure the external storage for the registry. Before, it was configured under `cloud` key and now it has to be configured under `registry` key.
 
 So, before `1.7.X`, the configuration to configure external storage would look like this:
 
@@ -60,14 +68,6 @@ registry:
 > If you didn't override a value for `cloud.secret`, you need to include the `registry.secret` section as posted in the previous snippet to keep working with the previous default values specified by the Okteto chart.
 >
 > If you had a custom value for `cloud.secret`, you need to specify the right values under `registry.secret` key.
-
-Also, we have changed the default behavior of BuildKit to don't use a persistent volume. If your BuildKit instance was already using a PVC, it should be kept but we recommend you to include the following key in the configuration file:
-
-```yaml
-buildkit:
-  persistence:
-    enabled: true
-```
 
 ## Upgrading from Okteto 0.x to 1.x
 

--- a/versioned_docs/version-1.7/self-hosted/install/upgrade.mdx
+++ b/versioned_docs/version-1.7/self-hosted/install/upgrade.mdx
@@ -61,6 +61,13 @@ registry:
 >
 > If you had a custom value for `cloud.secret`, you need to specify the right values under `registry.secret` key.
 
+Also, we have changed the default behavior of BuildKit to don't use a persistent volume. If your BuildKit instance was already using a PVC, it should be kept but we recommend you to include the following key in the configuration file:
+
+```yaml
+buildkit:
+  persistence:
+    enabled: true
+```
 
 ## Upgrading from Okteto 0.x to 1.x
 

--- a/versioned_docs/version-1.8/self-hosted/install/upgrade.mdx
+++ b/versioned_docs/version-1.8/self-hosted/install/upgrade.mdx
@@ -25,7 +25,15 @@ Please review [the release notes](self-hosted/install/releases.mdx) before upgra
 
 ## Upgrading to Okteto 1.7.x
 
-As part of [1.7.0](self-hosted/install/releases.mdx#170), we moved the configuration settings needed to configure the external storage for the registry. Before, it was configured under `cloud` key and now it has to be configured under `registry` key.
+As part of [1.7.0](self-hosted/install/releases.mdx#170), we have changed the default behavior of BuildKit to don't use a persistent volume. You have to include the following setting in your configuration file to keep using persistency:
+
+```yaml
+buildkit:
+  persistence:
+    enabled: true
+```
+
+We have also moved the configuration settings needed to configure the external storage for the registry. Before, it was configured under `cloud` key and now it has to be configured under `registry` key.
 
 So, before `1.7.X`, the configuration to configure external storage would look like this:
 
@@ -60,14 +68,6 @@ registry:
 > If you didn't override a value for `cloud.secret`, you need to include the `registry.secret` section as posted in the previous snippet to keep working with the previous default values specified by the Okteto chart.
 >
 > If you had a custom value for `cloud.secret`, you need to specify the right values under `registry.secret` key.
-
-Also, we have changed the default behavior of BuildKit to don't use a persistent volume. If your BuildKit instance was already using a PVC, it should be kept but we recommend you to include the following key in the configuration file:
-
-```yaml
-buildkit:
-  persistence:
-    enabled: true
-```
 
 ## Upgrading from Okteto 0.x to 1.x
 

--- a/versioned_docs/version-1.8/self-hosted/install/upgrade.mdx
+++ b/versioned_docs/version-1.8/self-hosted/install/upgrade.mdx
@@ -61,6 +61,13 @@ registry:
 >
 > If you had a custom value for `cloud.secret`, you need to specify the right values under `registry.secret` key.
 
+Also, we have changed the default behavior of BuildKit to don't use a persistent volume. If your BuildKit instance was already using a PVC, it should be kept but we recommend you to include the following key in the configuration file:
+
+```yaml
+buildkit:
+  persistence:
+    enabled: true
+```
 
 ## Upgrading from Okteto 0.x to 1.x
 


### PR DESCRIPTION
Added a paragraph in the `Before Upgrade` section to recommend to set explicitly the persistence for BuildKit before upgrading to `1.7`. Updated also `1.7` and `1.8` versions