### PR TITLE
Remove buildkit LoadBalancer config

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -360,7 +360,6 @@ The build service. It's used in combination with `okteto build` to build contain
 - `persistence.storageClass`: The storage class of the persistence volume attached to every buildkit pod.
 - `persistence.size`: The size of the persistence volume attached to every buildkit pod. Defaults to `750Gi`.
 - `persistence.cache`: The size (in Mi) of the buildkit cache to store image caches. It should be around 30Gi smaller than `storage.size`. Defaults to 500Gi.
-- `service.sessionAffinity`: The [sessionAffinity](https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity) setting for the buildkit service. `None` by default.
 
 ```yaml
 buildkit:

--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -149,23 +149,6 @@ okteto-ingress-nginx-controller  LoadBalancer   10.0.7.73    a519c8b3b27f94...ak
 
 You'll need to take the `EXTERNAL-IP` address and add it to your DNS for the domain you have chosen to use. In AzureDNS, this is done by creating an `A` record with the name  `*`, pointing to the IP of the Load Balancer.
 
-### Retrieve the Buildkit IP address
-
-You can use `kubectl` to fetch the address that has been dynamically allocated by AKS to the Buildkit instance you've just installed and configured as a part of Okteto:
-
-```console
-kubectl get service -l=app.kubernetes.io/instance=okteto,app.kubernetes.io/component=buildkit --namespace=okteto
-```
-
-The output will look something like this:
-
-```
-NAME                TYPE           CLUSTER-IP      EXTERNAL-IP                           PORT(S)          AGE
-okteto-buildkit     LoadBalancer   10.245.142.73   a519c8b3b27f95...aks.microsoft.com    1234:32449/TCP   5m
-```
-
-You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. This is done by creating an `A` record with the name `buildkit`.
-
 ## Sign in to your Okteto instance
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -6,10 +6,5 @@ cluster:
   endpoint:
 
 buildkit:
-  ingress:
-    enabled: false
-  service:
-    type: LoadBalancer
-    sessionAffinity: ClientIP
   persistence:
     enabled: true

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -147,23 +147,6 @@ okteto-ingress-nginx-controller  LoadBalancer   10.245.147.23  64.225.83.163   8
 
 You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. This is done by creating an `A` record with the name `*`.
 
-### Retrieve the Buildkit IP address
-
-You can use `kubectl` to fetch the address that has been dynamically allocated by DigitalOcean to the Buildkit instance you've just installed and configured as a part of Okteto:
-
-```console
-kubectl get service -l=app.kubernetes.io/instance=okteto,app.kubernetes.io/component=buildkit --namespace=okteto
-```
-
-The output will look something like this:
-
-```
-NAME                TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)          AGE
-okteto-buildkit     LoadBalancer   10.245.142.73   64.225.83.88    1234:32449/TCP   5m
-```
-
-You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. This is done by creating an `A` record with the name `buildkit`.
-
 ## Sign in to your Okteto instance
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -6,9 +6,5 @@ cluster:
   endpoint:
 
 buildkit:
-  ingress:
-    enabled: false
-  service:
-    type: LoadBalancer
   persistence:
     enabled: true

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -147,23 +147,6 @@ You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the do
 
 > Note: avoid using a `CNAME` record for `*` pointing to the public hostname of the Elastic Load Balancer, as it will block the cert-manager default capability for issuing/renewing certificates via ACME dns01.
 
-### Retrieve the Buildkit IP address
-
-You can use `kubectl` to fetch the address that has been dynamically allocated by EKS to the Buildkit instance you've just installed and configured as a part of Okteto:
-
-```console
-kubectl get service -l=app.kubernetes.io/instance=okteto,app.kubernetes.io/component=buildkit --namespace=okteto
-```
-
-The output will look something like this:
-
-```
-NAME                TYPE           CLUSTER-IP      EXTERNAL-IP                           PORT(S)          AGE
-okteto-buildkit     LoadBalancer   10.245.142.73   a519c8b3b27f95...elb.amazonaws.com    1234:32449/TCP   5m
-```
-
-You'll need to take the `EXTERNAL-IP` address and add it to your DNS for the domain you have chosen to use. This is done by creating an `A` record with the name `buildkit`.
-
 ## Sign in to your Okteto instance
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -5,12 +5,6 @@ subdomain:
 cluster:
   endpoint:
 
-buildkit:
-  ingress:
-    enabled: false
-  service:
-    type: LoadBalancer
-
 ingress-nginx:
   controller:
     service:

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -149,23 +149,6 @@ okteto-ingress-nginx-controller   LoadBalancer   10.0.7.73    34.68.230.234   80
 
 You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. In Google Cloud DNS, this is done by creating an `A` record with the name  `*`. We also suggest you set the TTL to 1 minute.
 
-### Retrieve the Buildkit IP address
-
-You can use `kubectl` to fetch the address that has been dynamically allocated by GKE to the Buildkit instance you've just installed and configured as a part of Okteto:
-
-```console
-kubectl get service -l=app.kubernetes.io/instance=okteto,app.kubernetes.io/component=buildkit --namespace=okteto
-```
-
-The output will look something like this:
-
-```
-NAME                TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)          AGE
-okteto-buildkit     LoadBalancer   10.245.142.73   34.68.230.233    1234:32449/TCP   5m
-```
-
-You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. This is done by creating an `A` record with the name `buildkit`.
-
 ## Sign in to your Okteto instance
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -6,10 +6,5 @@ cluster:
   endpoint:
 
 buildkit:
-  ingress:
-    enabled: false
-  service:
-    type: LoadBalancer
-    sessionAffinity: ClientIP
   persistence:
     enabled: true

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -139,23 +139,6 @@ okteto-ingress-nginx-controller  LoadBalancer   10.0.7.73    a519c8b3b27f94...ak
 
 You'll need to take the `EXTERNAL-IP` address and add it to your DNS for the domain you have chosen to use. In AzureDNS, this is done by creating an `A` record with the name  `*`, pointing to the IP of the Load Balancer.
 
-### Retrieve the Buildkit IP address
-
-You can use `kubectl` to fetch the address that has been dynamically allocated by AKS to the Buildkit instance you've just installed and configured as a part of Okteto:
-
-```console
-kubectl get service -l=app.kubernetes.io/instance=okteto,app.kubernetes.io/component=buildkit --namespace=okteto
-```
-
-The output will look something like this:
-
-```
-NAME                TYPE           CLUSTER-IP      EXTERNAL-IP                           PORT(S)          AGE
-okteto-buildkit     LoadBalancer   10.245.142.73   a519c8b3b27f95...aks.microsoft.com    1234:32449/TCP   5m
-```
-
-You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the domain you have chosen to use. This is done by creating an `A` record with the name `buildkit`.
-
 ## Sign in to your Okteto instance
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.


### PR DESCRIPTION
We are recommending to use buildkit within the ingress so this PR removes the documented installation and config.yaml properties for buildkit setting as LoadBalancer