### PR TITLE
Index page for samples

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -83,6 +83,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Samples',
+          link: { type: 'doc', id: 'guides/samples/more' },
           items: [
             'guides/samples/aspnetcore',
             'guides/samples/golang',
@@ -91,7 +92,6 @@ module.exports = {
             'guides/samples/php',
             'guides/samples/python',
             'guides/samples/ruby',
-            'guides/samples/more',
           ],
         },
       ],

--- a/src/content/guides/samples/more.mdx
+++ b/src/content/guides/samples/more.mdx
@@ -1,12 +1,20 @@
 ---
-title: Learn more about Okteto in our samples repository
-description: Learn more about Okteto in our samples repository
-sidebar_label: And More...
-id: more
+title: Samples
+description: Samples
 ---
 
-Okteto makes it easier to develop Cloud Native applications of all shapes and forms. 
+Okteto makes it easier to develop on Kubernetes for applications of all shapes and forms.
 
-Take a look at [our samples repository](https://github.com/okteto/samples) to see more examples of how to develop applications directly in your Kubernetes cluster with different programming languages, frameworks, and deployment tools.
+We have getting started guides explaining how to configure your Development Containers for the following languages:
+
+- [ASP.NET](guides/samples/aspnetcore.mdx)
+- [Go](guides/samples/golang.mdx)
+- [Java](guides/samples/java.mdx)
+- [Node.js](guides/samples/node.mdx)
+- [PHP](guides/samples/php.mdx)
+- [Python](guides/samples/python.mdx)
+- [Ruby](guides/samples/ruby.mdx)
+
+Take a look at [our samples repository](https://github.com/okteto/samples) to see more examples of how to build, deploy and develop applications on Okteto with different programming languages, frameworks, and deployment tools.
 
 Are we missing your favorite framework or programming language? [File an issue](https://github.com/okteto/samples/issues/new) and let us know!

--- a/src/content/guides/tutorials/compose-getting-started.mdx
+++ b/src/content/guides/tutorials/compose-getting-started.mdx
@@ -132,4 +132,4 @@ Congratulations, you just developed **your first application with Okteto** 🚀.
 
 Read the docs for the [Docker Compose](reference/docker-compose.mdx) and the [available Okteto CLI commands](reference/okteto-cli.mdx) to learn more about developing your Docker Compose application on Okteto.
 
-Head over to our getting started guides for [Go](guides/samples/golang.mdx#step-4-debug-directly-in-okteto-cloud), [ASP.NET](guides/samples/aspnetcore.mdx#step-4-debug-directly-in-okteto-cloud), [Java](guides/samples/java.mdx#step-4-debug-directly-in-okteto-cloud), [Node.js](guides/samples/node.mdx#step-4-debug-directly-in-okteto-cloud), [PHP](guides/samples/php.mdx#step-4-debug-directly-in-okteto-cloud), [Python](guides/samples/python.mdx#step-4-debug-directly-in-okteto-cloud), or [Ruby](guides/samples/ruby.mdx#step-4-debug-directly-in-okteto-cloud) to see how to configure Okteto to live-update your application with different programming languages and **debuggers**.
+Head over to [our getting started guides](guides/samples/more.mdx) to see how to configure Okteto to live-update your application with different programming languages and **debuggers**.

--- a/src/content/guides/tutorials/getting-started-with-okteto.mdx
+++ b/src/content/guides/tutorials/getting-started-with-okteto.mdx
@@ -290,4 +290,4 @@ Go back to the browser and reload the page. Your code changes were instantly app
 
 Congratulations, you just configured **your first Okteto Manifest** 🚀.
 
-Head over to our samples for [Go](guides/samples/golang.mdx), [ASP.NET](guides/samples/aspnetcore.mdx), [Java](guides/samples/java.mdx), [Node.js](guides/samples/node.mdx), [PHP](guides/samples/php.mdx), [Python](guides/samples/python.mdx), or [Ruby](guides/samples/ruby.mdx) to see how to use Okteto to live-update your application with different programming languages and **debuggers**.
+Head over to [our getting started guides](guides/samples/more.mdx) to see how to configure Okteto to live-update your application with different programming languages and **debuggers**.

--- a/src/content/guides/tutorials/getting-started-with-pipelines.mdx
+++ b/src/content/guides/tutorials/getting-started-with-pipelines.mdx
@@ -208,4 +208,4 @@ Congratulations, you just configured **your first Okteto Pipeline on Okteto** ðŸ
 We have covered how to deploy realistic environments for cloud-native applications in just one-click.
 The full source code used on this tutorial is available [here](https://github.com/okteto/pipeline-getting-started).
 
-Head over to our samples for [Go](guides/samples/golang.mdx), [ASP.NET](guides/samples/aspnetcore.mdx), [Java](guides/samples/java.mdx), [Node.js](guides/samples/node.mdx), [PHP](guides/samples/php.mdx), [Python](guides/samples/python.mdx), or [Ruby](guides/samples/ruby.mdx) to see how to use Okteto to live-update your application with different programming languages and **debuggers**.
+Head over to [our getting started guides](guides/samples/more.mdx) to see how to configure Okteto to live-update your application with different programming languages and **debuggers**.


### PR DESCRIPTION
Have a dedicated index page for our samples. This makes our nivigation more intuitive and it also makes it possible to refer to all the samples with a single link.

Keeping current names to avoid redirects