### PR TITLE
Don't build images, to make the getting started guides run faster

### DIFF
--- a/src/content/get-started/deploy-first-env.mdx
+++ b/src/content/get-started/deploy-first-env.mdx
@@ -1,24 +1,23 @@
 ---
 title: Development Environments
 description: In this section, we'll see how you can start using your Development Environment.
-sidebar_label: Deploy your first environment
+sidebar_label: Your first environment
 id: deploy-first-environment
 ---
 
 import Image from "@theme/Image";
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
-We configured Okteto CLI to use the Okteto platform in the [previous section](get-started/install-okteto-cli.mdx). In this section, we'll do the fun part: work on our application in our Okteto Development Environment.
+You configured the Okteto CLI to use your Okteto cluster in the [previous section](get-started/install-okteto-cli.mdx). In this section, you'll do the fun part: work on your application in a Development Environment.
 
 ## One Command To Rule Them All
 
 `okteto up` is the focal point of the Okteto CLI experience and is a big part of what makes Okteto so easy to use.
 
-In this guide we'll be fixing a bug in our sample Movies application. The application consists of:
+In this guide you'll be fixing a bug in the Movies app. The application consists of:
 
 - a React frontend
 - a Node.js backend API
+- a MongoDB database
 
 The frontend uses the REST endpoints of the backend API and loads two different lists of movies based on its response. Ideally, the application looks like this:
 
@@ -30,65 +29,22 @@ The frontend uses the REST endpoints of the backend API and loads two different 
   />
 </p>
 
-But there is a bug in the backend code we need to fix to get to this working state 🙂
+But there is a bug in the backend code you need to fix to get to this working state 🙂. Let's fix it using an Okteto Development Environment.
 
-We'll be using two different versions of this Movies application to demonstrate this. One [using Docker Compose](https://github.com/okteto/movies-with-compose) and one [using Helm charts](https://github.com/okteto/movies-with-helm) to deploy the application.
-
-<Tabs>
-<TabItem value="docker" label="Movies App with Docker Compose" default>
-
-```console
-$ git clone https://github.com/okteto/movies-with-compose
-$ cd movies-with-compose
-```
-
-```console
-$ okteto up
-```
-
-Since we already have a [Docker compose file](https://github.com/okteto/movies-with-compose/blob/main/docker-compose.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
-
-When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
-
-```console
- ✓  Endpoint 'movies' created
- ✓  Volume 'data' created
- ✓  Service 'frontend' created
- ✓  Service 'mongodb' created
- ✓  Service 'api' created
- ✓  Service 'init' created
- ✓  Service 'movies' created
- ✓  Compose 'movies-with-compose' successfully deployed
- i  Endpoints available:
-  - https://movies-with-compose-cindylopez.okteto.example.com/
-```
-
-The deployed endpoint is also shown in the Okteto dashboard.
-
-<p align="center">
-  <Image
-    src={require("@site/static/img/compose-endpoints.png").default}
-    alt="UI showing the movies app"
-    width="850"
-  />
-</p>
-
-</TabItem>
-
-<TabItem value="helm" label="Movies App with Helm">
+Start by cloning the Movies app repository:
 
 ```console
 $ git clone https://github.com/okteto/movies-with-helm
 $ cd movies-with-helm
 ```
 
+Since the repo already has an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` will start your Development Environment:
+
 ```console
 $ okteto up
 ```
 
-Since we already have an [Okteto manifest](https://github.com/okteto/movies-with-helm/blob/main/okteto.yml), running `okteto up` should show Okteto CLI building the required Docker images for your microservices.
-
-When it's done building the images, it will start deploying your application to the Okteto platform. You should see the deployed endpoints as part of the output in the CLI:
+You should see the deployed endpoints as part of the output in the CLI:
 
 ```console
 Release "movies" does not exist. Installing it now.
@@ -105,19 +61,15 @@ Success! Your application will be available shortly.
   - https://movies-cindylopez.okteto.example.com/api
 ```
 
-These endpoints are also shown in the Okteto dashboard:
+These endpoints are also shown in the Okteto UI:
 
 <p align="center">
   <Image
     src={require("@site/static/img/next-endpoints.png").default}
-    alt="UI showing the movies app"
+    alt="UI showing the Movies app"
     width="850"
   />
 </p>
-
-</TabItem>
-
-</Tabs>
 
 Next, a prompt will ask for the microservice you want to develop.
 
@@ -128,7 +80,7 @@ Next, a prompt will ask for the microservice you want to develop.
     frontend
 ```
 
-Let's go with `api` because we know there's a bug there we need to fix 🙂
+Let's go with `api` because you know there's a bug there you need to fix 🙂
 
 ```console
  ✓  Development container 'api' selected
@@ -136,7 +88,7 @@ Let's go with `api` because we know there's a bug there we need to fix 🙂
  ✓  Images successfully pulled
  ✓  Files synchronized
     Context:   okteto.example.com
-    Namespace: cindylopezlopez
+    Namespace: cindylopez
     Name:      api
     Forward:   9229 -> 9229
 
@@ -150,7 +102,7 @@ $ nodemon server.js
 Server running on port 8080.
 ```
 
-You should be able to view your application when you visit this endpoint. Behind the scenes, the Development Environment in Okteto will synchronize your changes every time you save them locally.
+You should be able to view your application when you visit this endpoint. Behind the scenes, Okteto will synchronize your changes to your Development Environment every time you save them locally.
 
 ## Development Time!
 
@@ -159,7 +111,7 @@ Visiting the frontend endpoint for the Movies app, something doesn't look right 
 <p align="center">
   <Image
     src={require("@site/static/img/next-ui-movies.png").default}
-    alt="UI showing the movies app"
+    alt="UI showing the Movies app"
     width="850"
   />
 </p>
@@ -172,7 +124,8 @@ Open your favorite IDE on your local machine and edit line 43 in `/api/server.js
   db.collection('watching').find().toArray( (err, results) =>{
 ```
 
-Now save your changes and refresh the browser. Okteto CLI will automatically synchronize your changes to your development environment. Take a look at the development environment shell and notice how the changes are detected by [nodemon](https://www.npmjs.com/package/nodemon) and automatically hot reloaded.
+Now save your changes. Okteto will automatically synchronize your changes to your Development Environment.
+Take a look at the shell and notice how the changes are detected by [nodemon](https://www.npmjs.com/package/nodemon) and automatically hot reloaded.
 
 ```console
 [nodemon] restarting due to changes...
@@ -180,21 +133,22 @@ Now save your changes and refresh the browser. Okteto CLI will automatically syn
 Server running on port 8080.
 ```
 
-Okteto's Development Environment immediately picks up the changes you made on the deployed version of your application. You can see your changes by simply refreshing the browser. You don't need to wait for a CI pipeline to complete before you can validate the changes you've made. This saves a ton of time.
+Great, you can see your changes by simply refreshing the browser. This saves a ton of time!
 
 <p align="center">
   <Image
     src={require("@site/static/img/next-ui-movies-fixed.png").default}
-    alt="UI showing the movies app"
+    alt="UI showing the Movies app"
     width="850"
   />
 </p>
 
 ## Next Steps
 
-Congratulations! You successfully developed your first application in a Remote Development Environment.
+Congratulations! You successfully developed your first application in an Okteto Development Environment.
 
-In this Getting Started guide, we learned how to install Okteto CLI and configure it with the Okteto platform. Then we launched a Development Environment using a single command: `okteto up`. After that, we fixed a bug in our Movies application using the Development Environment we just set up.
+In this Getting Started guide, we launched an Okteto Development Environment using a single command: `okteto up`.
+After that, we fixed a bug in our Movies app taking advantage of a blazing fast feedback loop 🚀
 
 From here, we recommend:
 

--- a/src/content/guides/samples/aspnetcore.mdx
+++ b/src/content/guides/samples/aspnetcore.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to develop and debug an ASP.NET application usin
 
 ## Prerequisites
 
-Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our getting started guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
+Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our installation guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
 
 ## Step 1: Deploy the ASP.NET Sample App
 
@@ -24,16 +24,9 @@ $ git clone https://github.com/okteto/aspnetcore-getting-started
 $ cd aspnetcore-getting-started
 ```
 
-At the root of the directory, you'll find the `okteto.yaml` file. This describes how to [build](reference/okteto-manifest.mdx#build-object-optional) and [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the ASP.NET Sample App.
+At the root of the directory, you'll find the `okteto.yml` file. This file describes how to [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the ASP.NET Sample App.
 
-```
-build:
-  hello-world:
-    image: okteto.dev/aspnet-hello-world:1.0.0
-    context: .
-  hello-world-dev:
-    context: .
-    target: dev
+```yaml
 deploy:
   - kubectl apply -f k8s.yml
 ```
@@ -41,16 +34,11 @@ deploy:
 Deploy your development environment by executing:
 
 ```console
-$ okteto deploy --build
+$ okteto deploy
 ```
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/aspnet-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-[+] Building 5.9s (11/11) FINISHED
- ...
- ✓  Image 'registry.okteto.example.com/cindy/aspnet-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -73,10 +61,10 @@ Did you notice that you're accessing your application through an HTTPs endpoint?
 
 The [dev](reference/okteto-manifest.mdx#dev-object-optional) section defines how to activate a development container for the ASP.NET Sample App:
 
-```
+```yaml
 dev:
   hello-world:
-    image: ${OKTETO_BUILD_HELLO_WORLD_DEV_IMAGE}
+    image: okteto/aspnetcore-getting-started:dev
     command: bash
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
@@ -85,7 +73,7 @@ dev:
 
 The `hello-world` key matches the name of the hello world Deployment. The meaning of the rest of fields is:
 
-- `image`: the image used by the development container. More information on development images [here](deploy/development-environments.mdx) and [dynamic value for the tag](reference/okteto-manifest.mdx#build-object-optional)
+- `image`: the image used by the development container (built from this [Dockerfile](https://github.com/okteto/aspnetcore-getting-started/blob/main/Dockerfile)).
 - `command`: the start command of the development container.
 - `environment`: the environment variables added or overwritten in your development container.
 - `remote`: the local port to use for SSH communication with your development environment.

--- a/src/content/guides/samples/golang.mdx
+++ b/src/content/guides/samples/golang.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to develop and debug a Go application using Okte
 
 ## Prerequisites
 
-Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our getting started guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
+Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our installation guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
 
 ## Step 1: Deploy the Go Sample App
 
@@ -24,14 +24,9 @@ $ git clone https://github.com/okteto/go-getting-started
 $ cd go-getting-started
 ```
 
-At the root of the directory, you'll find the `okteto.yaml` file. This describes how to [build](reference/okteto-manifest.mdx#build-object-optional) and [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Go Sample App.
+At the root of the directory, you'll find the `okteto.yml` file. This file describes how to [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Go Sample App.
 
 ```yaml
-build:
-  hello-world:
-    image: okteto.dev/go-hello-world:1.0.0
-    context: .
-
 deploy:
   - kubectl apply -f k8s.yml
 ```
@@ -39,15 +34,11 @@ deploy:
 Deploy your development environment by executing:
 
 ```console
-$ okteto deploy --build
+$ okteto deploy
 ```
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/go-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-...
- ✓  Image 'registry.okteto.example.com/cindy/go-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -90,7 +81,7 @@ dev:
 
 The `hello-world` key matches the name of the hello world Deployment. The meaning of the rest of fields is:
 
-- `image`: the image used by the development container. More information on development images [here](deploy/development-environments.mdx).
+- `image`: the image used by the development container.
 - `command`: the start command of the development container.
 - `sync`: the folders that will be synchronized between your local machine and the development container.
 - `volumes`: a list of paths in your development container to be mounted as persistent volumes. For example, this can be used to persist the Go cache.

--- a/src/content/guides/samples/java.mdx
+++ b/src/content/guides/samples/java.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to develop and debug a Java application using Ok
 
 ## Prerequisites
 
-Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our getting started guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
+Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our installation guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
 
 ## Step 1: Deploy the Java Sample App
 
@@ -33,26 +33,18 @@ $ git clone https://github.com/okteto/java-gradle-getting-started
 $ cd java-gradle-getting-started
 ```
 
-At the root of the directory, you'll find the `okteto.yaml` file. This describes how to [build](reference/okteto-manifest.mdx#build-object-optional), [deploy](reference/okteto-manifest.mdx#deploy-string-optional), and [develop](reference/okteto-manifest.mdx#develop-string-optional) the Java Sample App.
+At the root of the directory, you'll find the `okteto.yml` file. This file describes how to [deploy](reference/okteto-manifest.mdx#deploy-string-optional), and [develop](reference/okteto-manifest.mdx#develop-string-optional) the Java Sample App.
 
 #### Maven
 
-```
-build:
-  hello-world:
-    image: okteto.dev/java-maven-hello-world:1.0.0
-    context: .
+```yaml
 deploy:
   - kubectl apply -f k8s.yml
 ```
 
 #### Gradle
 
-```
-build:
-  hello-world:
-    image: okteto.dev/java-gradle-hello-world:1.0.0
-    context: .
+```yaml
 deploy:
   - kubectl apply -f k8s.yml
 ```
@@ -60,18 +52,13 @@ deploy:
 Deploy your development environment by executing:
 
 ```console
-$ okteto deploy --build
+$ okteto deploy
 ```
 
 #### Maven
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/java-maven-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-[+] Building 5.9s (11/11) FINISHED
- ...
- ✓  Image 'registry.okteto.example.com/cindy/java-maven-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -84,11 +71,6 @@ ingress.networking.k8s.io/hello-world created
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/java-gradle-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-[+] Building 5.9s (11/11) FINISHED
- ...
- ✓  Image 'registry.okteto.example.com/cindy/java-gradle-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -113,7 +95,7 @@ The [dev](reference/okteto-manifest.mdx#dev-object-optional) section defines how
 
 #### Maven
 
-```
+```yaml
 dev:
   hello-world:
     image: okteto/maven:3
@@ -128,7 +110,7 @@ dev:
 
 #### Gradle
 
-```
+```yaml
 dev:
   hello-world:
     image: okteto/gradle:6.5
@@ -143,10 +125,10 @@ dev:
 
 The `hello-world` key matches the name of the hello world Deployment. The meaning of the rest of fields is:
 
-- `image`: the image used by the development container. More information on development images [here](deploy/development-environments.mdx)
-- `command`: the start command of the development container
-- `sync`: the folders that will be synchronized between your local machine and the development container
-- `forward`: a list of ports to forward from your development container
+- `image`: the image used by the development container.
+- `command`: the start command of the development container.
+- `sync`: the folders that will be synchronized between your local machine and the development container.
+- `forward`: a list of ports to forward from your development container.
 - `volumes`: a list of paths in your development container to be mounted as persistent volumes. This is useful to persist the maven/gradle caches.
 
 Also, note that there is a `.stignore` file to indicate which files shouldn't be synchronized to your development container.

--- a/src/content/guides/samples/node.mdx
+++ b/src/content/guides/samples/node.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to develop and debug a Node.js application using
 
 ## Prerequisites
 
-Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our getting started guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
+Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our installation guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
 
 ## Step 1: Deploy the Node.js Sample App
 
@@ -24,13 +24,9 @@ $ git clone https://github.com/okteto/node-getting-started
 $ cd node-getting-started
 ```
 
-At the root of the directory, you'll find the `okteto.yaml` file. This describes how to [build](reference/okteto-manifest.mdx#build-object-optional) and [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Node Sample App.
+At the root of the directory, you'll find the `okteto.yml` file. This file describes how to [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Node Sample App.
 
-```
-build:
-  hello-world:
-    image: okteto.dev/node-hello-world:1.0.0
-    context: .
+```yaml
 deploy:
   - kubectl apply -f k8s.yml
 ```
@@ -38,16 +34,11 @@ deploy:
 Deploy your development environment by executing:
 
 ```console
-$ okteto deploy --build
+$ okteto deploy
 ```
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/node-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-[+] Building 5.9s (11/11) FINISHED
- ...
- ✓  Image 'registry.okteto.example.com/cindy/node-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -70,7 +61,7 @@ Did you notice that you're accessing your application through an HTTPs endpoint?
 
 The [dev](reference/okteto-manifest.mdx#dev-object-optional) section defines how to activate a development container for the Node Sample App:
 
-```
+```yaml
 dev:
   hello-world:
     command: bash

--- a/src/content/guides/samples/php.mdx
+++ b/src/content/guides/samples/php.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to develop and debug a PHP application using Okt
 
 ## Prerequisites
 
-Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our getting started guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
+Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our installation guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
 
 ## Step 1: Deploy the PHP Sample App
 
@@ -24,16 +24,9 @@ $ git clone https://github.com/okteto/php-getting-started
 $ cd php-getting-started
 ```
 
-At the root of the directory, you'll find the `okteto.yaml` file. This describes how to [build](reference/okteto-manifest.mdx#build-object-optional) and [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Php Sample App.
+At the root of the directory, you'll find the `okteto.yml` file. This file describes how to [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Php Sample App.
 
-```
-build:
-  hello-world:
-    image: okteto.dev/php-hello-world:1.0.0
-    context: .
-  hello-world-dev:
-    context: .
-    target: dev
+```yaml
 deploy:
   - kubectl apply -f k8s.yml
 ```
@@ -41,16 +34,11 @@ deploy:
 Deploy your development environment by executing:
 
 ```console
-$ okteto deploy --build
+$ okteto deploy
 ```
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/php-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-[+] Building 5.9s (11/11) FINISHED
- ...
- ✓  Image 'registry.okteto.example.com/cindy/php-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -73,10 +61,10 @@ Did you notice that you're accessing your application through an HTTPS endpoint?
 
 The [dev](reference/okteto-manifest.mdx#dev-object-optional) section defines how to activate a development container for the Php Sample App:
 
-```
+```yaml
 dev:
   hello-world:
-    image: ${OKTETO_BUILD_HELLO_WORLD_DEV_IMAGE}
+    image: okteto/php-getting-started:dev
     command: bash
     sync:
       - .:/app
@@ -88,7 +76,7 @@ dev:
 
 The `hello-world` key matches the name of the hello world Deployment. The meaning of the rest of fields is:
 
-- `image`: the image used by the development container. More information on development images [here](deploy/development-environments.mdx) and [dynamic value for the tag](reference/okteto-manifest.mdx#build-object-optional)
+- `image`: the image used by the development container (built from this [Dockerfile](https://github.com/okteto/php-getting-started/blob/main/Dockerfile)).
 - `command`: the start command of the development container.
 - `sync`: the folders that will be synchronized between your local machine and the development container.
 - `reverse`: a list of ports to reverse forward from your development container to your local machine

--- a/src/content/guides/samples/python.mdx
+++ b/src/content/guides/samples/python.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to develop and debug a Python application using 
 
 ## Prerequisites
 
-Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our getting started guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
+Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our installation guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
 
 ## Step 1: Deploy the Python Sample App
 
@@ -24,13 +24,9 @@ $ git clone https://github.com/okteto/python-getting-started
 $ cd python-getting-started
 ```
 
-At the root of the directory, you'll find the `okteto.yaml` file. This describes how to [build](reference/okteto-manifest.mdx#build-object-optional) and [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Python Sample App.
+At the root of the directory, you'll find the `okteto.yml` file. This file describes how to [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Python Sample App.
 
-```
-build:
-  hello-world:
-    image: okteto.dev/python-hello-world:1.0.0
-    context: .
+```yaml
 deploy:
   - kubectl apply -f k8s.yml
 ```
@@ -38,16 +34,11 @@ deploy:
 Deploy your development environment by executing:
 
 ```console
-$ okteto deploy --build
+$ okteto deploy
 ```
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/python-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-[+] Building 5.9s (11/11) FINISHED
- ...
- ✓  Image 'registry.okteto.example.com/cindy/python-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -70,7 +61,7 @@ Did you notice that you're accessing your application through an HTTPs endpoint?
 
 The [dev](reference/okteto-manifest.mdx#dev-object-optional) section defines how to activate a development container for the Python Sample App:
 
-```
+```yaml
 dev:
   hello-world:
     command: bash

--- a/src/content/guides/samples/ruby.mdx
+++ b/src/content/guides/samples/ruby.mdx
@@ -13,7 +13,7 @@ This tutorial will show you how to develop and debug a Ruby application using Ok
 
 ## Prerequisites
 
-Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our getting started guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
+Install the latest version of the Okteto CLI and configure it to access Okteto. [Follow our installation guide](get-started/install-okteto-cli.mdx) if you haven't done it yet.
 
 ## Step 1: Deploy the Ruby Sample App
 
@@ -24,13 +24,10 @@ $ git clone https://github.com/okteto/ruby-getting-started
 $ cd ruby-getting-started
 ```
 
-At the root of the directory, you'll find the `okteto.yaml` file. This describes how to [build](reference/okteto-manifest.mdx#build-object-optional) and [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Python Sample App.
+At the root of the directory, you'll find the `okteto.yml` file. This file describes how to [deploy](reference/okteto-manifest.mdx#deploy-string-optional) the Python Sample App.
 
-```
+```yaml
 build:
-  hello-world:
-    image: okteto.dev/ruby-hello-world:1.0.0
-    context: .
 deploy:
   - kubectl apply -f k8s.yml
 ```
@@ -38,16 +35,11 @@ deploy:
 Deploy your development environment by executing:
 
 ```console
-$ okteto deploy --build
+$ okteto deploy
 ```
 
 ```console
  i  Using cindy @ okteto.example.com as context
- i  Building image for service 'hello-world'
- i  Building the image 'okteto.dev/ruby-hello-world:1.0.0' in tcp://buildkit.okteto.example.com:1234...
-[+] Building 5.9s (11/11) FINISHED
- ...
- ✓  Image 'registry.okteto.example.com/cindy/ruby-hello-world:1.0.0' successfully pushed
  i  Running kubectl apply -f k8s.yml
 deployment.apps/hello-world created
 service/hello-world created
@@ -70,7 +62,7 @@ Did you notice that you're accessing your application through an HTTPs endpoint?
 
 The [dev](reference/okteto-manifest.mdx#dev-object-optional) section defines how to activate a development container for the Ruby Sample App:
 
-```
+```yaml
 dev:
   hello-world:
     command: bash


### PR DESCRIPTION
Now our samples are executed in SH, users cannot take advantage of smart builds when running our samples.
This PR updates our samples to use pre-built images and speed up the execution of the sample.

This PR must be merged in combination with:
- https://github.com/okteto/movies-with-helm/pull/9
- https://github.com/okteto/movies-with-compose/pull/15
- https://github.com/okteto/aspnetcore-getting-started/pull/12
- https://github.com/okteto/go-getting-started/pull/18
- https://github.com/okteto/java-gradle-getting-started/pull/6
- https://github.com/okteto/java-maven-getting-started/pull/9
- https://github.com/okteto/node-getting-started/pull/10
- https://github.com/okteto/php-getting-started/pull/11
- https://github.com/okteto/python-getting-started/pull/16
- https://github.com/okteto/ruby-getting-started/pull/11