### PR TITLE
docs: add cmd flags to `context show`

### DIFF
--- a/src/content/reference/cli.mdx
+++ b/src/content/reference/cli.mdx
@@ -187,10 +187,15 @@ Print the current context.
 $ okteto context show
 ```
 
+| Options           |   Type   | Description                                             |
+|-------------------|:--------:|---------------------------------------------------------|
+| _--include-token_ |  (bool)  | Include the token in the output (default: `false`)      |
+| _--output_        | (string) | Output format. One of: `json`, `yaml` (default: `json`) |
+
 ```console
 {
   "name": "https://okteto.example.com",
-  "token": "REDACTED",
+  "token": "REDACTED", # only printed using flag: --include-token
   "namespace": "cindylopez",
   "builder": "tcp://buildkit.okteto.example.com:1234",
   "registry": "registry.okteto.example.com",


### PR DESCRIPTION
Updates the docs for `okteto context show` which has a new flag called `--include-token` (see related [PR](https://github.com/okteto/okteto/pull/4010))

| Before | After |
|--------|-------|
|    <img src="https://github.com/okteto/docs/assets/2318450/e76c325c-f78f-44df-9137-fb0a60dceea7" width="300" height="auto" alt="before" />    |     <img src="https://github.com/okteto/docs/assets/2318450/9ef71340-8810-4aa2-9c96-78f844eadeff" width="300" height="auto" alt="after" />  |
