### PR TITLE
Rewrite Okteto Registry section

### DIFF
--- a/src/content/core/container-registry.mdx
+++ b/src/content/core/container-registry.mdx
@@ -1,61 +1,52 @@
 ---
-title: Okteto registry
-description: The Okteto Registry allows every Okteto namespace to have its own space to store its container images
-sidebar_label: Container registry
+title: Okteto Registry
+description: The Okteto Registry allows every Okteto Namespace to have its own space to store its container images
+sidebar_label: Okteto Registry
 id: container-registry
 ---
 
-The Okteto Registry allows every Okteto namespace to have its own space to store its container images.
+The Okteto Registry allows every Okteto Namespace to have its own space to store its container images.
 
-## Authentication
+## Push container images to the Okteto Registry
 
-You can use [Okteto CLI](development/using-okteto-cli.mdx) to build and push images to the Okteto Registry.
+The recommended way to use the Okteto Registry is by [installing and configuring the Okteto CLI](get-started/install-okteto-cli.mdx).
 
-Run [`okteto context`](reference/okteto-cli.mdx#context) to configure Okteto CLI to be able to push images. This command will download the required tokens and certificates required to push and pull images to the Okteto Registry.
+The Okteto CLI is automatically configured to interact with the Okteto Registry. For example, if your have the following Okteto Manifest:
 
-## Push images into the Okteto Registry
-
-The Okteto CLI is automatically configured to interact with the Okteto Registry. Just make sure that you're using the registry URL with your Okteto namespace.
-
-```console
-okteto build -t okteto.dev/hello-world:golang .
+```yaml title="okteto.yml"
+build:
+  api:
+    context: api
+  frontend:
+    context: frontend
 ```
 
-When using the Okteto CLI, you can use the notation `okteto.dev` to refer to images in your [Namespace](core/namespaces.mdx). `okteto.dev` gets expanded to `registry.okteto.example.com/<okteto-namespace>`. For example, `okteto.dev/hello-world:golang` expands to `registry.okteto.example.com/cindy/hello-world:golang` for the namespace `cindy` and expands to `registry.okteto.example.com/tom/hello-world:golang` for the namespace `tom`. You can configure your current namespace using [Okteto CLI](development/using-okteto-cli.mdx)'s [`okteto namespace`](reference/okteto-cli.mdx#namespace) command.
+The command `okteto build` will build and automatically push the **api** and **frontend** images to:
 
-You can also use `okteto.dev` in your Dockerfiles when building using the [Okteto CLI](development/using-okteto-cli.mdx).
+- **api**: `registry.okteto.example.com/cindy/api:okteto`
+- **frontend**: `registry.okteto.example.com/cindy/frontend:okteto`
 
-```
-# Dockerfile
-FROM okteto.dev/hello-world:golang
-WORKDIR /app
-COPY main.go ./
-RUN go build -o /usr/local/bin/hello-world
-EXPOSE 8080
-CMD ["/usr/local/bin/hello-world"]
-```
+But you don't need to use or remember these URLs, you can access the SHA of each image using the following environment variables:
 
-However, please note that this would not work if you try to build using `docker build` instead. In that case, you'll need to use the full expanded URL for your images.
+- **api**: `OKTETO_BUILD_API_IMAGE`
+- **frontend**: `OKTETO_BUILD_FRONTEND_IMAGE`
 
-When using the expanded URL for the Okteto Registry, please make sure that your image names follow the following scheme, where `<okteto-namespace>` is a valid Okteto [Namespace](core/namespaces.mdx).
+You can read more about the available environment [variables to access your images here](core/okteto-variables.mdx#built-in-environment-variables-for-images-in-okteto-registry).
 
-```
-registry.okteto.example.com/<okteto-namespace>/<image>:<tag>
-```
-
-## Use images from the Okteto Registry
+## Pull container images from the Okteto Registry
 
 Any image pushed into the Okteto Registry is private. You'll need to authenticate with the registry before pulling an image.
 
 Namespaces in Okteto are automatically allowed to pull images that belong to their namespace automatically. If your application uses images from the Okteto Registry, it'll be able to pull container images without any extra configuration.
 
-To pull an image from a different namespace, you'll need to create and configure the required `imagePullSecrets` as outlined [here](reference/faqs.mdx#how-to-use-private-images).
+## Push Helm chart to the Okteto Registry
 
-## Push helm chart into the Okteto Registry
+You can push Helm charts to the Okteto Registry, but this process isn't integrated with the Okteto CLI.
+The first step is to log in to the Okteto Registry where you want to push the Helm chart.
+For this you will need some credentials that you can obtain by executing the `okteto context show --include-token` command.
+This command will show you information about the current okteto context in use:
 
-Just as you can push images to the Okteto Registry, you also have the option to push Helm charts. To do this, the first step is to log in to the registry where you want to push the chart. For this you will need some credentials that you can obtain by executing the `okteto context show` command. This command will show you information about the current okteto context in use.
-
-```
+```json
 {
     "name": "https://okteto.example.com",
     "id": "3cf4529c-1gbd-4364-99cf-3f4bbe499adb",
@@ -69,26 +60,35 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](reference/okteto-cli.mdx#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your escript is running as part of the `deploy`commands of your Okteto Manifest.
+For example:
 
-```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+```yaml title="okteto.yml"
+deploy:
+  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart.
 
-```
-helm package ./chart
+```yaml title="okteto.yml"
+deploy:
+  - helm package ./chart
 ```
 
 After that you can push the packaged Helm chart to the registry.
 
+```yaml title="okteto.yml"
+deploy:
+  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
-```
+
+## Pull Helm chart to the Okteto Registry
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
-```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+```yaml title="okteto.yml"
+deploy:
+  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/src/content/core/container-registry.mdx
+++ b/src/content/core/container-registry.mdx
@@ -61,7 +61,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your escript is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your script is running as part of the `deploy`commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yml"


### PR DESCRIPTION
The current registry section instructs the user to push images to the Okteto Registry directly, but our recommended way to interact with the Okteto Registry is via the Okteto Manifest and the `okteto build` command