### PR TITLE
Revert changes in public guides to explain again how to configure the cluster endpoint in the cart configuration

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -34,6 +34,13 @@ We recommend the following specs:
 - A pool with at least 3 `Standard D4` nodes
 - 250 GB per Standard SSD Managed Disk
 
+You'll be using the cluster's API server endpoint when configuring Okteto.
+Run the following command to obtain your cluster's API server endpoint:
+
+```
+kubectl config view --minify | grep server
+```
+
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -67,13 +74,15 @@ Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/do
 
 - Your `license` (optional)
 - A `subdomain`
+- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
-
 subdomain: dev.example.com
+cluster:
+  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -2,6 +2,9 @@ license:
 
 subdomain: 
 
+cluster:
+  endpoint:
+
 buildkit:
   persistence:
     enabled: true

--- a/src/content/self-hosted/civo.mdx
+++ b/src/content/self-hosted/civo.mdx
@@ -70,13 +70,15 @@ Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/d
 
 - Your `license` (optional)
 - A `subdomain`
+- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
-
 subdomain: dev.example.com
+cluster:
+  endpoint: "https://35.205.100.149"
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/civo/config.yaml
+++ b/src/content/self-hosted/civo/config.yaml
@@ -1,3 +1,11 @@
 license:
 
 subdomain: 
+
+cluster:
+  endpoint:
+
+ingress-nginx:
+  controller:
+    extraArgs:
+      enable-ssl-passthrough: "true"

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -35,6 +35,13 @@ To get started with Okteto, follow these specs:
 - A pool with at least 3 nodes (4CPUs and 16GBs each)
 - 250 GB per disk
 
+You'll be using the cluster's API server endpoint when configuring Okteto.
+Run the following command to obtain your cluster's API server endpoint:
+
+```
+kubectl config view --minify | grep server
+```
+
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -66,17 +73,20 @@ Download a copy of the [Okteto DigitalOcean configuration file](https://www.okte
 
 - Your `license` (optional)
 - A `subdomain`
+- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
-
 subdomain: dev.example.com
+cluster:
+  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:
     enabled: true
+
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -2,6 +2,9 @@ license:
 
 subdomain: 
 
+cluster:
+  endpoint:
+
 buildkit:
   persistence:
     enabled: true

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -34,6 +34,13 @@ We recommend the following specs:
 - A pool with at least 3 `m5.xlarge` nodes
 - 250 GB per disk
 
+You'll be using the cluster's API server endpoint when configuring Okteto.
+Run the following command to obtain your cluster's API server endpoint:
+
+```
+kubectl config view --minify | grep server
+```
+
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -67,13 +74,15 @@ Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/do
 
 - Your `license` (optional)
 - A `subdomain`
+- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
-
 subdomain: dev.example.com
+cluster:
+  endpoint: "https://XXXXXX.gr7.us-west-2.eks.amazonaws.com"
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -1,3 +1,12 @@
 license:
 
 subdomain: 
+
+cluster:
+  endpoint:
+
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -34,6 +34,13 @@ We recommend the following specs:
 - A pool with at least 3 `n2-standard-4` nodes
 - 250 GB per disk
 
+You'll be using the cluster's API server endpoint when configuring Okteto.
+Run the following command to obtain your cluster's API server endpoint:
+
+```
+kubectl config view --minify | grep server
+```
+
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -67,13 +74,16 @@ Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/do
 
 - Your `license` (optional)
 - A `subdomain`
+- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
-
 subdomain: dev.example.com
+
+cluster:
+  endpoint: https://35.205.100.149
 
 buildkit:
   persistence:

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -2,6 +2,9 @@ license:
 
 subdomain: 
 
+cluster:
+  endpoint:
+
 buildkit:
   persistence:
     enabled: true

--- a/src/content/self-hosted/install/config.yaml
+++ b/src/content/self-hosted/install/config.yaml
@@ -1,1 +1,4 @@
 license:
+
+cluster:
+  endpoint:

--- a/src/content/self-hosted/install/deployment.mdx
+++ b/src/content/self-hosted/install/deployment.mdx
@@ -14,12 +14,27 @@ Before running `helm install`, we recommend that you create a yaml configuration
 
 You can use [this sample configuration file](https://www.okteto.com/docs/self-hosted/install/config.yaml) as a starting point. The different configuration settings are explained below.
 
+### Cluster Endpoint
+
+This is the public endpoint of your Kubernetes cluster. It will be used by Okteto when generating `Kubeconfig` credentials for your users.
+
+```yaml
+cluster:
+  endpoint: "https://52.30.32.1"
+```
+
+Run the following command to obtain your cluster's API server endpoint:
+
+```
+kubectl config view --minify | grep server
+```
+
 ### License
 
 Okteto is free for small teams.  You get all the features of [Okteto](self-hosted.mdx) for up to 3 users.
 
 ```yaml
-license: 1234567890ABCD==
+license: XXXXX
 ```
 
 Want to use Okteto with a bigger team? [Let's talk](https://okteto.com/#talktous)

--- a/src/content/self-hosted/install/preparation.mdx
+++ b/src/content/self-hosted/install/preparation.mdx
@@ -33,6 +33,8 @@ We recommend the following specs:
 - A pool with at least 3 nodes with a minimum of 4CPUs and 16 GB of Memory
 - 250 GB per disk
 
+You'll be using the cluster's API server endpoint when configuring Okteto.
+
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -26,6 +26,13 @@ This guide will assume that your domain is registered in [AzureDNS](https://docs
 
 We recommend that you follow Azure's [cluster creation guide](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough) and check our [preparation guide](self-hosted/install/preparation.mdx#deploy-a-kubernetes-cluster).
 
+You'll be using the cluster's API server endpoint when configuring Okteto.
+Run the following command to obtain your cluster's API server endpoint:
+
+```
+kubectl config view --minify | grep server
+```
+
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -59,13 +66,15 @@ Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/do
 
 - Your `license` (optional)
 - A `subdomain`
+- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
-
 subdomain: dev.example.com
+cluster:
+  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:


### PR DESCRIPTION
We detected an scenario in which the Kubernetes API exposed behind our ingress is not working correctly when there are self-signed certificates, so we have to restore again the requirement of configuring the `cluster.endpoint` property until we fix it

This is a revert of commits 8387d26 and b08a6b9