### PR TITLE
docs: stack support enabled feat flag

### DIFF
--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -209,6 +209,7 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)
 - `OKTETO_DISABLE_SPINNER`: if set disables the spinner rotation (defaults to `false`)
 - `OKTETO_SYNCTHING_VERSION`: specifies the syncthing version the CLI must use
+- `OKTETO_SUPPORT_STACKS_ENABLED`: if true, detect if a file is stack or compose file based on its name (default: `false`)
 
 ## Accessing Okteto variables at deploy time
 

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -209,7 +209,7 @@ Okteto provides a list of variables that serve as feature flags for some of the 
 - `OKTETO_COMPOSE_UPDATE_STRATEGY`: defines the update strategy that the compose must translate (it can be one of: `rolling`/`recreate`/`on-delete`)
 - `OKTETO_DISABLE_SPINNER`: if set disables the spinner rotation (defaults to `false`)
 - `OKTETO_SYNCTHING_VERSION`: specifies the syncthing version the CLI must use
-- `OKTETO_SUPPORT_STACKS_ENABLED`: if true, detect if a file is stack or compose file based on its name (default: `false`)
+- `OKTETO_SUPPORT_STACKS_ENABLED`: if true, detect if a file is stack or compose file based on its name (default: `true`)
 
 ## Accessing Okteto variables at deploy time
 


### PR DESCRIPTION
Adds documentation about `OKTETO_SUPPORT_STACKS_ENABLED`. 

Defaults to true
If not set it will determine that all the files that could be used as compose/stack are compose files
If set it will detect if it's a compose or stack based on the name