### PR TITLE
changing name of key for external storage configuration docs

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -588,7 +588,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -637,7 +637,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -664,7 +664,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -711,7 +711,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -588,7 +588,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -637,7 +637,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -664,7 +664,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -711,7 +711,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -711,7 +711,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
@@ -650,7 +650,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
@@ -527,7 +527,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -576,7 +576,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -603,7 +603,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -650,7 +650,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
@@ -527,7 +527,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -576,7 +576,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -603,7 +603,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -650,7 +650,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
@@ -572,7 +572,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -621,7 +621,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -648,7 +648,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -695,7 +695,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
@@ -695,7 +695,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
@@ -572,7 +572,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -621,7 +621,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -648,7 +648,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -695,7 +695,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
@@ -572,7 +572,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -621,7 +621,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -648,7 +648,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -695,7 +695,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
@@ -695,7 +695,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:

--- a/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
@@ -572,7 +572,7 @@ Create a secret with the value of `STORAGE_ACCOUNT_ACCESS_KEY` using the command
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=STORAGE_ACCOUNT_ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=STORAGE_ACCOUNT_ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -621,7 +621,7 @@ Create a secret with the value of `IAM_SECRET_KEY` using the command below.
 
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=IAM_SECRET_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=IAM_SECRET_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -648,7 +648,7 @@ Use this to use DigitalOcean Spaces to store your private images.
 Create a secret with the value of `ACCESS_KEY` using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=secretKey=ACCESS_KEY
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-literal=key=ACCESS_KEY
 ```
 
 Then, add the following configuration to your Okteto helm values file:
@@ -695,7 +695,7 @@ registry:
 Create a secret with the value of `key.json`  using the command below.
 
 ```console
-$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=secretKey=key.json
+$ kubectl create secret generic okteto-registry-secret --namespace=okteto --from-file=key=key.json
 ```
 
 Then, add the following configuration to your Okteto helm values file:


### PR DESCRIPTION
The secret name should be `key` because that's what is expected by the pods. cc @rberrelleza 