### PR TITLE
docs: use gke gce n2 family

### DIFF
--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -31,7 +31,7 @@ Okteto supports Kubernetes versions 1.24 through 1.26.
 
 We recommend the following specs:
 - v1.26
-- A pool with at least 3 `n1-standard-4` nodes
+- A pool with at least 3 `n2-standard-4` nodes
 - 250 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.


### PR DESCRIPTION
`n1-standard-4` is no longer selectable, therefore this PR changes the recomendation to `n2-standard-4` (4 vCPUs, 16 GB RAM).