### PR TITLE
Updating quota section in self-hosted configuration docs.

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -1120,7 +1120,6 @@ Enables [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-qu
   - `maxReplicationControllers`: Maximum number of replication controllers per namespace.
   - `maxSecrets`: Maximum number of secrets per namespace.
   - `maxServices`: Maximum number of services per namespace.
-  - `maxIngresses`: Maximum number of ingresses per namespace.
   - `maxJobs`: Maximum number of jobs per namespace.
   - `maxCronjobs`: Maximum number of cronjobs per namespace.
   - `maxLoadBalancers`: Maximum number of services of type `LoadBalancer` per namespace.

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -577,7 +577,7 @@ The private container registry.
 
 #### storage
 
-Okteto supports different storage drivers to store the images inside the [Okteto Registry](cloud/registry.mdx). Check out our video tutorial on how to configure a persistent storage for your Okteto installation: 
+Okteto supports different storage drivers to store the images inside the [Okteto Registry](cloud/registry.mdx). Check out our video tutorial on how to configure a persistent storage for your Okteto installation:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/eaKc05Qzlvw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -1120,6 +1120,9 @@ Enables [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-qu
   - `maxReplicationControllers`: Maximum number of replication controllers per namespace.
   - `maxSecrets`: Maximum number of secrets per namespace.
   - `maxServices`: Maximum number of services per namespace.
+  - `maxIngresses`: Maximum number of ingresses per namespace.
+  - `maxJobs`: Maximum number of jobs per namespace.
+  - `maxCronjobs': Maximum number of cronjobs per namespace.
   - `maxLoadBalancers`: Maximum number of services of type `LoadBalancer` per namespace.
   - `maxNodePorts`: Maximum number of services of type `NodePort` per namespace.
   - `maxConfigMaps`: Maximum number of config maps per namespace.
@@ -1160,15 +1163,24 @@ quotas:
     maxNamespaces: "3"
     maxPods: "20"
     maxServices: "20"
+    maxLoadBalancers: "0"
+    maxNodePorts: "0"
     maxReplicationControllers: "30"
     maxSecrets: "50"
     maxConfigMaps: "50"
     maxPVCs: "10"
     maxVolumeSnapshots: "10"
+    maxIngresses: "20"
+    maxJobs: "20"
+    maxCronjobs: "20"
   bandwidth:
     enabled: false
     ingress: "800M"
     egress: "800M"
+    up:
+      enabled: false
+      ingress: "800M"
+      egress: "800M"
   requests:
     enabled: false
     cpu: "1"
@@ -1186,8 +1198,9 @@ quotas:
       memory: "12Gi"
     requests:
       enabled: true
-      cpu: "100m"
-      memory: "0.2Gi"
+      limitRequestRatio: 0
+      cpu: "10m"
+      memory: "50Mi"
     limits:
       enabled: true
       cpu: "2"

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -1122,7 +1122,7 @@ Enables [resource quotas](https://kubernetes.io/docs/concepts/policy/resource-qu
   - `maxServices`: Maximum number of services per namespace.
   - `maxIngresses`: Maximum number of ingresses per namespace.
   - `maxJobs`: Maximum number of jobs per namespace.
-  - `maxCronjobs': Maximum number of cronjobs per namespace.
+  - `maxCronjobs`: Maximum number of cronjobs per namespace.
   - `maxLoadBalancers`: Maximum number of services of type `LoadBalancer` per namespace.
   - `maxNodePorts`: Maximum number of services of type `NodePort` per namespace.
   - `maxConfigMaps`: Maximum number of config maps per namespace.


### PR DESCRIPTION
The quotas section has been updated with the defaults copied directly from the latest chart and missing descriptions have been added.