### PR TITLE
Use the recommended version instead of latest

### DIFF
--- a/src/content/preview/github/using-github-actions.mdx
+++ b/src/content/preview/github/using-github-actions.mdx
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Context
-        uses: okteto/context@latest
+        uses: okteto/context@2.25.1
         with:
           url: ${{secrets.OKTETO_URL}}
           token: ${{ secrets.OKTETO_TOKEN }}
 
       - name: Deploy preview environment
-        uses: okteto/deploy-preview@latest
+        uses: okteto/deploy-preview@2.25.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -114,13 +114,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Context
-        uses: okteto/context@latest
+        uses: okteto/context@2.25.1
         with:
           url: ${{secrets.OKTETO_URL}}
           token: ${{ secrets.OKTETO_TOKEN }}
 
       - name: Destroy preview environment
-        uses: okteto/destroy-preview@latest
+        uses: okteto/destroy-preview@2.25.1
         with:
           name: pr-${{ github.event.number }}
 ```

--- a/src/content/preview/using-gitlab-cicd.mdx
+++ b/src/content/preview/using-gitlab-cicd.mdx
@@ -87,7 +87,7 @@ The `.gitlab-ci.yml` looks like this:
 
 ```yaml
 # file: .gitlab.ci.yml
-image: okteto/okteto:2.23.1
+image: okteto/okteto:2.25.1
 
 stages:
   - review

--- a/versioned_docs/version-1.17/preview/github/using-github-actions.mdx
+++ b/versioned_docs/version-1.17/preview/github/using-github-actions.mdx
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Context
-        uses: okteto/context@latest
+        uses: okteto/context@2.24.0
         with:
           url: ${{secrets.OKTETO_URL}}
           token: ${{ secrets.OKTETO_TOKEN }}
 
       - name: Deploy preview environment
-        uses: okteto/deploy-preview@latest
+        uses: okteto/deploy-preview@2.24.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -116,13 +116,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Context
-        uses: okteto/context@latest
+        uses: okteto/context@2.24.0
         with:
           url: ${{secrets.OKTETO_URL}}
           token: ${{ secrets.OKTETO_TOKEN }}
 
       - name: Destroy preview environment
-        uses: okteto/destroy-preview@latest
+        uses: okteto/destroy-preview@2.24.0
         with:
           name: pr-${{ github.event.number }}-cindylopez
 ```

--- a/versioned_docs/version-1.17/preview/using-gitlab-cicd.mdx
+++ b/versioned_docs/version-1.17/preview/using-gitlab-cicd.mdx
@@ -87,7 +87,7 @@ The `.gitlab-ci.yml` looks like this:
 
 ```yaml
 # file: .gitlab.ci.yml
-image: okteto/okteto:2.23.1
+image: okteto/okteto:2.24.0
 
 stages:
   - review


### PR DESCRIPTION
Our customers typically copy-paste the doc when configuring a preview environment. 

Having the recommended version for the version of the docs they are looking at should reduce the likelihood of them using the wrong CLI version.