### PR TITLE
Fix broken images

### DIFF
--- a/src/content/get-started/deploy-first-env.mdx
+++ b/src/content/get-started/deploy-first-env.mdx
@@ -6,9 +6,8 @@ id: deploy-first-environment
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](get-started/install-okteto-cli.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/get-started/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the Okteto dashboard.
 
 <p align="center">
-<Image
-  src="/docs/get-started/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -110,7 +109,7 @@ These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
   <Image
-    src="/docs/get-started/images/next-endpoints.png"
+    src={require("@site/static/img/next-endpoints.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/get-started/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/get-started/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](preview/overview.mdx)

--- a/versioned_docs/version-1.10/using-dev-envs.mdx
+++ b/versioned_docs/version-1.10/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the Okteto dashboard.
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.11/using-dev-envs.mdx
+++ b/versioned_docs/version-1.11/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the Okteto dashboard.
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.12/using-dev-envs.mdx
+++ b/versioned_docs/version-1.12/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the Okteto dashboard.
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.13/using-dev-envs.mdx
+++ b/versioned_docs/version-1.13/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the Okteto dashboard.
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.14/using-dev-envs.mdx
+++ b/versioned_docs/version-1.14/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the Okteto dashboard.
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.15/using-dev-envs.mdx
+++ b/versioned_docs/version-1.15/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the Okteto dashboard.
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the Okteto dashboard:
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.4/using-dev-envs.mdx
+++ b/versioned_docs/version-1.4/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We set configured Okteto CLI with Okteto Cloud in the [previous section](getting-started.mdx). In this section, let's do the fun bits of developing our application in our Development Environment.
 
@@ -21,7 +20,7 @@ Ideally, the application should look like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -65,11 +64,11 @@ You should see the deployed endpoints as part of the output in the CLI:
 These endpoints are also shown in the [Okteto Cloud dashboard](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -108,11 +107,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the [Okteto Cloud dashboard](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,10 +182,9 @@ Server running on port 8080.
 
 See the magic?
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -196,10 +194,11 @@ Okteto's Development Environment allowed the changes you made to your code local
 
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up.
 
 From here, we recommend the following next steps:
+
 - Try launching a Dev Environment for your own application following similar steps to what we saw in this guide.
 - If you want to know more things Okteto can help you with, have a look at our [Preview Environments](cloud/preview-environments/overview.mdx).

--- a/versioned_docs/version-1.5/using-dev-envs.mdx
+++ b/versioned_docs/version-1.5/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We set configured Okteto CLI with Okteto Cloud in the [previous section](getting-started.mdx). In this section, let's do the fun bits of developing our application in our Development Environment.
 
@@ -21,7 +20,7 @@ Ideally, the application should look like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -65,11 +64,11 @@ You should see the deployed endpoints as part of the output in the CLI:
 These endpoints are also shown in the [Okteto Cloud dashboard](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -108,11 +107,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the [Okteto Cloud dashboard](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,10 +182,9 @@ Server running on port 8080.
 
 See the magic?
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -196,10 +194,11 @@ Okteto's Development Environment allowed the changes you made to your code local
 
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up.
 
 From here, we recommend the following next steps:
+
 - Try launching a Dev Environment for your own application following similar steps to what we saw in this guide.
 - If you want to know more things Okteto can help you with, have a look at our [Preview Environments](cloud/preview-environments/overview.mdx).

--- a/versioned_docs/version-1.6/using-dev-envs.mdx
+++ b/versioned_docs/version-1.6/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We set configured Okteto CLI with Okteto Cloud in the [previous section](getting-started.mdx). In this section, let's do the fun bits of developing our application in our Development Environment.
 
@@ -21,7 +20,7 @@ Ideally, the application should look like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -65,11 +64,11 @@ You should see the deployed endpoints as part of the output in the CLI:
 These endpoints are also shown in the [Okteto Cloud dashboard](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -108,11 +107,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the [Okteto Cloud dashboard](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,10 +182,9 @@ Server running on port 8080.
 
 See the magic?
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -196,10 +194,11 @@ Okteto's Development Environment allowed the changes you made to your code local
 
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with Okteto Cloud. Then we saw how you could launch a Development Environment just using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Dev Environment we had spun up.
 
 From here, we recommend the following next steps:
+
 - Try launching a Dev Environment for your own application following similar steps to what we saw in this guide.
 - If you want to know more things Okteto can help you with, have a look at our [Preview Environments](cloud/preview-environments/overview.mdx).

--- a/versioned_docs/version-1.7/using-dev-envs.mdx
+++ b/versioned_docs/version-1.7/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the [Okteto UI](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the [Okteto UI](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.8/using-dev-envs.mdx
+++ b/versioned_docs/version-1.8/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the [Okteto UI](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the [Okteto UI](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)

--- a/versioned_docs/version-1.9/using-dev-envs.mdx
+++ b/versioned_docs/version-1.9/using-dev-envs.mdx
@@ -6,9 +6,8 @@ id: using-dev-envs
 ---
 
 import Image from "@theme/Image";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We configured Okteto CLI to use the Okteto platform in the [previous section](getting-started.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
 
@@ -19,13 +18,13 @@ We configured Okteto CLI to use the Okteto platform in the [previous section](ge
 In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
 
 - a React frontend
-- a Node.js backend API 
+- a Node.js backend API
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -47,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -67,11 +66,11 @@ When it's done building the images, it will start deploying your application to 
 These endpoints are also shown in the [Okteto UI](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/compose-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/compose-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -87,7 +86,7 @@ $ cd movies-with-helm
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -109,11 +108,11 @@ Success! Your application will be available shortly.
 These endpoints are also shown in the [Okteto UI](https://cloud.okteto.com/):
 
 <p align="center">
-<Image
-  src="/docs/images/next-endpoints.png"
-  alt="UI showing the movies app"
-  width="850"
-/>
+  <Image
+    src={require("@site/static/img/next-endpoints.png").default}
+    alt="UI showing the movies app"
+    width="850"
+  />
 </p>
 
 </TabItem>
@@ -159,7 +158,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies.png"
+    src={require("@site/static/img/next-ui-movies.png").default}
     alt="UI showing the movies app"
     width="850"
   />
@@ -183,22 +182,21 @@ Server running on port 8080.
 
 Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
-
 <p align="center">
   <Image
-    src="/docs/images/next-ui-movies-fixed.png"
+    src={require("@site/static/img/next-ui-movies-fixed.png").default}
     alt="UI showing the movies app"
     width="850"
   />
 </p>
 
-
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment. 
+Congratulations! You successfully developed your first application in a Remote Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up. 
+In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
 
 From here, we recommend:
+
 - Launching a Development Environment for your own application using this guide
 - Reading about Okteto's [Preview Environments](cloud/preview-environments/overview.mdx)


### PR DESCRIPTION
In https://github.com/okteto/docs/pull/558, we moved all the images into the `assets` folder - it looks like I missed one page