### PR TITLE
docs: use heading 3 in 1.10 release notes

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -8,7 +8,7 @@ id: releases
 ## 1.10.0
 5 July 2023
 
-## Removal Notice
+### Removal Notice
 
 Kubernetes 1.23 is no longer supported.
 

--- a/versioned_docs/version-1.10/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.10/self-hosted/install/releases.mdx
@@ -8,7 +8,7 @@ id: releases
 ## 1.10.0
 5 July 2023
 
-## Removal Notice
+### Removal Notice
 
 Kubernetes 1.23 is no longer supported.
 


### PR DESCRIPTION
It should use heading-3 to be equivalent to following sections:
<img width="755" alt="image" src="https://github.com/okteto/docs/assets/92427625/5bb42cb7-f86b-44cf-b3d9-99b15b7121f2">
