### PR TITLE
docs: specify aws lb scheme

### DIFF
--- a/src/content/get-started/cloud-provider-guides/eks.mdx
+++ b/src/content/get-started/cloud-provider-guides/eks.mdx
@@ -107,6 +107,7 @@ ingress-nginx:
     service:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
+        service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
 
 buildkit:
   persistence:


### PR DESCRIPTION
Add an annotation to set the AWS LB scheme to "internet-facing". This annotation is only parsed by the newer AWS Load Balancer controller.

If a user follows this guide and has that controller installed, the LB will be exposed internally by default.