### PR TITLE
Add storage driver requirements to EKS install guide

### DIFF
--- a/src/content/get-started/cloud-provider-guides/eks.mdx
+++ b/src/content/get-started/cloud-provider-guides/eks.mdx
@@ -88,6 +88,16 @@ ingress-nginx:
     service:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+buildkit:
+  persistence:
+    enabled: true
+
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true
 ```
 
 The `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparison between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).

--- a/src/content/get-started/cloud-provider-guides/eks.mdx
+++ b/src/content/get-started/cloud-provider-guides/eks.mdx
@@ -54,6 +54,14 @@ helm repo add okteto https://charts.okteto.com
 helm repo update
 ```
 
+### Configure the Amazon EBS CSI storage driver
+Install the Amazon EBS CSI storage driver as an EKS add-on so that your cluster knows how to provision storage. Follow the [official documentation here.](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html#adding-ebs-csi-eks-add-on)
+
+Verify that your storage driver has been installed and is running correctly:
+```
+kubectl get pods -n kube-system | grep ebs-csi
+```
+
 ### Getting your Okteto License
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).

--- a/src/content/self-hosted/eks/config.yaml
+++ b/src/content/self-hosted/eks/config.yaml
@@ -7,3 +7,13 @@ ingress-nginx:
     service:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+buildkit:
+  persistence:
+    enabled: true
+
+registry:
+  storage:
+    filesystem:
+      persistence:
+        enabled: true


### PR DESCRIPTION
Add a step to the EKS SH install guide to add the Amazon EBS CLI storage driver add-on