### PR TITLE
rename default to personal namespace

### DIFF
--- a/src/content/core/components/namespaces.mdx
+++ b/src/content/core/components/namespaces.mdx
@@ -61,7 +61,7 @@ In the `Share` dialog, type the email address of the team members you want to sh
 
 ## Transfer namespace ownership
 
-Okteto administrators have the ability to transfer non-default namespaces between users. This process can be achieved through the Okteto UI.
+Okteto administrators have the ability to transfer non-personal namespaces between users. This process can be achieved through the Okteto UI.
 
 To transfer a namespace to a new owner, go to the Okteto UI -> Admin -> Namespaces then locate the namespace that you would like to transfer. Click on the three dots `...` to display the namespace menu. From the namespace menu select `Transfer Ownership`.
 

--- a/versioned_docs/version-1.17/core/components/namespaces.mdx
+++ b/versioned_docs/version-1.17/core/components/namespaces.mdx
@@ -61,7 +61,7 @@ In the `Share` dialog, type the email address of the team members you want to sh
 
 ## Transfer namespace ownership
 
-Okteto administrators have the ability to transfer non-default namespaces between users. This process can be achieved through the Okteto UI.
+Okteto administrators have the ability to transfer non-personal namespaces between users. This process can be achieved through the Okteto UI.
 
 To transfer a namespace to a new owner, go to the Okteto UI -> Admin -> Namespaces then locate the namespace that you would like to transfer. Click on the three dots `...` to display the namespace menu. From the namespace menu select `Transfer Ownership`.
 


### PR DESCRIPTION
renaming "default namespace" to "personal namespace" which better implies user ownership. Need to add clarification on what a personal namespace is to the namespaces documentation page. This will be handled in another PR with additional changes to the namespaces page.