### PR TITLE
docs: adds compose.yaml as part of the docker compose files

### DIFF
--- a/src/content/development/using-okteto-cli.mdx
+++ b/src/content/development/using-okteto-cli.mdx
@@ -16,7 +16,7 @@ If you haven't done so yet, install and configure the Okteto CLI following [this
 The Okteto CLI requires one of the following manifests to know how to deploy your application:
 
 1. [Okteto manifest](core/okteto-manifest.mdx): if there is an `okteto.yml` or `.okteto/okteto.yml` file in your folder, Okteto will use this file to deploy your application
-1. [Docker Compose](reference/docker-compose.mdx): if there is an `okteto-compose.yaml` or `docker-compose.yaml` file, Okteto will use this file to deploy your application
+1. [Docker Compose](reference/docker-compose.mdx): if there is an `okteto-compose.yaml`, `docker-compose.yaml` or `compose.yaml` file, Okteto will use this file to deploy your application
 
 :::note
 You can use the `-f` flag on any Okteto CLI command to explicitly define the location of an Okteto Manifest.


### PR DESCRIPTION
Compose preferred name has changed from `docker-compose.yaml` to `compose.yaml` ([Link to spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file)):

> The default path for a Compose file is compose.yaml (preferred) or compose.yml that is placed in the working directory. Compose also supports docker-compose.yaml and docker-compose.yml for backwards compatibility of earlier versions. If both files exist, Compose prefers the canonical compose.yaml.

[CLI PR](https://github.com/okteto/okteto/pull/4209)