### PR TITLE
Added deprecation notice in 1.19 to indicate the support of Kubernetes 1.25 will be removed on next release

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -11,6 +11,10 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.25 to 1.29
 
+### Deprecation Notice
+
+- Support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) has been deprecated and will be removed in the next release.
+
 ### Improvements
 
 - Okteto CLI: the scope of the breaking change introduced in 1.19.0 has been reduced. `okteto deploy` will ignore host volumes of Docker Compose services only if the service defines a `build` section. [Please see our community post for more details](https://community.okteto.com/t/important-update-changes-to-docker-compose-deployment-behavior-in-okteto/1246)

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -29,6 +29,10 @@ This version is compatible with Kubernetes versions 1.25 to 1.29
 
 This version is compatible with Kubernetes versions 1.25 to 1.29
 
+### Deprecation Notice
+
+- Support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) has been deprecated and will be removed in the next release.
+
 ### New Features
 
 - [Okteto Insights](admin/okteto-insights.mdx): Pod v2, Build, Deploy, User, Namespace, and Preview metrics are now available <!-- 7897, 7906, 7898, 7900 -->

--- a/versioned_docs/version-1.19/release-notes.mdx
+++ b/versioned_docs/version-1.19/release-notes.mdx
@@ -11,6 +11,10 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.25 to 1.29
 
+### Deprecation Notice
+
+- Support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) has been deprecated and will be removed in the next release.
+
 ### Improvements
 
 - Okteto CLI: the scope of the breaking change introduced in 1.19.0 has been reduced. `okteto deploy` will ignore host volumes of Docker Compose services only if the service defines a `build` section. [Please see our community post for more details](https://community.okteto.com/t/important-update-changes-to-docker-compose-deployment-behavior-in-okteto/1246)

--- a/versioned_docs/version-1.19/release-notes.mdx
+++ b/versioned_docs/version-1.19/release-notes.mdx
@@ -29,6 +29,10 @@ This version is compatible with Kubernetes versions 1.25 to 1.29
 
 This version is compatible with Kubernetes versions 1.25 to 1.29
 
+### Deprecation Notice
+
+- Support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) has been deprecated and will be removed in the next release.
+
 ### New Features
 
 - [Okteto Insights](admin/okteto-insights.mdx): Pod v2, Build, Deploy, User, Namespace, and Preview metrics are now available <!-- 7897, 7906, 7898, 7900 -->


### PR DESCRIPTION
Kubernetes `1.25`  will not be support on next Okteto version, so I'm adding the deprecation notice