### PR TITLE
Redirect index.html URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,10 @@
 [[redirects]]
+  from = "/*/index.html"
+  to = "/:splat/"
+  status = 301
+  force = true
+  
+[[redirects]]
   from = "/docs/self-hosted/install/private-repositories/*"
   to = "/docs/admin/private-repositories/:splat"
   status = 301

--- a/src/content/self-hosted/manage/crds.mdx
+++ b/src/content/self-hosted/manage/crds.mdx
@@ -71,7 +71,7 @@ spec:
 
 ## Catalog Items
 
-Catalog items are mainly managed via the [Admin dashboard](admin/dashboard.mdx#catalog-items), but can also be managed via one of the CRDs installed by Okteto: `catalogitems.git.okteto.com`. This last case is useful, for example, if you want to add catalog items manually with a simple `kubectl` command or manage your catalog using GitOps.
+Catalog items are mainly managed via the [Admin dashboard](admin/dashboard.mdx#catalog), but can also be managed via one of the CRDs installed by Okteto: `catalogitems.git.okteto.com`. This last case is useful, for example, if you want to add catalog items manually with a simple `kubectl` command or manage your catalog using GitOps.
 For example, if you want to add a configuration for a catalog item, you will need to create a resource like this:
 
 - `metadata.name`: name of the CatalogItem resource to be created.


### PR DESCRIPTION
Fix https://okteto.slack.com/archives/C02SX9665RP/p1715785267007669

### Test plan

Any index.html files should redirect to the subdirectory:

https://deploy-preview-733--okteto-docs.netlify.app/docs/reference/okteto-cli/index.html should redirect to https://deploy-preview-733--okteto-docs.netlify.app/docs/reference/okteto-cli/

https://deploy-preview-733--okteto-docs.netlify.app/docs/reference/manifest/index.html should redirect to https://deploy-preview-733--okteto-docs.netlify.app/docs/reference/okteto-manifest