### PR TITLE
Fix broken redirects for 1.16 and 1.17

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,16 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/reference/manifest"
+  to = "/docs/1.16/reference/okteto-manifest"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/reference/manifest"
+  to = "/docs/1.17/reference/okteto-manifest"
+  status = 301
+
+[[redirects]]
   from = "/docs/reference/compose"
   to = "/docs/reference/docker-compose"
   status = 301
@@ -64,6 +74,17 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/administration/*"
+  to = "/docs/1.16/admin/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/administration/*"
+  to = "/docs/1.17/admin/:splat"
+  status = 301
+
+
+[[redirects]]
   from = "/docs/self-hosted/install/releases"
   to = "/docs/release-notes"
   status = 301
@@ -84,6 +105,16 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/self-hosted/install/custom-resource-definitions"
+  to = "/docs/1.16/self-hosted/manage/custom-resource-definitions"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/self-hosted/install/custom-resource-definitions"
+  to = "/docs/1.17/self-hosted/manage/custom-resource-definitions"
+  status = 301
+
+[[redirects]]
   from = "/docs/self-hosted/install/troubleshooting"
   to = "/docs/self-hosted/manage/troubleshooting"
   status = 301
@@ -94,8 +125,28 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/self-hosted/administration/configuration"
+  to = "/docs/1.16/reference/helm-chart-values"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/self-hosted/administration/configuration"
+  to = "/docs/1.17/reference/helm-chart-values"
+  status = 301
+
+[[redirects]]
   from = "/docs/self-hosted/administration/*"
   to = "/docs/self-hosted/install/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.16/self-hosted/administration/*"
+  to = "/docs/1.16/self-hosted/install/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/self-hosted/administration/*"
+  to = "/docs/1.17/self-hosted/install/:splat"
   status = 301
 
 [[redirects]]
@@ -109,8 +160,13 @@
   status = 301
 
 [[redirects]]
-  from = "/docs/cloud/preview-environments/dashboard"
-  to = "/docs/preview/github/configure-github-prev"
+  from = "/docs/1.16/cloud/preview-environments/preview-environments"
+  to = "/docs/1.16/preview/overview-prev-env"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/cloud/preview-environments/preview-environments"
+  to = "/docs/1.17/preview/overview-prev-env"
   status = 301
 
 [[redirects]]
@@ -124,8 +180,28 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/cloud/preview-environments/preview-environments-gitlab"
+  to = "/docs/1.16/preview/using-gitlab-cicd"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/cloud/preview-environments/preview-environments-gitlab"
+  to = "/docs/1.17/preview/using-gitlab-cicd"
+  status = 301
+
+[[redirects]]
   from = "/docs/reference/development-environments"
   to = "/docs/deploy/development-environments"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.16/reference/development-environments"
+  to = "/docs/1.16/deploy/development-environments"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/reference/development-environments"
+  to = "/docs/1.17/deploy/development-environments"
   status = 301
 
 [[redirects]]
@@ -154,6 +230,16 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/cloud/secrets"
+  to = "/docs/1.16/manifest/okteto-variables"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/cloud/secrets"
+  to = "/docs/1.17/manifest/okteto-variables"
+  status = 301
+
+[[redirects]]
   from = "/docs/manifest/okteto-secrets"
   to = "/docs/manifest/okteto-variables"
   status = 301
@@ -179,6 +265,16 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/cloud/namespaces"
+  to = "/docs/1.16/core/components/namespaces"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/cloud/namespaces"
+  to = "/docs/1.17/core/components/namespaces"
+  status = 301
+
+[[redirects]]
   from = "/docs/cloud/use-volume-snapshots"
   to = "/docs/core/components/use-volume-snapshots"
   status = 301
@@ -199,6 +295,16 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/cloud/credentials"
+  to = "/docs/1.16/core/credentials/kubernetes-credentials"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/cloud/credentials"
+  to = "/docs/1.17/core/credentials/kubernetes-credentials"
+  status = 301
+
+[[redirects]]
   from = "/docs/cloud/personal-access-tokens"
   to = "/docs/core/credentials/personal-access-tokens"
   status = 301
@@ -206,6 +312,16 @@
 [[redirects]]
   from = "/docs/cloud/okteto-cli"
   to = "/docs/core/using-okteto-cli"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.16/cloud/okteto-cli"
+  to = "/docs/1.16/core/using-okteto-cli"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/cloud/okteto-cli"
+  to = "/docs/1.17/core/using-okteto-cli"
   status = 301
 
 [[redirects]]
@@ -244,6 +360,16 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/1.16/getting-started"
+  to = "/docs/1.16/get-started/install-okteto-cli"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/getting-started"
+  to = "/docs/1.17/get-started/install-okteto-cli"
+  status = 301
+
+[[redirects]]
   from = "/docs/self-hosted/install/preparation"
   to = "/docs/get-started/overview"
   status = 301
@@ -265,6 +391,16 @@
 [[redirects]]
   from = "/docs/getting-started/installation"
   to = "/docs/cloud/okteto-cli"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.16/getting-started/installation"
+  to = "/docs/1.16/cloud/okteto-cli"
+  status = 301
+
+[[redirects]]
+  from = "/docs/1.17/getting-started/installation"
+  to = "/docs/1.17/cloud/okteto-cli"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
Fix redirects for old versions, used by the Okteto UI