### PR TITLE
docs: use eks ec2 m5 family

### DIFF
--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -31,7 +31,7 @@ Okteto supports Kubernetes versions 1.24 through 1.26.
 
 We recommend the following specs:
 - v1.26
-- A pool with at least 3 `m4.xlarge` nodes
+- A pool with at least 3 `m5.xlarge` nodes
 - 250 GB per disk
 
 You'll be using the cluster's API server endpoint when configuring Okteto.


### PR DESCRIPTION
`m4.xlarge` is outdated, therefore this PR changes the recommendation to `m5.xlarge` (4 vCPUs, 16 GB RAM).