### PR TITLE
Remove redundant overview section

### DIFF
--- a/src/content/get-started/overview.mdx
+++ b/src/content/get-started/overview.mdx
@@ -8,10 +8,6 @@ id: overview
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Okteto is a platform that simplifies the process of deploying development environments in Kubernetes without requiring the expertise to do this yourself.
-This enables developers to automatically spin up fully-managed development environments that emulate production as closely as possible.
-Okteto eliminates the friction of local development environments, the many deviations that can exist for the same engineering organization, and the troubleshooting that comes with them.
-
 :::info
 If you are interested in using Okteto's SaaS offering, you can ignore this page and skip to [Install the Okteto CLI](get-started/install-okteto-cli.mdx).
 :::


### PR DESCRIPTION
This section is already on the first section of https://www.okteto.com/docs/, I think it's redundant here. wdyt?