### PR TITLE
Added configuration settings to configure NLB for Okteto in default installation guide for EKS

### DIFF
--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -91,6 +91,8 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
+Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion ebtween the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
+
 ### Installing your Okteto instance
 
 Install the latest version of Okteto by running:

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -91,7 +91,7 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
-Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
+The `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
 
 ### Installing your Okteto instance
 

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -83,6 +83,12 @@ license: 1234567890ABCD==
 subdomain: dev.example.com
 cluster:
   endpoint: "https://XXXXXX.gr7.us-west-2.eks.amazonaws.com"
+
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/eks.mdx
+++ b/src/content/self-hosted/eks.mdx
@@ -91,7 +91,7 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
-Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion ebtween the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
+Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
 
 ### Installing your Okteto instance
 

--- a/versioned_docs/version-1.12/self-hosted/eks.mdx
+++ b/versioned_docs/version-1.12/self-hosted/eks.mdx
@@ -91,6 +91,8 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
+Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion ebtween the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
+
 ### Installing your Okteto instance
 
 Install the latest version of Okteto by running:

--- a/versioned_docs/version-1.12/self-hosted/eks.mdx
+++ b/versioned_docs/version-1.12/self-hosted/eks.mdx
@@ -91,7 +91,7 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
-Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
+The `service.beta.kubernetes.io/aws-load-balancer-type: nlb`  annotation is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
 
 ### Installing your Okteto instance
 

--- a/versioned_docs/version-1.12/self-hosted/eks.mdx
+++ b/versioned_docs/version-1.12/self-hosted/eks.mdx
@@ -83,6 +83,12 @@ license: 1234567890ABCD==
 subdomain: dev.example.com
 cluster:
   endpoint: "https://XXXXXX.gr7.us-west-2.eks.amazonaws.com"
+
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
 ### Installing your Okteto instance

--- a/versioned_docs/version-1.12/self-hosted/eks.mdx
+++ b/versioned_docs/version-1.12/self-hosted/eks.mdx
@@ -91,7 +91,7 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
 
-Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion ebtween the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
+Annotation `service.beta.kubernetes.io/aws-load-balancer-type: nlb` is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparasion between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
 
 ### Installing your Okteto instance
 


### PR DESCRIPTION
In the configuration file we offer to download directly from the docs (https://github.com/okteto/docs/blob/main/src/content/self-hosted/eks/config.yaml) we include the settings to configure an NLB, but the snippet in the page doesn't have it, so as NLB is preferred, I'm adding also those settings in the snippet in case users copy-paste directly from there instead of downloading the config example file