### PR TITLE
Fix sidebars to allow index pages on sections

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -305,6 +305,12 @@ module.exports = {
               "/administration/private-repositories/ssh-key/",
             ],
           },
+          {
+            to: "manifest/index/",
+            from: [
+              "/manifest/overview-manifest/"
+            ]
+          }
         ],
       },
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,181 +6,202 @@
  */
 
 module.exports = {
-  "docs": [
+  docs: [
     {
-      "Get started": [
-      "welcome",
-      "get-started/start-trial",
-      "get-started/quickstart-guide",
-      "get-started/deploy-first-environment",
-      "get-started/next-steps"
-    ],
-  },
-  {
-    "Core concepts": [
-      "core/using-okteto-cli",
-      {
-        "type": "category",
-        "label": "Okteto components",
-        "items": [
-          "core/components/development-containers",
-          "core/components/namespaces",
-          "core/components/build-service",
-          "core/components/container-registry",
-          "core/components/use-volume-snapshots",
-        ],
-      },
-      {
-        "type": "category",
-        "label": "Ingress",
-        "items": [
-          "core/ingress/automatic-ssl",
-          "core/ingress/private-endpoints",
-        ],
-      },
-      {
-        "type": "category",
-        "label": "Credentials",
-        "items": [
-          "core/credentials/kubernetes-credentials",
-          "core/credentials/personal-access-tokens",
-        ],
-      },
-    ]
-  },
-  {
-    "Guides": [
-      {
-        "type": "category",
-        "label": "Tutorials",
-        "items": [
-          "guides/tutorials/aws-lambda",
-          "guides/tutorials/compose-getting-started",
-          "guides/tutorials/getting-started-with-okteto",
-          "guides/tutorials/getting-started-with-pipelines",
-          "guides/tutorials/webpack"
-        ],
-      },
-      {
-        "type": "category",
-        "label": "Samples",
-        "items": [
-          "guides/samples/aspnetcore",
-          "guides/samples/golang",
-          "guides/samples/java",
-          "guides/samples/node",
-          "guides/samples/php",
-          "guides/samples/python",
-          "guides/samples/ruby",
-          "guides/samples/more"
-        ],
-      },
-    ]
-  },
-  {
-    "Okteto manifest": [
-      "manifest/overview-manifest",
-      "manifest/external-resources",
-      "manifest/okteto-variables",
-      "manifest/hybrid-development"
-    ]  
-  },
-  {
-    "Deploy development environments": [
-      "deploy/development-environments",
-      "deploy/deploy-from-catalog",
-      "deploy/deploy-from-git",
-      "deploy/from-private-repositories",
-      "deploy/develop-on-okteto-button"
-    ],
-  },
-  {
-    "Deploy preview environments": [
-      "preview/overview-prev-env",
-      "preview/github/using-github-actions",
-      "preview/using-gitlab-cicd"
-    ],
-  },
-  {
-    "Okteto Self-Hosted": [
-      "get-started/overview",
-      {
-        "type": "category",
-        "label": "Cloud provider guides",
-        "items": [
-          "get-started/cloud-provider-guides/amazon-eks",
-          "get-started/cloud-provider-guides/civo",
-          "get-started/cloud-provider-guides/digitalocean-doks",
-          "get-started/cloud-provider-guides/google-gke",
-          "get-started/cloud-provider-guides/microsoft-aks"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "Manage Okteto",
-        "items": [
-          "self-hosted/manage/upgrade",
-          "self-hosted/manage/okteto-license",
-          "self-hosted/manage/backup",
-          "self-hosted/manage/custom-resource-definitions",
-          "self-hosted/manage/troubleshooting",
-          "self-hosted/manage/diagnostics",
-        ]
-      },
-      {
-        "type": "category",
-        "label": "Complete the installation",
-        "items": [
-          "self-hosted/install/certificates",
-          "self-hosted/install/custom-installer-image",
-          "self-hosted/install/github-integration",
-          "self-hosted/install/volume-snapshots",
-          {
-            "type": "category",
-            "label": "Private Repositories",
-            "items": [
-              "self-hosted/install/private-repositories/github-app",
-              "self-hosted/install/private-repositories/ssh-key"
-            ]
-          },
-        ]
-      },
-    ],
-  },
-  {
-    "Admin features": [
-      "admin/dashboard",
-      "admin/catalog",
-      "admin/cleanup",
-      "admin/okteto-insights"
-    ]
-  },
-  {
-    "References": [
-      "reference/okteto-cli",
-      "reference/okteto-manifest",
-      "reference/docker-compose",
-      "reference/helm-chart-values",
-      "reference/supported-github-actions",
-      "reference/file-synchronization",
-      "reference/ssh-server",
-    ],
-  },
-  {
-    "Community and support": [
-      "reference/faqs",
-      {
-        "type": "link",
-        "label": "Community forum",
-        "href": "https://community.okteto.com/"
-      },
-    ]  
-  },
-  "release-notes",
-  {
-    "type": "link",
-    "label": "Archives",
-    "href": "/archives"
-  }
+      type: 'category',
+      label: 'Get Started',
+      items: [
+        'welcome',
+        'get-started/start-trial',
+        'get-started/quickstart-guide',
+        'get-started/deploy-first-environment',
+        'get-started/next-steps',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Core concepts',
+      items: [
+        'core/using-okteto-cli',
+        {
+          type: 'category',
+          label: 'Okteto components',
+          items: [
+            'core/components/development-containers',
+            'core/components/namespaces',
+            'core/components/build-service',
+            'core/components/container-registry',
+            'core/components/use-volume-snapshots',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Ingress',
+          items: ['core/ingress/automatic-ssl', 'core/ingress/private-endpoints'],
+        },
+        {
+          type: 'category',
+          label: 'Credentials',
+          items: [
+            'core/credentials/kubernetes-credentials',
+            'core/credentials/personal-access-tokens',
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Guides',
+      items: [
+        {
+          type: 'category',
+          label: 'Tutorials',
+          items: [
+            'guides/tutorials/aws-lambda',
+            'guides/tutorials/compose-getting-started',
+            'guides/tutorials/getting-started-with-okteto',
+            'guides/tutorials/getting-started-with-pipelines',
+            'guides/tutorials/webpack',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Samples',
+          items: [
+            'guides/samples/aspnetcore',
+            'guides/samples/golang',
+            'guides/samples/java',
+            'guides/samples/node',
+            'guides/samples/php',
+            'guides/samples/python',
+            'guides/samples/ruby',
+            'guides/samples/more',
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Okteto Manifest',
+      link: { type: 'doc', id: 'manifest/index' },
+      items: [
+        'manifest/external-resources',
+        'manifest/okteto-variables',
+        'manifest/hybrid-development',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Deploy development environments',
+      items: [
+        'deploy/development-environments',
+        'deploy/deploy-from-catalog',
+        'deploy/deploy-from-git',
+        'deploy/from-private-repositories',
+        'deploy/develop-on-okteto-button',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Deploy preview environments',
+      items: [
+        'preview/overview-prev-env',
+        'preview/github/using-github-actions',
+        'preview/using-gitlab-cicd',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Okteto Self-Hosted',
+      items: [
+        'get-started/overview',
+        {
+          type: 'category',
+          label: 'Cloud provider guides',
+          items: [
+            'get-started/cloud-provider-guides/amazon-eks',
+            'get-started/cloud-provider-guides/civo',
+            'get-started/cloud-provider-guides/digitalocean-doks',
+            'get-started/cloud-provider-guides/google-gke',
+            'get-started/cloud-provider-guides/microsoft-aks',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Manage Okteto',
+          items: [
+            'self-hosted/manage/upgrade',
+            'self-hosted/manage/okteto-license',
+            'self-hosted/manage/backup',
+            'self-hosted/manage/custom-resource-definitions',
+            'self-hosted/manage/troubleshooting',
+            'self-hosted/manage/diagnostics',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Complete the installation',
+          items: [
+            'self-hosted/install/certificates',
+            'self-hosted/install/custom-installer-image',
+            'self-hosted/install/github-integration',
+            'self-hosted/install/volume-snapshots',
+            {
+              type: 'category',
+              label: 'Private Repositories',
+              items: [
+                'self-hosted/install/private-repositories/github-app',
+                'self-hosted/install/private-repositories/ssh-key',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Admin features',
+      items: [
+        'admin/dashboard',
+        'admin/catalog',
+        'admin/cleanup',
+        'admin/okteto-insights',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'References',
+      items: [
+        'reference/okteto-cli',
+        'reference/okteto-manifest',
+        'reference/docker-compose',
+        'reference/helm-chart-values',
+        'reference/supported-github-actions',
+        'reference/file-synchronization',
+        'reference/ssh-server',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Community and support',
+      items: [
+        'reference/faqs',
+        {
+          type: 'link',
+          label: 'Community forum',
+          href: 'https://community.okteto.com/',
+        },
+      ],
+    },
+    {
+      type: 'link',
+      label: 'Release notes',
+      href: '/release-notes',
+    },
+    {
+      type: 'link',
+      label: 'Archives',
+      href: '/archives',
+    },
   ],
-}
+};

--- a/src/content/manifest/index.mdx
+++ b/src/content/manifest/index.mdx
@@ -1,8 +1,6 @@
 ---
 title: Okteto Manifest
 description: An overview of the Okteto Manifest and its core features.
-sidebar_label: Overview
-id: overview-manifest
 ---
 
 import Tabs from "@theme/Tabs";

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -30,6 +30,7 @@
   --ifm-menu-link-padding-horizontal: 16px;
   --ifm-menu-link-padding-vertical: 5px;
   --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg alt="Arrow" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(35, 41, 53, 1)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
+  --ifm-menu-link-sublist-icon-active: url('data:image/svg+xml;utf8,<svg alt="Arrow" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(255, 255, 255, 1)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
   --ifm-menu-color: #{$navy};
   --ifm-menu-color-active: #{$navy};
 
@@ -99,8 +100,28 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0;
   padding-right: 0;
 
-  .menu__list-item {
-    margin: .25rem 0;
+  .menu__caret:before {
+    background: var(--ifm-menu-link-sublist-icon) 50% / 1.3rem 1.3rem;
+  }
+
+  .menu__link--sublist-caret:after {
+    background: var(--ifm-menu-link-sublist-icon) 50% / 1.3rem 1.3rem;
+  }
+
+  .menu__list-item-collapsible--active {
+    background: $navy;
+
+    .menu__link--active {
+      color: white;
+    }
+
+    .menu__caret:hover {
+      background: $light-navy;
+    }  
+
+    .menu__caret:before {
+      background: var(--ifm-menu-link-sublist-icon-active) 50% / 1.3rem 1.3rem;
+    }
   }
 
   .menu__link {
@@ -113,17 +134,7 @@ h1, h2, h3, h4, h5, h6 {
         border-radius: 3px;
         color: white;
         background: $navy;
-        margin-right: 8px;
       }
-    }
-
-    &.menu__link--sublist:after {
-      background-size: 20px 20px;
-      background-position: center;
-      content: ' ';
-      display: inline-block;
-      height: 20px;
-      width: 20px;
     }
   }
 
@@ -135,7 +146,6 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .container {
-
   @media (max-width: 996px) {
     max-width: 100vw;
   }


### PR DESCRIPTION
This will add page content to sections, removing the need of an "Overview" page.
To do this some styles had to be changed and the sidebar.js file needed to be reorganized. 
In this first example, I did it to the `Okteto Manifest` section, now it doesn't have an "Overview" page. Redirections need to be applied when doing this, as the path changes to `whatever/index` internally, and `whatever` as the canonical URL path.

### Before 

<img width="889" alt="Screenshot 2024-02-01 at 17 19 12" src="https://github.com/okteto/docs/assets/237819/29319d76-9d8e-4e9e-8ab5-02fe34f8103d">

### After 

<img width="721" alt="Screenshot 2024-02-01 at 17 19 02" src="https://github.com/okteto/docs/assets/237819/a8e824d6-d501-4618-ad38-0a29a6ef0abe">

