### PR TITLE
Document "x-node-selector" in the compose docs

### DIFF
--- a/src/content/reference/docker-compose.mdx
+++ b/src/content/reference/docker-compose.mdx
@@ -395,6 +395,17 @@ Override the default working directory of the container image `WORKDIR`.
 working_dir: "/app/code"
 ```
 
+#### x-node-selector (map[string]string, optional)
+
+List of labels that the node must have to include the service containers on it.
+
+```yaml
+x-node-selector:
+  disktype: ssd
+```
+
+More information about Kubernetes node selectors is [available here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
+
 ### volumes ([object], optional)
 
 List of volumes created by the Docker Compose file.


### PR DESCRIPTION
`x-node-selector` translates to Kubernetes node selectors