### PR TITLE
docs: add description for OKTETO_LOCAL_REGISTRY_STORE_ENABLED

### DIFF
--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -203,7 +203,7 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_FORCE_REMOTE`:
 - `OKTETO_FOLDER`:
 - `OKTETO_REMOTE_CLI_IMAGE`:
-- `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials and uses them instead of the one stored in the cluster.
+- `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
 
 ## Accessing Okteto variables at deploy time
 

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -203,6 +203,7 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_FORCE_REMOTE`:
 - `OKTETO_FOLDER`:
 - `OKTETO_REMOTE_CLI_IMAGE`:
+- `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials and uses them instead of the one stored in the cluster.
 
 ## Accessing Okteto variables at deploy time
 

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -203,27 +203,16 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_FOLDER`: defines the path where the okteto folder is located (defaults to `$OKTETO_HOME/.okteto`).
 - `OKTETO_REMOTE_CLI_IMAGE`: specifies the CLI image that Okteto is going to use while deploying/destroying on remote.
 - `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
-- `OKTETO_BIN`: version of the CLI that the init containers will use.
-- `OKTETO_SKIP_CLEANUP`: if set skips the deletion of the syncthing folder when running `okteto down`
 - `OKTETO_USE_STATIC_KUBETOKEN`: use a fixed token rather than a dynamic token for interactions with the Kubernetes API. (Defaults to `false`)
 - `OKTETO_HOME`: defines the path of okteto folder (Defaults to `$HOME`)
-- `OKTETO_URL`:  specifies the Okteto cluster URL to connect to.
-- `OKTETO_TOKEN`: specifies the Okteto token that should be used to connect to the Okteto cluster.
-- `OKTETO_CONTEXT`: specifies the Kubernetes cluster name to connect to.
-- `OKTETO_NAMESPACE`: specifies the Kubernetes namespace that the CLI will operate.
 - `COMPOSE_FILE`: specifies the compose file that the user has to use.
 - `OKTETO_AUTOGENERATE_STIGNORE`: if true generates the `.stignore` file when running `okteto up`. (Defaults to `false`)
 - `OKTETO_AUTODEPLOY`: if set forces the deployment of the development environment on `okteto up` (Defaults to `false`)
-- `OKTETO_DEPOT_TOKEN`: specifies the Depot token that the build is going to use.
-- `OKTETO_DEPOT_PROJECT_ID`: specifies the Depot project ID where the image will be built.
-- `KUBECONFIG`: specifies where the kubeconfig is stored (several files can be set by separating them by `:` on unix systems and `;` on windows)
-- `BUILDKIT_PROGRESS`: defines the output progress that buildkit must show.
 - `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)
 - `OKTETO_DISABLE_SPINNER`: if set disables the spinner rotation (defaults to `false`)
 - `OKTETO_K8S_REQUESTS_LOGGER_ENABLED`: If true logs all requests to the kubernetes API. (defaults to `true`)
 - `OKTETO_SYNCTHING_VERSION`: specifies the syncthing version the CLI must use
 - `OKTETO_EXECUTE_SSH`: specifies if the command must be executed through SSH vs Kubernetes exec (defaults to `true`)
-- `OKTETO_SSH_TIMEOUT`: specifies the timeout for the SSH operations.
 - `OKTETO_RESCAN_INTERVAL`: defines the rescan interval for syncthing in seconds (defaults to `300`)
 
 ## Accessing Okteto variables at deploy time

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -201,17 +201,13 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_KUBERNETES_TIMEOUT`: specifies the timeout while deploying. (defaults to `0`)
 - `OKTETO_FORCE_REMOTE`: if true deploy the repository on the cluster vs locally.
 - `OKTETO_FOLDER`: defines the path where the okteto folder is located (defaults to `$OKTETO_HOME/.okteto`).
-- `OKTETO_REMOTE_CLI_IMAGE`: specifies the CLI image that Okteto is going to use while deploying/destroying on remote.
 - `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
 - `OKTETO_USE_STATIC_KUBETOKEN`: use a fixed token rather than a dynamic token for interactions with the Kubernetes API. (Defaults to `false`)
 - `OKTETO_AUTOGENERATE_STIGNORE`: if true generates the `.stignore` file when running `okteto up`. (Defaults to `false`)
 - `OKTETO_AUTODEPLOY`: if set forces the deployment of the development environment on `okteto up` (Defaults to `false`)
 - `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)
 - `OKTETO_DISABLE_SPINNER`: if set disables the spinner rotation (defaults to `false`)
-- `OKTETO_K8S_REQUESTS_LOGGER_ENABLED`: If true logs all requests to the kubernetes API. (defaults to `true`)
 - `OKTETO_SYNCTHING_VERSION`: specifies the syncthing version the CLI must use
-- `OKTETO_EXECUTE_SSH`: specifies if the command must be executed through SSH vs Kubernetes exec (defaults to `true`)
-- `OKTETO_RESCAN_INTERVAL`: defines the rescan interval for syncthing in seconds (defaults to `300`)
 
 ## Accessing Okteto variables at deploy time
 

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -196,15 +196,15 @@ USERNAME has a static value, and PASSWORD is dynamically generated.
 
 Okteto provides a list of variables that serve as feature flags for some of the features we release in our product. Below is a list of those variables that you can use to leverage these newer and experimental features:
 
-- `OKTETO_SMART_BUILDS_ENABLED`: enables the "smart builds" feature that uses a hash of the build context to determine if an image needs to be rebuilt or can be pulled from the registry. This can accelerate build times.
+- `OKTETO_SMART_BUILDS_ENABLED`: enables the []"smart builds" feature](core/build-service.mdx#smart-builds) that uses a hash of the build context to determine if an image needs to be rebuilt or can be pulled from the registry. This can accelerate build times.
 - `OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED`: Compose services mounting the same volume will be placed on the same node using Kubernetes's pod affinity. (Defaults to `true`)
 - `OKTETO_KUBERNETES_TIMEOUT`: specifies the timeout while deploying. (defaults to `0`)
-- `OKTETO_FORCE_REMOTE`: if true, the CLI will run deploy and destroy commands on the cluster instead of running them locally.
-- `OKTETO_FOLDER`: defines the path where the okteto folder is located (defaults to `$OKTETO_HOME/.okteto`).
+- `OKTETO_FORCE_REMOTE`: if true, the CLI will run deploy and destroy commands on the cluster instead of running them locally
+- `OKTETO_FOLDER`: defines the path where the okteto folder is located (defaults to `$OKTETO_HOME/.okteto`)
 - `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
 - `OKTETO_USE_STATIC_KUBETOKEN`: use a fixed token rather than a dynamic token for interactions with the Kubernetes API. (Defaults to `false`)
-- `OKTETO_AUTOGENERATE_STIGNORE`: if true generates the `.stignore` file when running `okteto up`. (Defaults to `false`)
-- `OKTETO_AUTODEPLOY`: if set forces the deployment of the development environment on `okteto up` (Defaults to `false`)
+- `OKTETO_AUTOGENERATE_STIGNORE`: if true, generates the `.stignore` file when running `okteto up`. (Defaults to `false`)
+- `OKTETO_AUTODEPLOY`: if set, forces the deployment of the development environment on `okteto up` (Defaults to `false`)
 - `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)
 - `OKTETO_DISABLE_SPINNER`: if set disables the spinner rotation (defaults to `false`)
 - `OKTETO_SYNCTHING_VERSION`: specifies the syncthing version the CLI must use

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -204,7 +204,6 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_REMOTE_CLI_IMAGE`: specifies the CLI image that Okteto is going to use while deploying/destroying on remote.
 - `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
 - `OKTETO_USE_STATIC_KUBETOKEN`: use a fixed token rather than a dynamic token for interactions with the Kubernetes API. (Defaults to `false`)
-- `OKTETO_HOME`: defines the path of okteto folder (Defaults to `$HOME`)
 - `OKTETO_AUTOGENERATE_STIGNORE`: if true generates the `.stignore` file when running `okteto up`. (Defaults to `false`)
 - `OKTETO_AUTODEPLOY`: if set forces the deployment of the development environment on `okteto up` (Defaults to `false`)
 - `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -197,13 +197,34 @@ USERNAME has a static value, and PASSWORD is dynamically generated.
 Okteto provides a list of variables that serve as feature flags for some of the features we release in our product. Below is a list of those variables that you can use to leverage these newer and experimental features:
 
 - `OKTETO_SMART_BUILDS_ENABLED`: enables the "smart builds" feature that uses a hash of the build context to determine if an image needs to be rebuilt or can be pulled from the registry. This can accelerate build times.
-- `OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED`:
-- `OKTETO_KUBERNETES_TIMEOUT`:
-- `OKTETO_HOME`:
-- `OKTETO_FORCE_REMOTE`:
-- `OKTETO_FOLDER`:
-- `OKTETO_REMOTE_CLI_IMAGE`:
+- `OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED`: Compose services mounting the same volume will be placed on the same node using Kubernetes's pod affinity. (Defaults to `true`)
+- `OKTETO_KUBERNETES_TIMEOUT`: specifies the timeout while deploying. (defaults to `0`)
+- `OKTETO_FORCE_REMOTE`: if true deploy the repository on the cluster vs locally.
+- `OKTETO_FOLDER`: defines the path where the okteto folder is located (defaults to `$OKTETO_HOME/.okteto`).
+- `OKTETO_REMOTE_CLI_IMAGE`: specifies the CLI image that Okteto is going to use while deploying/destroying on remote.
 - `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
+- `OKTETO_BIN`: version of the CLI that the init containers will use.
+- `OKTETO_SKIP_CLEANUP`: if set skips the deletion of the syncthing folder when running `okteto down`
+- `OKTETO_USE_STATIC_KUBETOKEN`: use a fixed token rather than a dynamic token for interactions with the Kubernetes API. (Defaults to `false`)
+- `OKTETO_HOME`: defines the path of okteto folder (Defaults to `$HOME`)
+- `OKTETO_URL`:  specifies the Okteto cluster URL to connect to.
+- `OKTETO_TOKEN`: specifies the Okteto token that should be used to connect to the Okteto cluster.
+- `OKTETO_CONTEXT`: specifies the Kubernetes cluster name to connect to.
+- `OKTETO_NAMESPACE`: specifies the Kubernetes namespace that the CLI will operate.
+- `COMPOSE_FILE`: specifies the compose file that the user has to use.
+- `OKTETO_AUTOGENERATE_STIGNORE`: if true generates the `.stignore` file when running `okteto up`. (Defaults to `false`)
+- `OKTETO_AUTODEPLOY`: if set forces the deployment of the development environment on `okteto up` (Defaults to `false`)
+- `OKTETO_DEPOT_TOKEN`: specifies the Depot token that the build is going to use.
+- `OKTETO_DEPOT_PROJECT_ID`: specifies the Depot project ID where the image will be built.
+- `KUBECONFIG`: specifies where the kubeconfig is stored (several files can be set by separating them by `:` on unix systems and `;` on windows)
+- `BUILDKIT_PROGRESS`: defines the output progress that buildkit must show.
+- `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)
+- `OKTETO_DISABLE_SPINNER`: if set disables the spinner rotation (defaults to `false`)
+- `OKTETO_K8S_REQUESTS_LOGGER_ENABLED`: If true logs all requests to the kubernetes API. (defaults to `true`)
+- `OKTETO_SYNCTHING_VERSION`: specifies the syncthing version the CLI must use
+- `OKTETO_EXECUTE_SSH`: specifies if the command must be executed through SSH vs Kubernetes exec (defaults to `true`)
+- `OKTETO_SSH_TIMEOUT`: specifies the timeout for the SSH operations.
+- `OKTETO_RESCAN_INTERVAL`: defines the rescan interval for syncthing in seconds (defaults to `300`)
 
 ## Accessing Okteto variables at deploy time
 

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -205,7 +205,6 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
 - `OKTETO_USE_STATIC_KUBETOKEN`: use a fixed token rather than a dynamic token for interactions with the Kubernetes API. (Defaults to `false`)
 - `OKTETO_HOME`: defines the path of okteto folder (Defaults to `$HOME`)
-- `COMPOSE_FILE`: specifies the compose file that the user has to use.
 - `OKTETO_AUTOGENERATE_STIGNORE`: if true generates the `.stignore` file when running `okteto up`. (Defaults to `false`)
 - `OKTETO_AUTODEPLOY`: if set forces the deployment of the development environment on `okteto up` (Defaults to `false`)
 - `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -199,7 +199,7 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_SMART_BUILDS_ENABLED`: enables the "smart builds" feature that uses a hash of the build context to determine if an image needs to be rebuilt or can be pulled from the registry. This can accelerate build times.
 - `OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED`: Compose services mounting the same volume will be placed on the same node using Kubernetes's pod affinity. (Defaults to `true`)
 - `OKTETO_KUBERNETES_TIMEOUT`: specifies the timeout while deploying. (defaults to `0`)
-- `OKTETO_FORCE_REMOTE`: if true deploy the repository on the cluster vs locally.
+- `OKTETO_FORCE_REMOTE`: if true, the CLI will run deploy and destroy commands on the cluster instead of running them locally.
 - `OKTETO_FOLDER`: defines the path where the okteto folder is located (defaults to `$OKTETO_HOME/.okteto`).
 - `OKTETO_LOCAL_REGISTRY_STORE_ENABLED`: enables the local registry credentials over the credentials stored in the cluster. (Defaults to `true`) 
 - `OKTETO_USE_STATIC_KUBETOKEN`: use a fixed token rather than a dynamic token for interactions with the Kubernetes API. (Defaults to `false`)


### PR DESCRIPTION
Adds the description for the new `OKTETO_LOCAL_REGISTRY_STORE_ENABLED` env var