### PR TITLE
Document pull secrets operator enabled by default

### DIFF
--- a/src/content/admin/registry-credentials/index.mdx
+++ b/src/content/admin/registry-credentials/index.mdx
@@ -94,7 +94,7 @@ The docker config secret is also replicated in all namespaces and preview enviro
 `okteto-regcred` is injected as a pull secret to all pods by the [Okteto Webhook](self-hosted/helm-configuration.mdx#webhook) to allow the deployment of private images.
 
 :::note
-By default, `okteto-regcred` only contains credentials to the Okteto Registry
+By default, the `okteto-regcred` only contains credentials for the Okteto Registry
 :::
 
 To disable this behavior set the following configuration in your helm values:
@@ -105,7 +105,7 @@ regcredsManager:
     enabled: false
 ```
 
-If this behavior is disable, Okteto writes this secret on every node which allows Kubelet to pull private images at deployment time.
+If this behavior is disabled, Okteto writes this secret on every node which allows Kubelet to pull private images at deployment time.
 To also disable this behavior set the following configuration in your helm values:
 
 ```yaml

--- a/src/content/admin/registry-credentials/index.mdx
+++ b/src/content/admin/registry-credentials/index.mdx
@@ -90,7 +90,7 @@ This secret is called `okteto-dockerconfig-static` and is always up to date with
 
 This docker config secret is used as a pull secret in installer jobs, in case your installer job image is private.
 
-The docker config secret is also replicated in all namespaces and preview environments created by Okteto, with the name `okteto-regcred`.
+The docker config secret is added in all namespaces and preview environments created by Okteto, with the name `okteto-regcred`.
 `okteto-regcred` is injected as a pull secret to all pods by the [Okteto Webhook](self-hosted/helm-configuration.mdx#webhook) to allow the deployment of private images.
 
 :::note

--- a/src/content/admin/registry-credentials/index.mdx
+++ b/src/content/admin/registry-credentials/index.mdx
@@ -88,25 +88,32 @@ If you add credentials using CRDs they will be displayed in the UI, but they can
 Okteto runs a dedicated Kubernetes Controller to manage Registy Credentials. As part of this process, the Controller creates and manages a [Docker Config JSON](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets) secret in the Okteto namespace.
 This secret is called `okteto-dockerconfig-static` and is always up to date with your Registy Credentials, either through the UI or using CRDs.
 
-This docker config secret is used as a pull secret in installer jobs.
-If the `daemonset.configurePrivateRegistriesInNodes.enabled` setting is active, Okteto writes this secret on every node which allows Kubelet to pull private images at deployment time.
+This docker config secret is used as a pull secret in installer jobs, in case your installer job image is private.
+
+The docker config secret is also replicated in all namespaces and preview environments created by Okteto, with the name `okteto-regcred`.
+`okteto-regcred` is injected as a pull secret to all pods by the [Okteto Webhook](self-hosted/helm-configuration.mdx#webhook) to allow the deployment of private images.
 
 :::note
-Any changes you make to Registry Credentials can take a few minutes to propagate to all nodes in the cluster. 
+By default, `okteto-regcred` only contains credentials to the Okteto Registry
 :::
 
-## Pull Secrets vs Kubelet reconfiguration
-
-An `okteto-regcred` secret exists in all namespaces and preview environments created by Okteto. This secret, by default, only contains credentials to the Okteto Registry and is injected as a pull secret to all pods by the [Okteto Webhook](self-hosted/helm-configuration.mdx#webhook).
-
-Okteto supports adding all your Registry Credentials to this `okteto-regcred` secret, not requiring the Okteto Daemonset to copy the docker config secret in every node.
-
-To enable this behavior set the following configuration in your helm values:
+To disable this behavior set the following configuration in your helm values:
 
 ```yaml
 regcredsManager:
   pullSecrets:
-    enabled: true
+    enabled: false
 ```
 
-When `regcredsManager.pullSecrets.enabled=true` the docker credentials defined in `okteto-dockerconfig-static` will no longer be copied into the nodes.
+If this behavior is disable, Okteto writes this secret on every node which allows Kubelet to pull private images at deployment time.
+To also disable this behavior set the following configuration in your helm values:
+
+```yaml
+daemonset:
+  configurePrivateRegistriesInNodes:
+    enabled: false
+```
+
+:::note
+`daemonset.configurePrivateRegistriesInNodes.enabled` is deprecated and it will be removed in Chart 1.21
+:::

--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -200,20 +200,14 @@ The daemonset automatically configures every node of your cluster to work better
 - `extraEnv`: Environment variables to be set on the daemonset containers.
 - `labels`: Labels to add to the daemonset pods.
 - `image`: Container image used by the daemonset pods.
-- `configurePrivateRegistriesInNodes.enabled`: Specifies if the daemonset should configure the private registry credentials in the nodes for kubelet or not. It defaults to `true`.
+- `configurePrivateRegistriesInNodes.enabled`: Specifies if the daemonset should configure the private registry credentials in the nodes for kubelet or not. It defaults to `true` but it's disabled if `regcredsManager.pullSecrets.enabled=true`.
 - `priorityClassName`: The priority class to be used by the daemonset pods. The PriorityClass must already exist in your cluster before using this setting. This value has precedence over `globals.priorityClassName` if both are set. If this value is not set, the pods will inherit the priority class defined by the value set in `globals.priorityClassName`.
-
-```yaml
-daemonset:
-  configurePrivateRegistriesInNodes:
-    enabled: true
-```
 
 The daemonset performs the following tasks on each node:
 
 - [Overrides](self-hosted/helm-configuration.mdx#overrideregistryresolution) the Okteto Registry hostname resolution to use internal IPs.
 - [Overrides](self-hosted/helm-configuration.mdx#overridefilewatchers) the default kernel values for file watchers on every node.
-- Configures the kubelet with registry credentials for [private registries](self-hosted/helm-configuration.mdx#daemonset) (if `configurePrivateRegistriesInNodes.enabled` key is `true`).
+- Configures the kubelet with registry credentials for [private registries](self-hosted/helm-configuration.mdx#daemonset) (if `configurePrivateRegistriesInNodes.enabled=true` and `regcredsManager.pullSecrets.enabled=false`).
 - Installs your CA if `wildcardCertificate.privateCA` is enabled.
 - Installs a CA if using self-signed certificates (`wildcardCertificate.create: true`).
 
@@ -1003,11 +997,11 @@ wildcardCertificate:
 
 The configuration for the controller manager of the Registry Credentials Operator.
 
-This controller manager is deployed as a deployment and is responsible to managing private registry credentials in the cluster. If `pullSecrets.enabled=true` all private registry credentials are copied to the `okteto-regcred` secret in user dev namespaces and previews. If `pullSecrets.enabled=false` these credentials are copied to all nodes through the okteto daemonset.
-
+This controller manager is deployed as a deployment and is responsible to managing private registry credentials in the cluster. If `pullSecrets.enabled=true` all private registry credentials are copied to the `okteto-regcred` secret in user dev namespaces and previews.
+If `pullSecrets.enabled=false` these credentials are copied to all nodes through the Okteto Daemon if `daemonset.configurePrivateRegistriesInNodes.enabled=true`.
 
 - `priorityClassName`: The priority class to be used by the controller manager pods. The PriorityClass must already exist in your cluster before using this setting. This value has precedence over `globals.priorityClassName` if both are set. If this value is not set, the pods will inherit the priority class defined by the value set in `globals.priorityClassName`.
-- `pullSecrets.enabled`: If enabled, private registry credentials defined in the cluster will be written to user namespaces as pull secrets and no longer be written to the nodes. In beta, defaults to false.
+- `pullSecrets.enabled`: If enabled, private registry credentials defined in the cluster will be written to user namespaces as pull secrets and no longer be written to the nodes. Defaults to true.
 - `internalCertificate.annotations`: Annotations to add to the tls secret used in the controller manager webhook server.
 - `podAnnotations`: Annotations to add to the controller manager pods.
 - `podLabels`: Labels to add to the controller manager pods.

--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -997,7 +997,7 @@ wildcardCertificate:
 
 The configuration for the controller manager of the Registry Credentials Operator.
 
-This controller manager is deployed as a deployment and is responsible to managing private registry credentials in the cluster. If `pullSecrets.enabled=true` all private registry credentials are copied to the `okteto-regcred` secret in user dev namespaces and previews.
+This controller manager is deployed as a deployment and is responsible for managing private registry credentials in the cluster. If `pullSecrets.enabled=true` all private registry credentials are copied to the `okteto-regcred` secret in user dev namespaces and previews.
 If `pullSecrets.enabled=false` these credentials are copied to all nodes through the Okteto Daemon if `daemonset.configurePrivateRegistriesInNodes.enabled=true`.
 
 - `priorityClassName`: The priority class to be used by the controller manager pods. The PriorityClass must already exist in your cluster before using this setting. This value has precedence over `globals.priorityClassName` if both are set. If this value is not set, the pods will inherit the priority class defined by the value set in `globals.priorityClassName`.


### PR DESCRIPTION
Starting on Chart 1.20, the Registry Credentials pull secrets operator is enabled by default, deprecating the functionality that writes these credentials to the nodes.