### PR TITLE
Redirect /unreleased/* paths to currently unreleased version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ If the release comes with a new or a removed Kubernetes version, update `kuberne
 To create a new version, run the following commands:
 
 ```
-yarn add docusaurus
 yarn run docusaurus docs:version 1.XX
 ```
 
@@ -65,9 +64,9 @@ This will create a new version with the docs on your current branch.
 Modify the `presets.docs.versions` section of  [`docusaurus.config.js`](docusaurus.config.js) as follows:
 
 
-1. Update `lastVersion` to the new official version
+1. Update `lastVersion` to the new _official_ version
 
-2. Update `current` to the version in development
+2. Update `current` to _unreleased_ version in development
 
 3. Update the values of the `path` of the  previous official version in the  `versions` subsection to match the version number. 
 
@@ -89,7 +88,7 @@ Modify the `presets.docs.versions` section of  [`docusaurus.config.js`](docusaur
         },
     ```
 
-4. Add a new entry in the `versions` subsection to match the new official version, with `/` as the path.
+4. Add a new entry in the `versions` subsection to match the new _official_ version, with `/` as the path.
     
     ```
         "1.5": {
@@ -99,14 +98,20 @@ Modify the `presets.docs.versions` section of  [`docusaurus.config.js`](docusaur
         },
     ```
 
-Modify the redirection rules on `netlify.toml` so that `/docs/$OFFICIAL_VERSION/` redirects to `/docs`
+Modify the redirection rules on `netlify.toml` so that `/docs/<OFFICIAL_VERSION>/` redirects to `/docs` and `/docs/unreleased/` redirects to `/docs/<CURRENT_VERSION>`
 
 ```
-# Redirect the current version to /docs/
+# Redirect official version to docs root
 [[redirects]]
   from = "/docs/1.5/*"
   to = "/docs/:splat"
   status = 301
+
+# Redirect unreleased to "current" version
+[[redirects]]
+  from = "/docs/unreleased/*"
+  to = "/docs/1.6/:splat"
+  status = 302
 ```
 
 Update `/src/pages/archives.md` with the new latest version

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -184,10 +184,14 @@ module.exports = {
           lastVersion: "1.18",
           versions: {
             current: {
+              // aka unreleased version in development
+              // Remember to also update "unreleased" redirect if changing the value!
               label: "1.19",
               path: "1.19",
             },
             1.18: {
+              // aka latest/official version
+              // Remember to also update docs root redirect if changing the value!
               label: "1.18",
               path: "/",
               banner: "none",

--- a/netlify.toml
+++ b/netlify.toml
@@ -553,11 +553,17 @@
   to = "/docs/guides/samples/:splat"
   status = 301
 
-# Redirect the current version to /docs/
+# Redirect official version to docs root
 [[redirects]]
   from = "/docs/1.18/*"
   to = "/docs/:splat"
   status = 301
+
+# Redirect unreleased to "current" version
+[[redirects]]
+  from = "/docs/unreleased/*"
+  to = "/docs/1.19/:splat"
+  status = 302
 
 # Before version 1.4, we used to point the homepage to `/welcome/overview`.
 # These redirects make sure we don’t show a 404


### PR DESCRIPTION
This adds an additional redirect for all URLs so we can link to next _unreleased_ version without having to specify or know the "next version" elsewhere. This is planned to be used for the Okteto UI app, to reference docs from next/unreleased chart version.

For example, at time of writing, "current" (unreleased) version is specified to _1.19_. With this change we can link to https://www.okteto.com/docs/unrelesed/development instead of https://www.okteto.com/docs/1.19/development, the new redirect will bring user to the expected version. This way we keep the definition of next/"current" version here, and in a single place.

Updated readme so we take this into account for future updates to docs versions, since just like the _official_ version we would need to update the new redirect accordingly.

# Considered but discarded approach

Instead of adding an additional redirect that have to be updated on every release, considered changing the configuration such that the _unreleased_ is always the default path for "current":

```js
// docusaurus.config.js
current: {
  label: "1.19",
  path: "unreleased",
},
```

It's also mentioned as best-practice in the Docusaurus docs, [_Version your documentation only when needed_](https://docusaurus.io/docs/next/versioning#version-your-documentation-only-when-needed).

But that would break some redirects that are already defined through for next 1.19 version through the [Netlify config](https://github.com/okteto/docs/blob/3dc6b2363d299b722e667e25faf3200e5b8fa148/netlify.toml#L1-L139). Not sure how we would handle this kind of redirections in such future scenario? 

Docusaurus docs also have more general notes on how to [configuring versioning behavior](https://docusaurus.io/docs/next/versioning#configuring-versioning-behavior), but unsure about the ramifications. Probably not a good idea to do _now_ when we have several path rewrites in motion, maybe better to discuss once 1.19 is official. Anyway, calling it out for future consideration.