### PR TITLE
Replace "clientId" by "clientSecret"

### DIFF
--- a/src/content/self-hosted/install/auth/google.mdx
+++ b/src/content/self-hosted/install/auth/google.mdx
@@ -44,7 +44,7 @@ auth:
     enabled: true
     clientId: clientid.apps.googleusercontent.com
     // highlight-next-line
-    clientId: "REPLACE_ME_WITH_YOUR_OAUTH_CLIENT_SECRET"
+    clientSecret: "REPLACE_ME_WITH_YOUR_OAUTH_CLIENT_SECRET"
     allowDomains:
       - example.com
 ```

--- a/versioned_docs/version-1.19/self-hosted/install/auth/google.mdx
+++ b/versioned_docs/version-1.19/self-hosted/install/auth/google.mdx
@@ -44,7 +44,7 @@ auth:
     enabled: true
     clientId: clientid.apps.googleusercontent.com
     // highlight-next-line
-    clientId: "REPLACE_ME_WITH_YOUR_OAUTH_CLIENT_SECRET"
+    clientSecret: "REPLACE_ME_WITH_YOUR_OAUTH_CLIENT_SECRET"
     allowDomains:
       - example.com
 ```


### PR DESCRIPTION
Fix typo in Google OAuth guide