### PR TITLE
Added release notes for 1.16.1 and fixed the kubernetes supported versions

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -5,11 +5,22 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.16.1
+
+10 January 2024
+
+This version is compatible with Kubernetes versions 1.25 to 1.28.
+
+### Bugfixes
+
+- The Okteto CLI used for Pipeline installation has been upgraded to version [2.23.3](https://github.com/okteto/okteto/releases/tag/2.23.3). It includes a fix for scenarios where image builds were failing because an image was not being found in the global registry.
+- The Okteto Insights endpoint was not exposing build metrics when the Helm release name included the word "okteto"
+
 ## 1.16.0
 
 20 December 2023
 
-This version is compatible with Kubernetes versions 1.24 to 1.28.
+This version is compatible with Kubernetes versions 1.25 to 1.28.
 
 ### Features
 
@@ -34,7 +45,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.28.
 
 1 December 2023
 
-This version is compatible with Kubernetes versions 1.24 to 1.27.
+This version is compatible with Kubernetes versions 1.25 to 1.27.
 
 ### Bugfixes
 

--- a/versioned_docs/version-1.16/release-notes.mdx
+++ b/versioned_docs/version-1.16/release-notes.mdx
@@ -5,11 +5,22 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.16.1
+
+10 January 2024
+
+This version is compatible with Kubernetes versions 1.25 to 1.28.
+
+### Bugfixes
+
+- The Okteto CLI used for Pipeline installation has been upgraded to version [2.23.3](https://github.com/okteto/okteto/releases/tag/2.23.3). It includes a fix for scenarios where image builds were failing because an image was not being found in the global registry.
+- The Okteto Insights endpoint was not exposing build metrics when the Helm release name included the word "okteto"
+
 ## 1.16.0
 
 20 December 2023
 
-This version is compatible with Kubernetes versions 1.24 to 1.28.
+This version is compatible with Kubernetes versions 1.25 to 1.28.
 
 ### Features
 
@@ -33,7 +44,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.28.
 
 1 December 2023
 
-This version is compatible with Kubernetes versions 1.24 to 1.27.
+This version is compatible with Kubernetes versions 1.25 to 1.27.
 
 ### Bugfixes
 


### PR DESCRIPTION
* Release notes for `1.16.1`
* Fixing kubernetes supported versions. Support for `1.24` was dropped on `1.15`. In fact, `1.15` docs version has the right kubernetes versions