### PR TITLE
New supported flag for okteto preview list

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -14,4 +14,4 @@ dev:
     command: "yarn start"
     autocreate: true
     forward:
-      - 8080:8080
+      - 8081:8080

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -638,6 +638,7 @@ You need to be [logged in](reference/cli.mdx#context) to Okteto before running t
 |  Options  |  Type  | Description                                                                            |
 | :-------- | :----: | :------------------------------------------------------------------------------------- |
 | _--label_ | (list) | tag and organize preview environments using labels (multiple _--label_ flags accepted) |
+| _--output_|(string)| Output format. One of: ['json', 'yaml']                                                |
 
 #### sleep
 


### PR DESCRIPTION
This PR mentions the `--output` flag for the `okteto preview list` command that was added in [this PR](https://github.com/okteto/okteto/pull/3804)

![image](https://github.com/okteto/docs/assets/86051118/23431cc9-c0d4-455e-9107-d52eecd20635)
