### PR TITLE
docs: improve docs on auto ingress (PLAT-330)

### DIFF
--- a/src/content/core/ingress/automatic-ssl.mdx
+++ b/src/content/core/ingress/automatic-ssl.mdx
@@ -8,6 +8,8 @@ id: automatic-ssl
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Auto create ingresses from services
+
 Okteto can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
 
 ```yaml
@@ -41,7 +43,9 @@ A sample of how this should look [is available here](https://github.com/okteto/g
 
 :::
 
-Adding this annotation will tell Okteto to automatically create an https ingress rule for you that redirects to the first http port of your service. `NodePort` or `LoadBalancer` services are managed as if they had this annotation too.
+Adding this annotation will tell Okteto to automatically create an https ingress rule for you that redirects to the first http port of your service.
+
+`NodePort` or `LoadBalancer` services are managed as if they had this annotation too. You can disable this behaviour by setting [`convertLoadBalancedServices.enabled`](reference/helm-chart-values.mdx#convertloadbalancedservices) to `false`.
 
 You can see the address of your endpoint by going to the Okteto dashboard or by running the `okteto endpoints` command. The endpoint address will be consistent across redeploys, as long as you don't change your service name.
 
@@ -55,8 +59,10 @@ Keep in mind that all the hosts you use in your ingress must end with`-$NAMESPAC
 
 Okteto can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
 
-```
-  dev.okteto.com/generate-host: "true"
+```yaml
+metadata:
+  annotations:
+    dev.okteto.com/generate-host: "true"
 ```
 
 Full example:
@@ -156,3 +162,15 @@ endpoints:
 
 </TabItem>
 </Tabs>
+
+## Expose HTTPS Backends Through Ingress
+
+If your application communicates over HTTPS instead of HTTP, you'll need to create a dedicated ingress, as demonstrated in the [Bring Your Own Ingress](#bring-your-own-ingress) section, and add the following annotation to it:
+
+```yaml
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+```
+
+Please note that this won't pass through the certificate served by your application to the requester. Instead, the wildcard certificate of the Okteto instance will be used.


### PR DESCRIPTION
- Move first section under a dedicated heading, so it appears at the sidebar on the right.
- Move sentence about NodePort or LoadBalancer services auto conversion to dedicated paragraph and explain how to disable that behaviour.
- Add JSON structure and code highlighting to generate host annotation snippet.
- Add a new section about HTTPS backends.

https://okteto.atlassian.net/browse/PLAT-330