### PR TITLE
Document the new setting key for the daemonset name 'configurePrivateRegistriesInNodes' that allows to enable or disable the configuration of private registry credentials in the nodes'

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -411,12 +411,19 @@ The daemonset automatically configures every node of your cluster to work better
 - `extraEnv`: Environment variables to be set on the daemonset containers.
 - `labels`: Labels to add to the daemonset pods.
 - `image`: Container image used by the daemonset pods.
+- `configurePrivateRegistriesInNodes.enabled`: Allows to specify if the daemonset should configure the private registry credentials in the nodes for kubelet or not. It defaults to `true`.
+
+```yaml
+daemonset:
+  configurePrivateRegistriesInNodes:
+    enabled: true
+```
 
 The daemonset performs the following tasks on each node:
 
 - [Overrides](self-hosted/administration/configuration.mdx#overrideregistryresolution) the Okteto Registry hostname resolution to use internal IPs.
 - [Overrides](self-hosted/administration/configuration.mdx#overridefilewatchers) the default kernel values for file watchers on every node.
-- Configures the kubelet with registry credentials for [private registries](self-hosted/administration/configuration.mdx#privateregistry).
+- Configures the kubelet with registry credentials for [private registries](self-hosted/administration/configuration.mdx#privateregistry) (if `configurePrivateRegistriesInNodes.enabled` key is `true`).
 - Installs your CA if `wildcardCertificate.privateCA` is enabled.
 - Installs a CA if using self-signed certificates (`wildcardCertificate.create: true`).
 

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -411,7 +411,7 @@ The daemonset automatically configures every node of your cluster to work better
 - `extraEnv`: Environment variables to be set on the daemonset containers.
 - `labels`: Labels to add to the daemonset pods.
 - `image`: Container image used by the daemonset pods.
-- `configurePrivateRegistriesInNodes.enabled`: Allows to specify if the daemonset should configure the private registry credentials in the nodes for kubelet or not. It defaults to `true`.
+- `configurePrivateRegistriesInNodes.enabled`: Specifies if the daemonset should configure the private registry credentials in the nodes for kubelet or not. It defaults to `true`.
 
 ```yaml
 daemonset:

--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -5,6 +5,13 @@ sidebar_label: Release Notes
 id: releases
 ---
 
+## 1.11.0
+TBD
+
+### Improvements
+
+- Added [configuration setting in the daemonset](self-hosted/administration/configuration.mdx#daemonset) to disable the configuration of private registry credentials in the nodes <!-- Ticket: 6741, PR: 6742 -->
+
 ## 1.10.0
 5 July 2023
 


### PR DESCRIPTION
A new setting was added to the chart value to allow enable/disable the configuration of the private registry credentials in the nodes by the daemonset.

This new setting will be included in the coming `1.11.0` release, so including the release notes for that version