### PR TITLE
Add the argo cd guide to 1.17

### DIFF
--- a/versioned_sidebars/version-1.17-sidebars.json
+++ b/versioned_sidebars/version-1.17-sidebars.json
@@ -130,6 +130,7 @@
           "items": [
             "self-hosted/install/certificates",
             "self-hosted/install/custom-installer-image",
+            "self-hosted/install/argocd",
             "self-hosted/install/github-integration",
             "self-hosted/install/volume-snapshots",
             {


### PR DESCRIPTION
Adding the ArgoCD guide so it is available in 1.17 as well