### PR TITLE
Fixed kubernetes supported version for last patch version of 1.15

### DIFF
--- a/src/content/self-hosted/install/releases.mdx
+++ b/src/content/self-hosted/install/releases.mdx
@@ -9,7 +9,7 @@ id: releases
 
 1 December 2023
 
-This version is compatible with Kubernetes versions 1.24 to 1.27.
+This version is compatible with Kubernetes versions 1.25 to 1.27.
 
 ### Bugfixes
 

--- a/versioned_docs/version-1.15/self-hosted/install/releases.mdx
+++ b/versioned_docs/version-1.15/self-hosted/install/releases.mdx
@@ -9,7 +9,7 @@ id: releases
 
 1 December 2023
 
-This version is compatible with Kubernetes versions 1.24 to 1.27.
+This version is compatible with Kubernetes versions 1.25 to 1.27.
 
 ### Bugfixes
 


### PR DESCRIPTION
Supported versions for `1.15` are: `1.25`, `1.26` and `1.27`