### PR TITLE
Added documentation about SSH in the --remote flag of deploy and destroy commands

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -253,7 +253,7 @@ $ okteto deploy
 | _--var_                                     |   (list)   | Set a pipeline variable (can be set more than once)                                                                                                            |
 | _--wait_                                    |   (bool)   | Wait until the pipeline finishes (defaults to false)                                                                                                           |
 | _--no-bash_                                 |   (bool)   | Execute the command using the container's default shell instead of bash (defaults to false)                                                                    |
-| _--remote_                                  |   (bool)   | Run the deploy commands in your Okteto cluster. Okteto will connect your local SSH agent with the cluster so you so can for example clone any private repository as part of your manifest execution as long as your local agent has the proper ssh key configured                                                                                                                 |
+| _--remote_                                  |   (bool)   | Run the deploy commands in your Okteto cluster. Okteto will connect your local SSH agent with the cluster. For example, this lets you clone any private repository as part of your manifest execution as long as your local agent has the proper ssh key configured                                                                                                             |
 
 
 > Executed commands will be executed using bash unless the `--no-bash` flag has been specified.
@@ -279,7 +279,7 @@ $ okteto destroy
 | _--wait_                                 |  (bool)  | Wait until the development environment is destroyed (defaults to `false`)                                                                               |
 | _--no-bash_                              |  (bool)  | Execute the command using the container's default shell instead of bash (defaults to false)                                                             |
 | _--all_                                  |  (bool)  | Destroy everything (defaults to `false`)                                                                                                                |
-| _--remote_                               |  (bool)  | Run the destroy commands in your Okteto cluster. Okteto will connect your local SSH agent with the cluster so you so can for example clone any private repository as part of your manifest execution as long as your local agent has the proper ssh key configured                                                                                                         |
+| _--remote_                               |  (bool)  | Run the deploy commands in your Okteto cluster. Okteto will connect your local SSH agent with the cluster. For example, this lets you clone any private repository as part of your manifest execution as long as your local agent has the proper ssh key configured                                                                                                          |
 
 > Executed commands will be executed using bash unless the `--no-bash` flag has been specified.
 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -66,7 +66,7 @@ $ okteto build [service...]
 ```
 
 If your [okteto context](reference/cli.mdx#context) points to an Okteto URL, images are built using the [Okteto Build Service](cloud/build.mdx).
-Otherwise, images are built using your local Docker daemon. If you want to use another BuildKit instance, set the variable `BUILDKIT_HOST` to point to its address, using the format `HOST:PORT`. 
+Otherwise, images are built using your local Docker daemon. If you want to use another BuildKit instance, set the variable `BUILDKIT_HOST` to point to its address, using the format `HOST:PORT`.
 
 The following flags can be used (very similar to `docker build`):
 
@@ -83,7 +83,7 @@ The following flags can be used (very similar to `docker build`):
 >  You can also use the `-f` to point to a Dockerfile. In this mode, `okteto build` will ignore your Okteto manifest, and directly build the image defined in the Dockerfile. Use this to build images that are not defined on your [Okteto manifest](https://www.okteto.com/docs/reference/manifest/).
 
 With `okteto build --platform` you can specify the platform (or architecture) for which you'd like to build the container images. For example, you could use a multiplatform image and the `okteto build --platform` command to deploy your web application on a Kubernetes cluster that consists of nodes running on both x86-64 and ARMv7 architectures.
-By using the multiplatform images built using this method, you can deploy the same images across the cluster without worrying about the underlying hardware differences. 
+By using the multiplatform images built using this method, you can deploy the same images across the cluster without worrying about the underlying hardware differences.
 
 Let's consider an example where you have a Node.js application that you want to build and deploy on both x86_64 and ARM-based platforms. You have a Dockerfile in your project directory that defines the build process. Here's
 how Okteto CLI can help you build multiplatform images for your application:
@@ -108,7 +108,7 @@ okteto build -t myapp:latest --platform linux/amd64,linux/arm/v7
 
 This command builds a multi-architecture Docker image named *myapp* with the latest tag for both x86_64 and ARM platforms.
 
-By using these commands, you can easily build the application image for different platforms without needing to maintain separate Dockerfiles or perform manual modifications. 
+By using these commands, you can easily build the application image for different platforms without needing to maintain separate Dockerfiles or perform manual modifications.
 This is particularly useful when you want to deploy your application to heterogeneous environments where you have both x86_64 and ARM-based devices, such as a mixed-cluster Kubernetes setup.
 
 ### context
@@ -253,7 +253,7 @@ $ okteto deploy
 | _--var_                                     |   (list)   | Set a pipeline variable (can be set more than once)                                                                                                            |
 | _--wait_                                    |   (bool)   | Wait until the pipeline finishes (defaults to false)                                                                                                           |
 | _--no-bash_                                 |   (bool)   | Execute the command using the container's default shell instead of bash (defaults to false)                                                                    |
-| _--remote_                                  |   (bool)   | Run the deploy commands in your Okteto cluster                                                                                                                 |
+| _--remote_                                  |   (bool)   | Run the deploy commands in your Okteto cluster. Okteto will connect your local SSH agent with the cluster so you so can for example clone any private repository as part of your manifest execution as long as your local agent has the proper ssh key configured                                                                                                                 |
 
 
 > Executed commands will be executed using bash unless the `--no-bash` flag has been specified.
@@ -279,7 +279,7 @@ $ okteto destroy
 | _--wait_                                 |  (bool)  | Wait until the development environment is destroyed (defaults to `false`)                                                                               |
 | _--no-bash_                              |  (bool)  | Execute the command using the container's default shell instead of bash (defaults to false)                                                             |
 | _--all_                                  |  (bool)  | Destroy everything (defaults to `false`)                                                                                                                |
-| _--remote_                               |  (bool)  | Run the destroy commands in your Okteto cluster                                                                                                         |
+| _--remote_                               |  (bool)  | Run the destroy commands in your Okteto cluster. Okteto will connect your local SSH agent with the cluster so you so can for example clone any private repository as part of your manifest execution as long as your local agent has the proper ssh key configured                                                                                                         |
 
 > Executed commands will be executed using bash unless the `--no-bash` flag has been specified.
 


### PR DESCRIPTION
Added a comment in the flag `--remote` of deploy and destroy commands to indicate that Okteto uses your local SSH agent to clone private repositories when working remotely. Probably we should have a dedicated section for the remote execution but for now, I added it here