### PR TITLE
Remove dependency on "cluster.endpoint" to install the okteto chart

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -34,13 +34,6 @@ We recommend the following specs:
 - A pool with at least 3 `Standard D4` nodes
 - 250 GB per Standard SSD Managed Disk
 
-You'll be using the cluster's API server endpoint when configuring Okteto.
-Run the following command to obtain your cluster's API server endpoint:
-
-```
-kubectl config view --minify | grep server
-```
-
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -74,15 +67,13 @@ Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/do
 
 - Your `license` (optional)
 - A `subdomain`
-- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
+
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -2,9 +2,6 @@ license:
 
 subdomain: 
 
-cluster:
-  endpoint:
-
 buildkit:
   persistence:
     enabled: true

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -76,9 +76,8 @@ For example:
 
 ```yaml
 license: 1234567890ABCD==
+
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://35.205.100.149"
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/civo/config.yaml
+++ b/src/content/self-hosted/civo/config.yaml
@@ -1,11 +1,3 @@
 license:
 
 subdomain: 
-
-cluster:
-  endpoint:
-
-ingress-nginx:
-  controller:
-    extraArgs:
-      enable-ssl-passthrough: "true"

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -79,14 +79,12 @@ For example:
 
 ```yaml
 license: 1234567890ABCD==
+
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:
     enabled: true
-
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -2,9 +2,6 @@ license:
 
 subdomain: 
 
-cluster:
-  endpoint:
-
 buildkit:
   persistence:
     enabled: true

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -80,9 +80,8 @@ For example:
 
 ```yaml
 license: 1234567890ABCD==
+
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://XXXXXX.gr7.us-west-2.eks.amazonaws.com"
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -1,12 +1,3 @@
 license:
 
 subdomain: 
-
-cluster:
-  endpoint:
-
-ingress-nginx:
-  controller:
-    service:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -80,10 +80,8 @@ For example:
 
 ```yaml
 license: 1234567890ABCD==
-subdomain: dev.example.com
 
-cluster:
-  endpoint: https://35.205.100.149
+subdomain: dev.example.com
 
 buildkit:
   persistence:

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -2,9 +2,6 @@ license:
 
 subdomain: 
 
-cluster:
-  endpoint:
-
 buildkit:
   persistence:
     enabled: true

--- a/src/content/self-hosted/install/config.yaml
+++ b/src/content/self-hosted/install/config.yaml
@@ -1,4 +1,1 @@
 license:
-
-cluster:
-  endpoint:

--- a/src/content/self-hosted/install/deployment.mdx
+++ b/src/content/self-hosted/install/deployment.mdx
@@ -14,27 +14,12 @@ Before running `helm install`, we recommend that you create a yaml configuration
 
 You can use [this sample configuration file](https://www.okteto.com/docs/self-hosted/install/config.yaml) as a starting point. The different configuration settings are explained below.
 
-### Cluster Endpoint
-
-This is the public endpoint of your Kubernetes cluster. It will be used by Okteto when generating `Kubeconfig` credentials for your users.
-
-```yaml
-cluster:
-  endpoint: "https://52.30.32.1"
-```
-
-Run the following command to obtain your cluster's API server endpoint:
-
-```
-kubectl config view --minify | grep server
-```
-
 ### License
 
 Okteto is free for small teams.  You get all the features of [Okteto](self-hosted.mdx) for up to 3 users.
 
 ```yaml
-license: XXXXX
+license: 1234567890ABCD==
 ```
 
 Want to use Okteto with a bigger team? [Let's talk](https://okteto.com/#talktous)

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -72,9 +72,8 @@ For example:
 
 ```yaml
 license: 1234567890ABCD==
+
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:


### PR DESCRIPTION
Okteto chart 1.10 removes the need to specify `cluster.endpoint` in the Helm values file.
This PR updates the installation guides to remove this dependency