### PR TITLE
Removing and rewording outdated config examples.

### DIFF
--- a/src/content/get-started/cloud-provider-guides/aks.mdx
+++ b/src/content/get-started/cloud-provider-guides/aks.mdx
@@ -64,9 +64,9 @@ If you are interested in evaluating Okteto, [sign up for our free 30 days trial.
 
 ### Configuring your Okteto instance
 
-Download a copy of the [Okteto AKS configuration file](https://www.okteto.com/docs/self-hosted/aks/config.yaml), open it, and update the following values:
+In order to install Okteto you need to first create a `config.yaml` for the installation process. This file requires two things:
 
-- Your `license`
+- Your Okteto `license`
 - A `subdomain`
 
 For example:
@@ -85,6 +85,7 @@ registry:
       persistence:
         enabled: true
 ```
+_Note: This is a very basic configuration. Learn more about the rest of the configuration options [here](reference/helm-chart-values.mdx)._
 
 ### Installing your Okteto instance
 

--- a/src/content/get-started/cloud-provider-guides/civo.mdx
+++ b/src/content/get-started/cloud-provider-guides/civo.mdx
@@ -66,9 +66,9 @@ If you are interested in evaluating Okteto, [sign up for our free 30 days trial.
 
 ### Configuring your Okteto instance
 
-Download a copy of the [Okteto Civo configuration file](https://www.okteto.com/docs/self-hosted/civo/config.yaml), open it, and update the following values:
+In order to install Okteto you need to first create a `config.yaml` for the installation process. This file requires two things:
 
-- Your `license`
+- Your Okteto `license`
 - A `subdomain`
 
 For example:
@@ -77,6 +77,7 @@ For example:
 license: 1234567890ABCD==
 subdomain: dev.example.com
 ```
+_Note: This is a very basic configuration. Learn more about the rest of the configuration options [here](reference/helm-chart-values.mdx)._
 
 ### Installing your Okteto instance
 

--- a/src/content/get-started/cloud-provider-guides/digitalocean.mdx
+++ b/src/content/get-started/cloud-provider-guides/digitalocean.mdx
@@ -63,9 +63,9 @@ If you are interested in evaluating Okteto, [sign up for our free 30 days trial.
 
 ## Installing Okteto
 
-Download a copy of the [Okteto DigitalOcean configuration file](https://www.okteto.com/docs/self-hosted/digitalocean/config.yaml), open it, and update the following values:
+In order to install Okteto you need to first create a `config.yaml` for the installation process. This file requires two things:
 
-- Your `license`
+- Your Okteto `license`
 - A `subdomain`
 
 For example:
@@ -84,6 +84,7 @@ registry:
       persistence:
         enabled: true
 ```
+_Note: This is a very basic configuration. Learn more about the rest of the configuration options [here](reference/helm-chart-values.mdx)._
 
 ### Installing your Okteto instance
 

--- a/src/content/get-started/cloud-provider-guides/eks.mdx
+++ b/src/content/get-started/cloud-provider-guides/eks.mdx
@@ -64,9 +64,9 @@ If you are interested in evaluating Okteto, [sign up for our free 30 days trial.
 
 ### Configuring your Okteto instance
 
-Download a copy of the [Okteto EKS configuration file](https://www.okteto.com/docs/self-hosted/eks/config.yaml), open it, and update the following values:
+In order to install Okteto you need to first create a `config.yaml` for the installation process. This file requires two things:
 
-- Your `license`
+- Your Okteto `license`
 - A `subdomain`
 
 For example:
@@ -81,6 +81,7 @@ ingress-nginx:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
 ```
+_Note: This is a very basic configuration. Learn more about the rest of the configuration options [here](reference/helm-chart-values.mdx)._
 
 The `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation is used to tell AWS to create a [Network Load Balancer (NLB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) instead of the default [Classic Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html) to expose the ingress controller. We recommend to use a NLB as it provides benefits like: websocket support, static IPs, and better performance. You can see a full comparison between the load balancers [here](https://aws.amazon.com/elasticloadbalancing/features/).
 

--- a/src/content/get-started/cloud-provider-guides/gke.mdx
+++ b/src/content/get-started/cloud-provider-guides/gke.mdx
@@ -71,9 +71,9 @@ If you are interested in evaluating Okteto, [sign up for our free 30 days trial.
 
 ### Configuring your Okteto instance
 
-Download a copy of the [Okteto GKE configuration file](https://www.okteto.com/docs/self-hosted/gke/config.yaml), open it, and set the following values:
+In order to install Okteto you need to first create a `config.yaml` for the installation process. This file requires two things:
 
-- Your `license`
+- Your Okteto `license`
 - A `subdomain`
 
 For example:
@@ -92,6 +92,7 @@ registry:
       persistence:
         enabled: true
 ```
+_Note: This is a very basic configuration. Learn more about the rest of the configuration options [here](reference/helm-chart-values.mdx)._
 
 ### Installing your Okteto instance
 


### PR DESCRIPTION
This PR removes mentions of sample `config.yaml` files since they are outdated/not maintained currently.

It rewords these sections and adds a reference link to the `Okteto helm values` reference page for further reading.