### PR TITLE
Update README.md to display contributor images

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,8 @@ Tiers is a `string` of tier separated by a space
 
 ## Contributors
 
-Made with [contributors-img](https://contrib.rocks).
+<a href="https://github.com/okteto/docs/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=okteto/docs" />
+</a>
+
+<!--  https://contrib.rocks -->


### PR DESCRIPTION
The image for the contributors that are supposed to be [here](https://github.com/okteto/docs#contributors) is not present due to the unavailability of the link. 

This PR adds the correct link.