### PR TITLE
Typos in the getting started tutorial

### DIFF
--- a/src/content/get-started/deploy-first-env.mdx
+++ b/src/content/get-started/deploy-first-env.mdx
@@ -46,7 +46,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 
@@ -63,7 +63,7 @@ When it's done building the images, it will start deploying your application to 
   - https://movies-with-compose-cindylopez.example.okteto.com/
 ```
 
-These endpoints are also shown in the Okteto dashboard.
+The deployed endpoint is also shown in the Okteto dashboard.
 
 <p align="center">
   <Image
@@ -150,7 +150,7 @@ $ nodemon server.js
 Server running on port 8080.
 ```
 
-Now, you should be able to view your application when you visit these endpoints. Behind the scenes, the Development Environment in Okteto will synchronize your changes every time you save them locally.
+You should be able to view your application when you visit this endpoint. Behind the scenes, the Development Environment in Okteto will synchronize your changes every time you save them locally.
 
 ## Development Time!
 
@@ -164,7 +164,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
   />
 </p>
 
-The list of movies is the same as Cindy's list. Let's fix that.
+The list of movies is the same as Cindy's continue watching list. Let's fix that.
 
 Open your favorite IDE on your local machine and edit line 43 in `/api/server.js` to:
 
@@ -180,7 +180,7 @@ Now save your changes and refresh the browser. Okteto CLI will automatically syn
 Server running on port 8080.
 ```
 
-Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
+Okteto's Development Environment immediately picks up the changes you made on the deployed version of your application. You can see your changes by simply refreshing the browser. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
 <p align="center">
   <Image

--- a/src/content/get-started/install-okteto-cli.mdx
+++ b/src/content/get-started/install-okteto-cli.mdx
@@ -76,7 +76,7 @@ https://okteto.example.com *  cindylopez      tcp://buildkit.okteto.example.com:
 
 ## Define Your Okteto Manifest
 
-For Okteto CLI to know how to launch your Development Environment, it needs an [Okteto manifest](core/using-okteto-cli.mdx#okteto-manifest). This manifest is used to configure for your Development Environment. Okteto CLI will analyze any [existing manifests](core/using-okteto-cli.mdx#deployment-manifests) (Helm, Kubernetes, etc.) in your source code directory and help you write an Okteto manifest for your application.
+For Okteto CLI to know how to launch your Development Environment, it needs an [Okteto manifest](core/using-okteto-cli.mdx#okteto-manifest). This manifest is used to configure your Development Environment. Okteto CLI will analyze any [existing manifests](core/using-okteto-cli.mdx#deployment-manifests) (Helm, Kubernetes, etc.) in your source code directory and help you write an Okteto manifest for your application.
 
 The Okteto manifest is required in all cases except when a Docker compose file exists and is configured for your application.
 

--- a/versioned_docs/version-1.15/getting-started.mdx
+++ b/versioned_docs/version-1.15/getting-started.mdx
@@ -76,7 +76,7 @@ https://okteto.example.com *  cindylopez      tcp://buildkit.okteto.example.com:
 
 ## Define Your Okteto Manifest
 
-For Okteto CLI to know how to launch your Development Environment, it needs an [Okteto manifest](cloud/okteto-cli.mdx#okteto-manifest). This manifest is used to configure for your Development Environment. Okteto CLI will analyze any [existing manifests](cloud/okteto-cli.mdx#deployment-manifests) (Helm, Kubernetes, etc.) in your source code directory and help you write an Okteto manifest for your application.
+For Okteto CLI to know how to launch your Development Environment, it needs an [Okteto manifest](cloud/okteto-cli.mdx#okteto-manifest). This manifest is used to configure your Development Environment. Okteto CLI will analyze any [existing manifests](cloud/okteto-cli.mdx#deployment-manifests) (Helm, Kubernetes, etc.) in your source code directory and help you write an Okteto manifest for your application.
 
 The Okteto manifest is required in all cases except when a Docker compose file exists and is configured for your application.
 

--- a/versioned_docs/version-1.15/using-dev-envs.mdx
+++ b/versioned_docs/version-1.15/using-dev-envs.mdx
@@ -180,7 +180,7 @@ Now save your changes and refresh the browser. Okteto CLI will automatically syn
 Server running on port 8080.
 ```
 
-Okteto's Development Environment immediately shows the changes you made on the deployed version of your application. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
+Okteto's Development Environment immediately picks up the changes you made on the deployed version of your application. You can see your changes by simply refreshing the browser. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
 
 <p align="center">
   <Image

--- a/versioned_docs/version-1.15/using-dev-envs.mdx
+++ b/versioned_docs/version-1.15/using-dev-envs.mdx
@@ -47,7 +47,7 @@ $ cd movies-with-compose
 $ okteto up
 ```
 
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml) running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
+Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices. 
 
 When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
 

--- a/versioned_docs/version-1.15/using-dev-envs.mdx
+++ b/versioned_docs/version-1.15/using-dev-envs.mdx
@@ -150,7 +150,7 @@ $ nodemon server.js
 Server running on port 8080.
 ```
 
-Now, you should be able to view your application when you visit this endpoint. Behind the scenes, the Development Environment in Okteto will synchronize your changes every time you save them locally.
+You should be able to view your application when you visit this endpoint. Behind the scenes, the Development Environment in Okteto will synchronize your changes every time you save them locally.
 
 ## Development Time!
 

--- a/versioned_docs/version-1.15/using-dev-envs.mdx
+++ b/versioned_docs/version-1.15/using-dev-envs.mdx
@@ -150,7 +150,7 @@ $ nodemon server.js
 Server running on port 8080.
 ```
 
-Now, you should be able to view your application when you visit these endpoints. Behind the scenes, the Development Environment in Okteto will synchronize your changes every time you save them locally.
+Now, you should be able to view your application when you visit this endpoint. Behind the scenes, the Development Environment in Okteto will synchronize your changes every time you save them locally.
 
 ## Development Time!
 

--- a/versioned_docs/version-1.15/using-dev-envs.mdx
+++ b/versioned_docs/version-1.15/using-dev-envs.mdx
@@ -164,7 +164,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
   />
 </p>
 
-The list of movies is the same as Cindy's list. Let's fix that.
+The list of movies is the same as Cindy's continue watching list. Let's fix that.
 
 Open your favorite IDE on your local machine and edit line 43 in `/api/server.js` to:
 

--- a/versioned_docs/version-1.15/using-dev-envs.mdx
+++ b/versioned_docs/version-1.15/using-dev-envs.mdx
@@ -63,7 +63,7 @@ When it's done building the images, it will start deploying your application to 
   - https://movies-with-compose-cindylopez.example.okteto.com/
 ```
 
-These endpoints are also shown in the Okteto dashboard.
+The deployed endpoint is also shown in the Okteto dashboard.
 
 <p align="center">
   <Image


### PR DESCRIPTION
A few minor corrections to improve legibility of the getting started section plus a couple of comments below:

Beyond these changes there's something that puzzles me a bit about the [Movies App with Helm](https://www.okteto.com/docs/using-dev-envs/) section. I think it's a bit of a stretch to assume that the reader understands why the Helm option includes an Okteto Manifest. Basically my problem is with the first sentence in that section: "Since we already have an Okteto Manifest".

Also note the result of `okteto up` that I got, since it said that no endpoints were available while in the ui they were clearly there.

![image](https://github.com/okteto/docs/assets/7386558/4213a8df-929e-4f72-b8a1-71adc4e16869)
