### PR TITLE
Document when `build` overrides the image of Docker Compose services

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -203,6 +203,11 @@ deploy:
   compose: docker-compose.yml
 ```
 
+:::note
+Images specified in the `build` section of the Okteto Manifest overrides the image associated with services sharing the same name in your Docker Compose files.
+:::
+
+
 There is an extended notation to deploy several Docker Compose files and [endpoints](reference/docker-compose.mdx#endpoints-object-optional):
 
 ```yaml


### PR DESCRIPTION
Although this behavior is confusing, I think we should document it