### PR TITLE
Added a blank line between date and supported version. It wasn't being rendered properly

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -8,6 +8,7 @@ id: releases
 ## 1.13.0
 
 27 September 2023
+
 This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes

--- a/versioned_docs/version-1.13/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.13/self-hosted/install/releases.mdx
@@ -8,6 +8,7 @@ id: releases
 ## 1.13.0
 
 27 September 2023
+
 This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes


### PR DESCRIPTION
Even if the phrase about supported Kubernetes versions was in a new line, it wasn't rendered corretly

<img width="696" alt="Captura de pantalla 2023-10-03 a las 13 41 40" src="https://github.com/okteto/docs/assets/3510171/92e62dbc-aa13-4d68-9d52-917df67a8b11">
