### PR TITLE
Remove references to cluster.endpoint

### DIFF
--- a/src/content/get-started/cloud-provider-guides/aks.mdx
+++ b/src/content/get-started/cloud-provider-guides/aks.mdx
@@ -35,13 +35,6 @@ We recommend the following specs:
 - A pool with at least 3 `Standard D4` nodes
 - 250 GB per Standard SSD Managed Disk
 
-You'll be using the cluster's API server endpoint when configuring Okteto.
-Run the following command to obtain your cluster's API server endpoint:
-
-```
-kubectl config view --minify | grep server
-```
-
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -75,15 +68,12 @@ Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/do
 
 - Your `license`
 - A `subdomain`
-- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:

--- a/src/content/get-started/cloud-provider-guides/civo.mdx
+++ b/src/content/get-started/cloud-provider-guides/civo.mdx
@@ -71,15 +71,12 @@ Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/d
 
 - Your `license`
 - A `subdomain`
-- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://35.205.100.149"
 ```
 
 ### Installing your Okteto instance

--- a/src/content/get-started/cloud-provider-guides/digitalocean.mdx
+++ b/src/content/get-started/cloud-provider-guides/digitalocean.mdx
@@ -36,13 +36,6 @@ To get started with Okteto, follow these specs:
 - A pool with at least 3 nodes (4CPUs and 16GBs each)
 - 250 GB per disk
 
-You'll be using the cluster's API server endpoint when configuring Okteto.
-Run the following command to obtain your cluster's API server endpoint:
-
-```
-kubectl config view --minify | grep server
-```
-
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -74,15 +67,12 @@ Download a copy of the [Okteto DigitalOcean configuration file](https://www.okte
 
 - Your `license`
 - A `subdomain`
-- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://XXXXXX.aks.microsoft.com"
 
 buildkit:
   persistence:

--- a/src/content/get-started/cloud-provider-guides/eks.mdx
+++ b/src/content/get-started/cloud-provider-guides/eks.mdx
@@ -35,13 +35,6 @@ We recommend the following specs:
 - A pool with at least 3 `m5.xlarge` nodes
 - 250 GB per disk
 
-You'll be using the cluster's API server endpoint when configuring Okteto.
-Run the following command to obtain your cluster's API server endpoint:
-
-```
-kubectl config view --minify | grep server
-```
-
 > Our installation guides assume Okteto will be running in a dedicated cluster. We recommend [contacting our team](https://www.okteto.com/contact/) if you plan on installing Okteto in a cluster with other workloads.
 
 ### Installing kubectl
@@ -75,15 +68,12 @@ Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/do
 
 - Your `license`
 - A `subdomain`
-- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
 subdomain: dev.example.com
-cluster:
-  endpoint: "https://XXXXXX.gr7.us-west-2.eks.amazonaws.com"
 
 ingress-nginx:
   controller:

--- a/src/content/get-started/cloud-provider-guides/gke.mdx
+++ b/src/content/get-started/cloud-provider-guides/gke.mdx
@@ -75,16 +75,12 @@ Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/do
 
 - Your `license`
 - A `subdomain`
-- Your cluster's API server endpoint
 
 For example:
 
 ```yaml
 license: 1234567890ABCD==
 subdomain: dev.example.com
-
-cluster:
-  endpoint: https://35.205.100.149
 
 buildkit:
   persistence:

--- a/src/content/get-started/quickstart-guide.mdx
+++ b/src/content/get-started/quickstart-guide.mdx
@@ -14,21 +14,6 @@ Before running `helm install`, we recommend that you create a yaml configuration
 
 You can use [this sample configuration file](https://www.okteto.com/docs/self-hosted/install/config.yaml) as a starting point. The different configuration settings are explained below.
 
-### Cluster Endpoint
-
-This is the public endpoint of your Kubernetes cluster. It will be used by Okteto when generating `Kubeconfig` credentials for your users.
-
-```yaml
-cluster:
-  endpoint: "https://52.30.32.1"
-```
-
-Run the following command to obtain your cluster's API server endpoint:
-
-```
-kubectl config view --minify | grep server
-```
-
 ### License
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).


### PR DESCRIPTION
This pr removes references to cluster.endpoint in our q
uickstart guide, as well as our cloud provider guides as this is deprecated in 1.16