### PR TITLE
Added ?origin=github to GitHub App auth callback 

### DIFF
--- a/src/content/self-hosted/administration/github.mdx
+++ b/src/content/self-hosted/administration/github.mdx
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.

--- a/versioned_docs/version-1.3/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.3/self-hosted/administration/github.mdx
@@ -19,7 +19,7 @@ There are several reasons for considering this approach including:
 - The pipelines use an app-scoped token, instead of a shared user.
 
 
-## Configuration Steps 
+## Configuration Steps
 
 Setting up the GitHub integration requires several steps in both GitHub and your Okteto instance. Complete the following steps in GitHub:
 
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.
@@ -69,7 +69,7 @@ To generate a private key authenticating to the GitHub App:
 1. Click on the `settings` of the organization you want to use to create the application.
 1. In the left navigation, select `Developer settings > GitHub Apps`.
 1. Select the GitHub App.
-1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step. 
+1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step.
 1. On the `Private keys` section (it's at the bottom of the page), press the `Generate a private key` button. A file with the private key will be saved in your computer.
 
 
@@ -113,7 +113,7 @@ helm install okteto okteto/okteto -f config.yaml --namespace=okteto
 
 ### Verifying your installation
 
-If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
+If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog.
 
 <p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 

--- a/versioned_docs/version-1.4/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.4/self-hosted/administration/github.mdx
@@ -19,7 +19,7 @@ There are several reasons for considering this approach including:
 - The pipelines use an app-scoped token, instead of a shared user.
 
 
-## Configuration Steps 
+## Configuration Steps
 
 Setting up the GitHub integration requires several steps in both GitHub and your Okteto instance. Complete the following steps in GitHub:
 
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.
@@ -69,7 +69,7 @@ To generate a private key authenticating to the GitHub App:
 1. Click on the `settings` of the organization you want to use to create the application.
 1. In the left navigation, select `Developer settings > GitHub Apps`.
 1. Select the GitHub App.
-1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step. 
+1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step.
 1. On the `Private keys` section (it's at the bottom of the page), press the `Generate a private key` button. A file with the private key will be saved in your computer.
 
 
@@ -113,7 +113,7 @@ helm install okteto okteto/okteto -f config.yaml --namespace=okteto
 
 ### Verifying your installation
 
-If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
+If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog.
 
 <p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 

--- a/versioned_docs/version-1.5/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.5/self-hosted/administration/github.mdx
@@ -19,7 +19,7 @@ There are several reasons for considering this approach including:
 - The pipelines use an app-scoped token, instead of a shared user.
 
 
-## Configuration Steps 
+## Configuration Steps
 
 Setting up the GitHub integration requires several steps in both GitHub and your Okteto instance. Complete the following steps in GitHub:
 
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.
@@ -69,7 +69,7 @@ To generate a private key authenticating to the GitHub App:
 1. Click on the `settings` of the organization you want to use to create the application.
 1. In the left navigation, select `Developer settings > GitHub Apps`.
 1. Select the GitHub App.
-1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step. 
+1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step.
 1. On the `Private keys` section (it's at the bottom of the page), press the `Generate a private key` button. A file with the private key will be saved in your computer.
 
 
@@ -113,7 +113,7 @@ helm install okteto okteto/okteto -f config.yaml --namespace=okteto
 
 ### Verifying your installation
 
-If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
+If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog.
 
 <p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 

--- a/versioned_docs/version-1.6/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.6/self-hosted/administration/github.mdx
@@ -19,7 +19,7 @@ There are several reasons for considering this approach including:
 - The pipelines use an app-scoped token, instead of a shared user.
 
 
-## Configuration Steps 
+## Configuration Steps
 
 Setting up the GitHub integration requires several steps in both GitHub and your Okteto instance. Complete the following steps in GitHub:
 
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.
@@ -69,7 +69,7 @@ To generate a private key authenticating to the GitHub App:
 1. Click on the `settings` of the organization you want to use to create the application.
 1. In the left navigation, select `Developer settings > GitHub Apps`.
 1. Select the GitHub App.
-1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step. 
+1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step.
 1. On the `Private keys` section (it's at the bottom of the page), press the `Generate a private key` button. A file with the private key will be saved in your computer.
 
 
@@ -113,7 +113,7 @@ helm install okteto okteto/okteto -f config.yaml --namespace=okteto
 
 ### Verifying your installation
 
-If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
+If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog.
 
 <p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 

--- a/versioned_docs/version-1.7/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.7/self-hosted/administration/github.mdx
@@ -19,7 +19,7 @@ There are several reasons for considering this approach including:
 - The pipelines use an app-scoped token, instead of a shared user.
 
 
-## Configuration Steps 
+## Configuration Steps
 
 Setting up the GitHub integration requires several steps in both GitHub and your Okteto instance. Complete the following steps in GitHub:
 
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.
@@ -69,7 +69,7 @@ To generate a private key authenticating to the GitHub App:
 1. Click on the `settings` of the organization you want to use to create the application.
 1. In the left navigation, select `Developer settings > GitHub Apps`.
 1. Select the GitHub App.
-1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step. 
+1. On the `Client secrets` section, press the `Generate a new client secret` button. Copy the value and save it in a safe place, since it won't be displayed again. You'll need to pass those to your Okteto instance in a future step.
 1. On the `Private keys` section (it's at the bottom of the page), press the `Generate a private key` button. A file with the private key will be saved in your computer.
 
 
@@ -113,7 +113,7 @@ helm install okteto okteto/okteto -f config.yaml --namespace=okteto
 
 ### Verifying your installation
 
-If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog. 
+If the installation was successful, you should now see a `GitHub` option in the `Deploy from Git` dialog.
 
 <p align="center"><Image src="/docs/self-hosted/administration/images/verify-installation.png" alt="verify your installation" width="650" /></p>
 

--- a/versioned_docs/version-1.8/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.8/self-hosted/administration/github.mdx
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.

--- a/versioned_docs/version-1.9/self-hosted/administration/github.mdx
+++ b/versioned_docs/version-1.9/self-hosted/administration/github.mdx
@@ -45,7 +45,7 @@ Once this configuration has been completed, your instance of Okteto will use the
     - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
     - `Homepage URL:` https://okteto.$SUBDOMAIN
     - `Callback URL:` https://okteto.$SUBDOMAIN
-    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback (Necessary if you are going to use GitHub as your auth provider)
+    - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.


### PR DESCRIPTION
Adding that query parameter to the GitHub App auth callback makes that we display the following screen instead of a blank page when users end configuring the repositories accessible by the GitHub App

<img width="1483" alt="Captura de pantalla 2023-06-27 a las 9 59 16" src="https://github.com/okteto/docs/assets/3510171/0492a70d-5c77-4bec-8024-7c33f336179c">
