### PR TITLE
Add "Edit this page" button to all pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -151,6 +151,7 @@ module.exports = {
         docs: {
           path: docsContentPath,
           routeBasePath: '/',
+          editUrl: 'https://github.com/okteto/docs/edit/main',
           breadcrumbs: false,
           sidebarPath: require.resolve('./sidebars.js'),
           lastVersion: '1.10',
@@ -258,7 +259,7 @@ module.exports = {
         to: '/cloud/starter-plan/',
         from: ['/cloud/developer-plan/']
       }
-    ]
+      ]
     }],
     ['docusaurus-gtm-plugin', {
       id: 'GTM-W6RQFNT'


### PR DESCRIPTION
# Why?
To incentivize users to contribute to the docs

# How?
With https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#editUrl and the edit URL for github https://github.com/okteto/docs/edit/main

# Testing
I've tested multiple versions and all work well:
- oldest 1.4
- current 1.10
- next 1.11

# Show me a screenshot
![image](https://github.com/okteto/docs/assets/49416765/d23654c9-7c33-4ef0-8b96-5e50983a5ee1)
