### PR TITLE
redirect getting started samples to new location

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -248,6 +248,11 @@
   to = "/docs/self-hosted/:splat"
   status = 301
 
+[[redirects]]
+  from = "/docs/samples/*"
+  to = "/docs/guides/samples/:splat"
+  status = 301
+
 # Redirect the current version to /docs/
 [[redirects]]
   from = "/docs/1.16/*"


### PR DESCRIPTION
redirect for getting started samples. Should fix broken links in getting started repositories.