### PR TITLE
Added documentation for 1.15.x release indicating the change we did to enable chroot by default

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -5,6 +5,17 @@ sidebar_label: Release Notes
 id: releases
 ---
 
+## 1.15.0
+
+TBD
+
+This version is compatible with Kubernetes versions 1.25 to 1.27.
+
+### Improvements
+
+- Upgrade ingress-nginx to 1.9.4 (Helm chart version 4.8.3)  <!-- 7386 -->
+- Enabled [chroot mode](https://kubernetes.io/blog/2022/04/28/ingress-nginx-1-2-0/) by default in both ingress-nginx controllers managed by Okteto. More info in [Upgrade your Okteto instance section](https://www.okteto.com/docs/self-hosted/install/upgrade/#upgrading-to-okteto-115x) <!-- 7425 -->
+
 ## 1.14.2
 
 8 November 2023

--- a/src/content/self-hosted/install/upgrade.mdx
+++ b/src/content/self-hosted/install/upgrade.mdx
@@ -25,6 +25,24 @@ $ helm upgrade okteto okteto/okteto -f config.yaml --namespace=okteto --version 
 
 Please review [the release notes](self-hosted/install/releases.mdx) before upgrading. New features, known issues, and configuration changes will be listed there.
 
+## Upgrading to Okteto 1.15.x
+
+As part of [1.15.0](self-hosted/install/releases.mdx#1150), we have enabled by default [chroot mode](https://kubernetes.io/blog/2022/04/28/ingress-nginx-1-2-0/) of the ingress controllers deployed as part of Okteto in order to reduce the resources accessible by the nginx process. This change will be applied automatically as part of the upgrade process to `1.15.x`, but it is important to know that the ingress controller pods need the capability `SYS_CHROOT` to work, so you have to make sure you can use it in your cluster.
+
+Chroot mode can be disabled anytime in both ingress controllers by setting the following values in your helm configuration:
+
+```yaml
+ingress-nginx:
+  controller:
+    image:
+      chroot: false
+
+okteto-nginx:
+  controller:
+    image:
+      chroot: false
+```
+
 ## Upgrading to Okteto 1.14.x
 
 As part of [1.14.0](self-hosted/install/releases.mdx#1140), we have changed the way you can configure credentials for private registries. Before, you had to specify them in your helm configuration under `privateRegistry` key. From now on, that section (`privateRegistry`) is deprecated and we have added new options in the [Admin view](administration/dashboard.mdx#registry-credentials) to manage them there.


### PR DESCRIPTION
As part of `1.15.x` release, we will enable [chroot mode](https://kubernetes.io/blog/2022/04/28/ingress-nginx-1-2-0/) by default in our ingress controllers.

This PR adds a call out to it letting customers know that it implies to include a new capability to controller pods and it has to be available. It also indicates how to disable it in case they are not interested on it 