### PR TITLE
Document new helm chart setting for kubetokens expiration

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -577,7 +577,7 @@ The private container registry.
 
 #### storage
 
-Okteto supports different storage drivers to store the images inside the [Okteto Registry](cloud/registry.mdx). Check out our video tutorial on how to configure a persistent storage for your Okteto installation: 
+Okteto supports different storage drivers to store the images inside the [Okteto Registry](cloud/registry.mdx). Check out our video tutorial on how to configure a persistent storage for your Okteto installation:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/eaKc05Qzlvw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -944,6 +944,12 @@ If this is disabled, you'll need to provide your own image in `installer.image`.
 injectDevelopmentBinaries:
   enabled: true
 ```
+
+### kubetoken
+
+- `lifetimeSeconds`: The lifetime in seconds of the tokens generated for the [Kubernetes credentials](cloud/credentials.mdx) provided by Okteto.
+
+> One important thing to bear in mind is that the maximum expiration time you can specify depends on the [Kubernetes apiserver's](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) flag `--service-account-max-token-expiration`, so it might happen that the expiration time retrieved on your tokens is not the one specified here. If you specify a higher value, you will always get the maximum allowed by the apiserver. Be aware that not all Kubernetes service providers allow you to change this value and they enforce their own.
 
 ### namespace
 

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -947,7 +947,7 @@ injectDevelopmentBinaries:
 
 ### kubetoken
 
-- `lifetimeSeconds`: The lifetime in seconds of the tokens generated for the [Kubernetes credentials](cloud/credentials.mdx) provided by Okteto.
+- `lifetimeSeconds`: The lifetime in seconds of the tokens generated for the [Kubernetes credentials](cloud/credentials.mdx) provided by Okteto. This value has to be equal or greater than [`installer.activeDeadlineSeconds`](self-hosted/administration/configuration.mdx#installer) to make sure the tokens are valid during all installer execution. Defaults to 86400 seconds (1 day).
 
 > One important thing to bear in mind is that the maximum expiration time you can specify depends on the [Kubernetes apiserver's](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) flag `--service-account-max-token-expiration`, so it might happen that the expiration time retrieved on your tokens is not the one specified here. If you specify a higher value, you will always get the maximum allowed by the apiserver. Be aware that not all Kubernetes service providers allow you to change this value and they enforce their own.
 


### PR DESCRIPTION
Added documentation for a new config setting which allow admins to change the expiration time of tokens used in Kubernetes credentials generated by Okteto.

Added a note to indicate that the maximum expiration might be limited by the Kubernetes server.