### PR TITLE
add labels in dev environments docs

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -535,6 +535,8 @@ You need to be [logged in](reference/cli.mdx#context) to Okteto before running t
 | _--timeout_        | (duration) | The duration to wait for the pipeline to complete. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h (default 5m0s)                  |
 | _--var_            |   (list)   | Set a pipeline variable (can be set more than once)                                                                                                   |
 | _--wait_           |   (bool)   | Wait until the pipeline finishes (defaults to false)                                                                                                  |
+| _--label_          |   (list)   | Tag and organize development environments using labels (multiple _--label_ flags accepted)                                                            |
+| _--reuse-params_   |   (bool)   | If pipeline exist, reuse same parameters to redeploy)                                                                                                     |
 
 #### destroy
 
@@ -556,6 +558,26 @@ You need to be [logged in](reference/cli.mdx#context) to Okteto before running t
 | _--timeout_   | (string) | The duration to wait for the pipeline to be destroyed. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h (default 5m0s) |
 | _--volumes_   |  (bool)  | Destroy the persistent volumes created by the pipeline (defaults to false)                                                               |
 | _--wait_      |  (bool)  | Wait until the pipeline is destroyed (defaults to false)                                                                                 |
+
+#### list
+
+List all your okteto development environments in the namespace in use.
+
+```console
+$ okteto pipeline list
+```
+
+Run `okteto pipeline list` to get the status and info of your development environments.
+
+You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+
+|  Options  |  Type  | Description                                                                            |
+| :-------- | :----: | :------------------------------------------------------------------------------------- |
+| _--label_ | (list) | Tag and organize development environments using labels (multiple _--label_ flags accepted) |
+| _--output_|(string)| Output format. One of: ['json', 'yaml'] |
+| _--namespace_ | (string) | The Kubernetes namespace to use (defaults to the current kube config namespace) to list the development environments.|
+| _--context_ | (string) | Context where the pipelines to list are deployed (defaults to the current context) |
+
 
 ### preview
 

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -561,7 +561,7 @@ You need to be [logged in](reference/cli.mdx#context) to Okteto before running t
 
 #### list
 
-List all your okteto development environments in the namespace in use.
+List all your Okteto development environments in the current namespace.
 
 ```console
 $ okteto pipeline list

--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -520,7 +520,7 @@ This is equivalent to clicking the **Launch Dev Environment** button on the Okte
 $ okteto pipeline deploy
 ```
 
-You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+You must be [logged in](reference/cli.mdx#context) to Okteto before running this command.
 
 ##### Options
 
@@ -547,7 +547,7 @@ This is equivalent to clicking the **Destroy** button on the Okteto UI.
 $ okteto pipeline destroy
 ```
 
-You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+You must be [logged in](reference/cli.mdx#context) to Okteto before running this command.
 
 ##### Options
 
@@ -569,7 +569,7 @@ $ okteto pipeline list
 
 Run `okteto pipeline list` to get the status and info of your development environments.
 
-You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+You must be [logged in](reference/cli.mdx#context) to Okteto before running this command.
 
 |  Options  |  Type  | Description                                                                            |
 | :-------- | :----: | :------------------------------------------------------------------------------------- |
@@ -599,7 +599,7 @@ $ okteto preview deploy [name]
 
 Run `okteto preview deploy` to automatically deploy a preview environment for your branch.
 
-You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+You must be [logged in](reference/cli.mdx#context) to Okteto before running this command.
 Only users with [admin access](administration/dashboard.mdx) can deploy a global preview environment.
 
 | Options                                   |    Type    | Description                                                                                                                                                                                                                                               |
@@ -624,7 +624,7 @@ $ okteto preview destroy [name]
 
 Run `okteto preview destroy` to destroy a given preview environment.
 
-You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+You must be [logged in](reference/cli.mdx#context) to Okteto before running this command.
 Only users with administration privileges can destroy a global preview environment.
 If the manifest includes `destroy` commands, they will be executed as part of this command.
 
@@ -640,7 +640,7 @@ List the endpoints of a preview environment.
 $ okteto preview endpoints [name]
 ```
 
-You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+You must be [logged in](reference/cli.mdx#context) to Okteto before running this command.
 
 | Options    |   Type   | Description                     |
 | :--------- | :------: | :------------------------------ |
@@ -658,7 +658,7 @@ $ okteto preview list
 
 Run `okteto preview list` to get the status and scope of your preview environments.
 
-You need to be [logged in](reference/cli.mdx#context) to Okteto before running this command.
+You must be [logged in](reference/cli.mdx#context) to Okteto before running this command.
 
 |  Options  |  Type  | Description                                                                            |
 | :-------- | :----: | :------------------------------------------------------------------------------------- |


### PR DESCRIPTION
### Proposed changes
documentation about new flags and subcommands to support labels for dev environments.

Changes are:
- new flag `--label` in `okteto pipeline deploy` command
- new flag `--reuse-params` in `okteto pipeline deploy` command
- new command `list` for `okteto pipeline`
- flags supported in `okteto pipeline list` command