### PR TITLE
Update configuration.mdx

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -984,9 +984,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -979,8 +979,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.10/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.10/self-hosted/administration/configuration.mdx
@@ -955,9 +955,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/versioned_docs/version-1.10/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.10/self-hosted/administration/configuration.mdx
@@ -950,8 +950,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.11/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.11/self-hosted/administration/configuration.mdx
@@ -962,9 +962,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/versioned_docs/version-1.11/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.11/self-hosted/administration/configuration.mdx
@@ -957,8 +957,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.12/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.12/self-hosted/administration/configuration.mdx
@@ -973,8 +973,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.12/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.12/self-hosted/administration/configuration.mdx
@@ -978,9 +978,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/versioned_docs/version-1.12/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.12/self-hosted/administration/configuration.mdx
@@ -973,8 +973,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
@@ -811,8 +811,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.5/self-hosted/administration/configuration.mdx
@@ -816,9 +816,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/versioned_docs/version-1.6/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.6/self-hosted/administration/configuration.mdx
@@ -840,8 +840,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.6/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.6/self-hosted/administration/configuration.mdx
@@ -845,9 +845,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
@@ -885,8 +885,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.7/self-hosted/administration/configuration.mdx
@@ -890,9 +890,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
@@ -933,8 +933,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.8/self-hosted/administration/configuration.mdx
@@ -938,9 +938,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy

--- a/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
@@ -933,8 +933,8 @@ namespace:
 Configures [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for each namespace to isolate network traffic.
 Disabled by default.
 
-- `ingress`: Ingress list of rules ([NetworkPolicyIngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyingressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto. (optional).
-- `egress`: Egress list of rules ([NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#networkpolicyegressrule-v1-networking-k8s-io)) to be applied on every namespace managed by Okteto (optional).
+- `ingress`: Ingress list of rules (NetworkPolicyIngressRule) to be applied on every namespace managed by Okteto. (optional).
+- `egress`: Egress list of rules (NetworkPolicyEgressRule) to be applied on every namespace managed by Okteto (optional).
 
 ```yaml
 networkPolicies:

--- a/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.9/self-hosted/administration/configuration.mdx
@@ -938,9 +938,29 @@ Disabled by default.
 
 ```yaml
 networkPolicies:
-  enabled: false
-  ingress: []
-  egress: []
+  enabled: true
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
 ```
 
 ### podSecurityPolicy


### PR DESCRIPTION
The links referring to Ingress and Egress rules for v.1.22 lead to a page that no longer exists. 

Updated them to refer to v.1.25 instead.

Fixes https://github.com/okteto/docs/issues/479
