### PR TITLE
Update gitlab previews sample

### DIFF
--- a/src/content/previews/using-gitlab-cicd.mdx
+++ b/src/content/previews/using-gitlab-cicd.mdx
@@ -97,7 +97,7 @@ review:
   variables:
     APP: review-$CI_COMMIT_REF_SLUG
   script:
-    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --scope global --branch $CI_COMMIT_REF_NAME --repository $CI_REPOSITORY_URL --wait
+    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --scope global --branch $CI_COMMIT_REF_NAME --repository $CI_PROJECT_URL --wait
 
   environment:
     name: review/$CI_COMMIT_REF_SLUG

--- a/versioned_docs/version-1.18/preview/using-gitlab-cicd.mdx
+++ b/versioned_docs/version-1.18/preview/using-gitlab-cicd.mdx
@@ -97,7 +97,7 @@ review:
   variables:
     APP: review-$CI_COMMIT_REF_SLUG
   script:
-    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --scope global --branch $CI_COMMIT_REF_NAME --repository $CI_REPOSITORY_URL --wait
+    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --scope global --branch $CI_COMMIT_REF_NAME --repository $CI_PROJECT_URL --wait
 
   environment:
     name: review/$CI_COMMIT_REF_SLUG


### PR DESCRIPTION
Use `CI_PROJECT_URL` instead of `CI_REPOSITORY_URL` in the gitlab previews sample.
`CI_REPOSITORY_URL` comes with the user token, which is less secure, and it also break private submodules.
Using `CI_PROJECT_URL` allows Okteto to clone git submodules using the SSH key