### PR TITLE
Enable registry persistence by default in the cloud-provider guides (…

### DIFF
--- a/src/content/self-hosted/aks.mdx
+++ b/src/content/self-hosted/aks.mdx
@@ -88,6 +88,11 @@ buildkit:
   persistence:
     enabled: true
 
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/aks/config.yaml
+++ b/src/content/self-hosted/aks/config.yaml
@@ -8,3 +8,9 @@ cluster:
 buildkit:
   persistence:
     enabled: true
+
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true

--- a/src/content/self-hosted/civo/config.yaml
+++ b/src/content/self-hosted/civo/config.yaml
@@ -4,8 +4,3 @@ subdomain:
 
 cluster:
   endpoint:
-
-ingress-nginx:
-  controller:
-    extraArgs:
-      enable-ssl-passthrough: "true"

--- a/src/content/self-hosted/digitalocean.mdx
+++ b/src/content/self-hosted/digitalocean.mdx
@@ -87,6 +87,11 @@ buildkit:
   persistence:
     enabled: true
 
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/digitalocean/config.yaml
+++ b/src/content/self-hosted/digitalocean/config.yaml
@@ -8,3 +8,9 @@ cluster:
 buildkit:
   persistence:
     enabled: true
+
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true

--- a/src/content/self-hosted/gke.mdx
+++ b/src/content/self-hosted/gke.mdx
@@ -88,6 +88,12 @@ cluster:
 buildkit:
   persistence:
     enabled: true
+
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true
 ```
 
 ### Installing your Okteto instance

--- a/src/content/self-hosted/gke/config.yaml
+++ b/src/content/self-hosted/gke/config.yaml
@@ -8,3 +8,9 @@ cluster:
 buildkit:
   persistence:
     enabled: true
+
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true

--- a/src/content/self-hosted/offline.mdx
+++ b/src/content/self-hosted/offline.mdx
@@ -79,6 +79,12 @@ cluster:
 buildkit:
   persistence:
     enabled: true
+
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true
 ```
 
 ### Installing your Okteto instance


### PR DESCRIPTION
…except for EKS)

For the cloud providers that we know that support PVCs by default, we can enable persistence storage for the registry in the default installation. This gives a better experience because you keep access to the existing images if the registry pod restarts.