### PR TITLE
Using okteto/okteto:stable in github sample

### DIFF
--- a/src/content/preview/using-gitlab-cicd.mdx
+++ b/src/content/preview/using-gitlab-cicd.mdx
@@ -87,7 +87,7 @@ The `.gitlab-ci.yml` looks like this:
 
 ```yaml
 # file: .gitlab.ci.yml
-image: okteto/okteto:2.23.1
+image: okteto/okteto:stable
 
 stages:
   - review


### PR DESCRIPTION
Using the `stable` tag in gitlab sample to avoid upgrading the cli version on every release