### PR TITLE
Add deprecation notice about Okteto Stacks

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -11,17 +11,21 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.26 to 1.29
 
+### Deprecation Notice
+
+- Announced [deprecation of compose file detection](https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262) by name
+
 ### New Features
 
 - Enable [Pull Secrets by default](admin/registry-credentials/index.mdx). If you do not wish to manage pull secrets, please see our [upgrade guide](self-hosted/manage/upgrade.mdx#upgrading-to-okteto-120x) to disable.  <!-- 8001 -->
 - Added onboarding guides to our documentation on [how to get started with Okteto Insights](admin/okteto-insights.mdx) <!-- 729 -->
+- Added the ability to assign a [PriorityClass](self-hosted/helm-configuration.mdx#globals) to Okteto components  <!-- 7966 -->
+- Added `globals` and `buildkit` tolerations to the Helm Chart and standardize their helm values  <!-- 8029 -->
 
 ### Improvements
 
 - Namespaces without an owner will now be picked up by the Garbage Collector  <!-- 8018 -->
-- Added the ability to assign a [PriorityClass](self-hosted/helm-configuration.mdx#globals) to Okteto components  <!-- 7966 -->
 - Removed ingress TLS validation to allow more flexibility in deploying your own ingress objects  <!-- 8021 -->
-- Added `globals` and `buildkit` tolerations to the Helm Chart and standardize their helm values  <!-- 8029 -->
 - Renamed Variables to "Admin Variables" in the Admin section for clarity  <!-- 8040 -->
 - Included license issue warning badges on Admin and sidebar menu items  <!-- 8074 -->
 - Made error handling and feedback messages more consistent and actionable throughout the UI  <!-- 7952 -->
@@ -30,7 +34,6 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 - Okteto CLI: Changed the heuristic to mask variables in logs and comments that are longer that 5 characters
 - Okteto CLI: Added support for variables expansion on `manifest.build.dockerfile`
 - Okteto CLI: Added support for variable expansion in variables defined in `.env` - for example `"VAR1=${VAR2:-default}"`
-- Okteto CLI: Announced deprecation of compose file detection by name (distinction between stack and compose files.)
 
 ### Bug Fixes
 

--- a/versioned_docs/version-1.20/release-notes.mdx
+++ b/versioned_docs/version-1.20/release-notes.mdx
@@ -11,17 +11,21 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.26 to 1.29
 
+### Deprecation Notice
+
+- Announced [deprecation of compose file detection](https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262) by name
+
 ### New Features
 
 - Enable [Pull Secrets by default](admin/registry-credentials/index.mdx). If you do not wish to manage pull secrets, please see our [upgrade guide](self-hosted/manage/upgrade.mdx#upgrading-to-okteto-120x) to disable.  <!-- 8001 -->
 - Added onboarding guides to our documentation on [how to get started with Okteto Insights](admin/okteto-insights.mdx) <!-- 729 -->
+- Added the ability to assign a [PriorityClass](self-hosted/helm-configuration.mdx#globals) to Okteto components  <!-- 7966 -->
+- Added `globals` and `buildkit` tolerations to the Helm Chart and standardize their helm values  <!-- 8029 -->
 
 ### Improvements
 
 - Namespaces without an owner will now be picked up by the Garbage Collector  <!-- 8018 -->
-- Added the ability to assign a [PriorityClass](self-hosted/helm-configuration.mdx#globals) to Okteto components  <!-- 7966 -->
 - Removed ingress TLS validation to allow more flexibility in deploying your own ingress objects  <!-- 8021 -->
-- Added `globals` and `buildkit` tolerations to the Helm Chart and standardize their helm values  <!-- 8029 -->
 - Renamed Variables to "Admin Variables" in the Admin section for clarity  <!-- 8040 -->
 - Included license issue warning badges on Admin and sidebar menu items  <!-- 8074 -->
 - Made error handling and feedback messages more consistent and actionable throughout the UI  <!-- 7952 -->
@@ -30,7 +34,6 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 - Okteto CLI: Changed the heuristic to mask variables in logs and comments that are longer that 5 characters
 - Okteto CLI: Added support for variables expansion on `manifest.build.dockerfile`
 - Okteto CLI: Added support for variable expansion in variables defined in `.env` - for example `"VAR1=${VAR2:-default}"`
-- Okteto CLI: Announced deprecation of compose file detection by name (distinction between stack and compose files.)
 
 ### Bug Fixes
 


### PR DESCRIPTION
This PR updates the 1.20 release notes to do the following:
- Add a deprecation notice section and a link to the doc about Okteto Stacks deprecation
- Move global tolerations and priority class to the "Features" section