### PR TITLE
Fixing missing and erroneous redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -69,8 +69,23 @@
   status = 301
 
 [[redirects]]
-  from = "/docs/self-hosted/install/*"
-  to = "/docs/self-hosted/manage/:splat"
+  from = "/docs/self-hosted/install/backup"
+  to = "/docs/self-hosted/manage/backup"
+  status = 301
+
+[[redirects]]
+  from = "/docs/self-hosted/install/upgrade"
+  to = "/docs/self-hosted/manage/upgrade"
+  status = 301
+
+[[redirects]]
+  from = "/docs/self-hosted/install/custom-resource-definitions"
+  to = "/docs/self-hosted/manage/custom-resource-definitions"
+  status = 301
+
+[[redirects]]
+  from = "/docs/self-hosted/install/troubleshooting"
+  to = "/docs/self-hosted/manage/troubleshooting"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
- Removed an erroneous `:splat` redirect that took precedence over other, correct redirects
- Added missing redirects