### PR TITLE
Add redirects for enterprise => self-hosted

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[dev]
+  command = "npm start"
+  targetPort = 3000
+
 [[redirects]]
   from = "/docs/getting-started/installation"
   to = "/docs/cloud/okteto-cli"
@@ -6,6 +10,11 @@
 [[redirects]]
   from = "/docs/enterprise/*"
   to = "/docs/self-hosted/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/:version/enterprise/*"
+  to = "/docs/:version/self-hosted/:splat"
   status = 301
 
 # Redirect the current version to /docs/
@@ -79,3 +88,16 @@
 
 [build]
   functions = "netlify/functions"
+
+
+[[edge_functions]]
+function = "og-image"
+path = "/og-image"
+
+[[edge_functions]]
+function = "og"
+path = "/og"
+
+[[edge_functions]]
+function = "log"
+path = "/log"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,3 @@
-[dev]
-  command = "npm start"
-  targetPort = 3000
-
 [[redirects]]
   from = "/docs/getting-started/installation"
   to = "/docs/cloud/okteto-cli"
@@ -88,16 +84,3 @@
 
 [build]
   functions = "netlify/functions"
-
-
-[[edge_functions]]
-function = "og-image"
-path = "/og-image"
-
-[[edge_functions]]
-function = "og"
-path = "/og"
-
-[[edge_functions]]
-function = "log"
-path = "/log"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,11 +8,6 @@
   to = "/docs/self-hosted/:splat"
   status = 301
 
-[[redirects]]
-  from = "/docs/:version/enterprise/*"
-  to = "/docs/:version/self-hosted/:splat"
-  status = 301
-
 # Redirect the current version to /docs/
 [[redirects]]
   from = "/docs/1.10/*"
@@ -23,48 +18,43 @@
 # These redirects make sure we don’t show a 404
 
 [[redirects]]
-  from = "/docs/1.3/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/1.3/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]
-  from = "/docs/1.2/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/1.2/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]
-  from = "/docs/1.1/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/1.1/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]
-  from = "/docs/1.0/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/1.0/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]
-  from = "/docs/0.15/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/0.15/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]
-  from = "/docs/0.14/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/0.14/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]
-  from = "/docs/0.14/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/0.12/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]
-  from = "/docs/0.12/welcome/overview/"
-  to = "/docs/"
-  status = 301
-
-[[redirects]]
-  from = "/docs/0.11/welcome/overview/"
-  to = "/docs/"
+  from = "/docs/0.11/*"
+  to = "/docs/:splat"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
Redirects old version to the current docs path

### Test plan

https://deploy-preview-457--okteto-docs.netlify.app/docs/0.12/enterprise/install/deployment/ should redirect to https://deploy-preview-457--okteto-docs.netlify.app/docs/self-hosted/install/deployment/