### PR TITLE
Fix default

### DIFF
--- a/src/content/self-hosted/administration/configuration.mdx
+++ b/src/content/self-hosted/administration/configuration.mdx
@@ -948,7 +948,7 @@ Configures the [Okteto Insights](administration/okteto-insights.mdx) feature in 
 
 - `enabled`: Whether to enable Okteto Insights. Defaults to `false`.
 - `bearerSecret.name`: Name of the secret where the token to acces Okteto Insights metrics is stored. Defaults to `okteto-insights`.
-- `bearerSecret.key`: Name of the key within the secret where the token to access Okteto Insights metrics is stored. Defaults to `token`.
+- `bearerSecret.key`: Name of the key within the secret where the token to access Okteto Insights metrics is stored. Defaults to `bearer`.
 
 ### kubetoken
 

--- a/versioned_docs/version-1.14/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.14/self-hosted/administration/configuration.mdx
@@ -948,7 +948,7 @@ Configures the [Okteto Insights](administration/okteto-insights.mdx) feature in 
 
 - `enabled`: Whether to enable Okteto Insights. Defaults to `false`.
 - `bearerSecret.name`: Name of the secret where the token to acces Okteto Insights metrics is stored. Defaults to `okteto-insights`.
-- `bearerSecret.key`: Name of the key within the secret where the token to access Okteto Insights metrics is stored. Defaults to `token`.
+- `bearerSecret.key`: Name of the key within the secret where the token to access Okteto Insights metrics is stored. Defaults to `bearer`.
 
 ### kubetoken
 

--- a/versioned_docs/version-1.15/self-hosted/administration/configuration.mdx
+++ b/versioned_docs/version-1.15/self-hosted/administration/configuration.mdx
@@ -948,7 +948,7 @@ Configures the [Okteto Insights](administration/okteto-insights.mdx) feature in 
 
 - `enabled`: Whether to enable Okteto Insights. Defaults to `false`.
 - `bearerSecret.name`: Name of the secret where the token to acces Okteto Insights metrics is stored. Defaults to `okteto-insights`.
-- `bearerSecret.key`: Name of the key within the secret where the token to access Okteto Insights metrics is stored. Defaults to `token`.
+- `bearerSecret.key`: Name of the key within the secret where the token to access Okteto Insights metrics is stored. Defaults to `bearer`.
 
 ### kubetoken
 


### PR DESCRIPTION
The default is `bearer` as per https://artifacthub.io/packages/helm/okteto/okteto?modal=values&path=insights