### PR TITLE
Mark lastest version in dropdown

### DIFF
--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -78,9 +78,9 @@ export default function DocsVersionDropdownNavbarItem({
 
       let versionDetails = '';
       if (version.name === 'current') {
-        versionDetails = '(not yet released)';
+        versionDetails = '(Unreleased)';
       } else if (version.isLast) {
-        versionDetails = '(latest release)';
+        versionDetails = '(Latest release)';
       }
 
       console.log(version);
@@ -108,7 +108,7 @@ export default function DocsVersionDropdownNavbarItem({
           description: 'The label for the navbar versions dropdown on mobile view',
         })
       : dropdownVersion.label;
-      
+
   const dropdownTo =
     mobile && items.length > 1 ? undefined : getVersionMainDoc(dropdownVersion).path; // We don't want to render a version dropdown with 0 or 1 item. If we build
   // the site with a single docs version (onlyIncludeVersions: ['1.0.0']),

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -75,9 +75,18 @@ export default function DocsVersionDropdownNavbarItem({
       // When not possible, fallback to the "main doc" of the version
       const versionDoc =
         activeDocContext?.alternateDocVersions[version.name] || getVersionMainDoc(version);
+
+      let versionDetails = '';
+      if (version.name === 'current') {
+        versionDetails = '(not yet released)';
+      } else if (version.isLast) {
+        versionDetails = '(latest release)';
+      }
+
+      console.log(version);
       return {
         isNavLink: true,
-        label: `${version.label} ${version.isLast ? '(Latest)' : ''}`,
+        label: `${version.label} ${versionDetails}`,
         to: versionDoc.path,
         isActive: () => version === activeDocContext?.activeVersion,
         onClick: () => {
@@ -99,6 +108,7 @@ export default function DocsVersionDropdownNavbarItem({
           description: 'The label for the navbar versions dropdown on mobile view',
         })
       : dropdownVersion.label;
+      
   const dropdownTo =
     mobile && items.length > 1 ? undefined : getVersionMainDoc(dropdownVersion).path; // We don't want to render a version dropdown with 0 or 1 item. If we build
   // the site with a single docs version (onlyIncludeVersions: ['1.0.0']),

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -77,7 +77,7 @@ export default function DocsVersionDropdownNavbarItem({
         activeDocContext?.alternateDocVersions[version.name] || getVersionMainDoc(version);
       return {
         isNavLink: true,
-        label: version.label,
+        label: `${version.label} ${version.isLast ? '(Latest)' : ''}`,
         to: versionDoc.path,
         isActive: () => version === activeDocContext?.activeVersion,
         onClick: () => {


### PR DESCRIPTION
I think it is confusing to see in the dropdown our current working version and not notify users which one is the latest available version. We can mark it as such like this:

<img width="628" alt="Screenshot 2024-02-16 at 11 06 53" src="https://github.com/okteto/docs/assets/237819/2c325147-8064-4dd2-8508-1e8dd3f7caab">
