### PR TITLE
Fix links to use *.mdx references

### DIFF
--- a/src/content/core/credentials/environment-variables.mdx
+++ b/src/content/core/credentials/environment-variables.mdx
@@ -9,8 +9,8 @@ Environment Variables provide another way to specify your credentials. This is t
 
 The supported environment variables are:
 
-- `OKTETO_TOKEN`: Specifies the [Personal Access Token](core/credentials/personal-access-tokens.mdx) or [Admin Access Token](/admin/dashboard.mdx#admin-access-tokens) to use (Required)
-- `OKTETO_CONTEXT`: Specifies the Okteto URL. If missing, it defaults to https://okteto.example.com (Required)
+- `OKTETO_TOKEN`: Specifies the [Personal Access Token](core/credentials/personal-access-tokens.mdx) or [Admin Access Token](admin/dashboard.mdx#admin-access-tokens) to use (Required)
+- `OKTETO_CONTEXT`: Specifies the Okteto URL (Required)
 - `OKTETO_NAMESPACE`: Specifies the Namespace to use. If missing, it defaults to the Namespace of the current context (Optional)
 
 :::tip

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -14,7 +14,7 @@ This page is a guide for those who are authoring Okteto manifests and configurin
 
 ## What are Okteto Variables?
 
-Okteto Variables are a way to parametrize your [Okteto manifest](/reference/okteto-manifest.mdx) and the deploy, destroy and test strategy.
+Okteto Variables are a way to parametrize your [Okteto manifest](reference/okteto-manifest.mdx) and the deploy, destroy and test strategy.
 
 ### Types of Variables
 
@@ -46,7 +46,7 @@ Okteto Variables are scoped to the execution of the Okteto CLI. This means that 
 - available for expanding values in the Okteto manifest
 - available to commands, scripts and tools running as part of `deploy`, `destroy` and `test` commands in the Okteto manifest
 
-Okteto Variables **are not** propagated to the development containers. If you need to pass variables to your development containers, see [Development Containers](/development/containers/index.mdx).
+Okteto Variables **are not** propagated to the development containers. If you need to pass variables to your development containers, see [Development Containers](development/containers/index.mdx).
 
 :::note
 
@@ -165,7 +165,7 @@ Here are some highlights, and clarifications on the example above:
 
 ### Configuring dynamic endpoints
 
-In this example, we show how `$OKTETO_ENV` can be used to configure dynamic endpoints for [External Resources](/core/okteto-manifest.mdx#external) within your dev environment.
+In this example, we show how `$OKTETO_ENV` can be used to configure dynamic endpoints for [External Resources](core/okteto-manifest.mdx#external) within your dev environment.
 
 External Resources are defined in the Okteto manifest and have a name and a URL. Often, the resource URL is generated dynamically when the infrastructure is provisioned, in this example we show how to dynamically set the URL of an SQS queue.
 
@@ -262,7 +262,7 @@ When you deploy an application from the Okteto UI or if your organization uses t
 
 ### Local Environment Variables
 
-Similar to the `--var` flag, local environment variables are useful when you need to specify ad-hoc variables when running a command like [deploy](/docs/reference/okteto-cli#deploy) or [preview deploy](/docs/reference/okteto-cli#deploy-2)
+Similar to the `--var` flag, local environment variables are useful when you need to specify ad-hoc variables when running a command like [deploy](reference/okteto-cli.mdx#deploy) or [preview deploy](reference/okteto-cli.mdx#deploy-2)
 
 Example:
 
@@ -381,7 +381,7 @@ To delete an existing variable, click on the **Delete** button on the right. You
 
 Some features in Okteto are controlled by feature flags. These flags can be enabled or disabled using Okteto Variables and they have an impact on the behavior of the Okteto CLI.
 
-For a list of available feature flags, see [Feature Flags](/docs/1.20/reference/feature-flags/).
+For a list of available feature flags, see [Feature Flags](reference/feature-flags.mdx).
 
 ## Security
 


### PR DESCRIPTION
Fix some docs to follow the following rules:
- Links to docs always use *.mdx extension
- Don't link to versioned docs