### PR TITLE
Update the GitLab sample for preview environments

### DIFF
--- a/src/content/preview/using-gitlab-cicd.mdx
+++ b/src/content/preview/using-gitlab-cicd.mdx
@@ -21,12 +21,12 @@ For this tutorial, we'll be using our sample [movies rental application](https:/
 To deploy a preview environment with Okteto, you need to define the following environment variables:
 
 1. `OKTETO_TOKEN`: an Okteto [personal access token](core/credentials/personal-access-tokens.mdx).
-1. [Optional] `OKTETO_URL`: Specify the URL of your Okteto instance (e.g., https://okteto.example.com). If empty, it will default to https://cloud.okteto.com.
+1. `OKTETO_URL`: specify the URL of your Okteto instance (e.g., https://okteto.example.com)
 
 To add the environment variables:
 
 1. Navigate to your GitLab repository.
-1. Go to the **Settings** menu on the left, and click on the **CI/CD** entry.
+1. Go to the **Settings** menu on the left, and click on the **CI/CD** entry:
 
 <p align="center">
   <Image
@@ -34,7 +34,8 @@ To add the environment variables:
     alt="GitLab settings, CI/CD"
   />
 </p>
-1. Expand the **Variables** section, and click on the **Add Variable** button.
+
+1. Expand the **Variables** section, and click on the **Add Variable** button:
 <p align="center">
   <Image
     src={
@@ -44,7 +45,7 @@ To add the environment variables:
   />
 </p>
 
-1. Add _OKTETO_TOKEN_ as the key, and your personal access token as the value, and press the _Add Variable_ button.
+1. Add _OKTETO_TOKEN_ as the key, and your personal access token as the value, and press the **Add Variable** button:
    <p align="center">
      <Image
        src={
@@ -54,6 +55,7 @@ To add the environment variables:
        alt="update variable with Okteto Token"
      />
    </p>
+
 1. Repeat the same process to add the _OKTETO_URL_ variables (optional)
    <p align="center">
      <Image
@@ -85,7 +87,7 @@ The `.gitlab-ci.yml` looks like this:
 
 ```yaml
 # file: .gitlab.ci.yml
-image: okteto/okteto:2.18.0
+image: okteto/okteto:2.23.1
 
 stages:
   - review
@@ -122,7 +124,7 @@ stop-review:
     - master
 ```
 
-There are two scopes for preview environments, `personal`, where the only one who has access to the environment is the user, and `global`, where all cluster members have access to it and do not need to have the user's name at the end of the preview environment name. To create a preview environment with global scope it is necessary to have administrator permissions.
+There are two scopes for preview environments, `personal`, where the only one who has access to the environment is the user, and `global`, where all cluster members have access to it. To create a preview environment with global scope it is necessary to have administrator permissions.
 
 A few recommendations when creating your preview environment:
 
@@ -148,71 +150,3 @@ After a few seconds, the workflow will update the pull request with the URL of y
 ## Step 4: Cleanup
 
 Merging the merge request or deleting the branch automatically triggers the `stop-review` job we defined in the `.gitlab-ci.yml` file. The `stop-review` job will destroy the preview environment automatically for you.
-
-## Configure your GitLab Runner in Okteto
-
-Okteto makes it easy to deploy your own [GitLab Runner](https://docs.gitlab.com/runner/) from the [Okteto Catalog](deploy/launch-from-catalog.mdx). Running your runners is useful if you find yourself constantly waiting for shared runners to be available or want to run more complex configurations.
-
-### Retrieve the Registration Information
-
-1. Navigate to your GitLab repository.
-1. Go to the **Settings** menu on the left, and click on the **CI/CD** entry.
-   <p align="center">
-     <Image
-       src={require("@site/static/img/gitlab-settings-cicd.png").default}
-       alt="settings for GitLab"
-     />
-   </p>
-1. Expand the **Runners** section, and copy the URL and registration tokens.
-   <p align="center">
-     <Image
-       src={
-         require("@site/static/img/gitlab-settings-cicd-registration.png")
-           .default
-       }
-       alt="GitLab specific runners"
-       width="650"
-     />
-   </p>
-
-### Deploy your GitLab Runner
-
-1. Log in using your Okteto account.
-1. Click on the **Deploy** button on the top.
-1. Choose **Catalog** as the source, select **gitlab-runner** from the options below, and click **Deploy**.
-
-<p align="center">
-  <Image
-    src={require("@site/static/img/gitlab-deploy-runner.png").default}
-    width="600"
-    alt="GitLab deploy runner"
-  />
-</p>
-
-1. On the **configuration** section, add your runner registration token to the `runnerRegistrationToken` key.
-
-<p align="center">
-  <Image
-    src={
-      require("@site/static/img/gitlab-deploy-runner-configuration.png").default
-    }
-    width="500"
-    alt="GitLab deploy runner configuration"
-  />
-</p>
-
-1. [Optional] If you're running your own GitLab instance, also update the value of `gitlabUrl`.
-1. Press the **Deploy** button.
-
-In a few seconds, your GitLab Runner will be deployed and registered with your repository. To validate this, go back to the **Runners** section on your repository's settings, and validate that the runner is available there.
-
-<p align="center">
-  <Image
-    src={
-      require("@site/static/img/gitlab-deploy-runner-registered.png").default
-    }
-    alt="GitLab runner registered"
-  />
-</p>
-
-> To learn more about GitLab Runners, we recommend you check [their official documentation](https://docs.gitlab.com/runner/).


### PR DESCRIPTION
- Remove mentions to Okteto Cloud from the Gitlab previews sample
- Remove references to the catalog, which was deprecated 2 releases ago