### PR TITLE
docs: include validation webhook in argo cd guide

### DIFF
--- a/src/content/self-hosted/install/argocd.mdx
+++ b/src/content/self-hosted/install/argocd.mdx
@@ -82,7 +82,6 @@ ignoreDifferences:
 
   # Webhook cabundles patched by Okteto
   - group: 'admissionregistration.k8s.io'
-    kind: 'MutatingWebhookConfiguration'
     jsonPointers:
       - '/webhooks/0/clientConfig/caBundle'
       - '/webhooks/1/clientConfig/caBundle'

--- a/versioned_docs/version-1.17/self-hosted/install/argocd.mdx
+++ b/versioned_docs/version-1.17/self-hosted/install/argocd.mdx
@@ -82,7 +82,6 @@ ignoreDifferences:
 
   # Webhook cabundles patched by Okteto
   - group: 'admissionregistration.k8s.io'
-    kind: 'MutatingWebhookConfiguration'
     jsonPointers:
       - '/webhooks/0/clientConfig/caBundle'
       - '/webhooks/1/clientConfig/caBundle'


### PR DESCRIPTION
This PR removes the "kind: mutationwebhook" from the argocd guide so it covers all kinds, including validation webhook in the cabundle ignore difference section.