### PR TITLE
Update Node image version in the tutorial

### DIFF
--- a/src/content/get-started/deploy-your-app/index.mdx
+++ b/src/content/get-started/deploy-your-app/index.mdx
@@ -65,7 +65,7 @@ dev:
       - 9229:9229
 
   frontend:
-    image: okteto/node:14
+    image: okteto/node:20
     command: bash
     sync:
       - frontend:/usr/src/app

--- a/versioned_docs/version-1.18/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.18/get-started/deploy-your-app/index.mdx
@@ -66,7 +66,7 @@ dev:
       - 9229:9229
 
   frontend:
-    image: okteto/node:14
+    image: okteto/node:20
     command: bash
     sync:
       - frontend:/usr/src/app

--- a/versioned_docs/version-1.19/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.19/get-started/deploy-your-app/index.mdx
@@ -65,7 +65,7 @@ dev:
       - 9229:9229
 
   frontend:
-    image: okteto/node:14
+    image: okteto/node:20
     command: bash
     sync:
       - frontend:/usr/src/app

--- a/versioned_docs/version-1.20/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.20/get-started/deploy-your-app/index.mdx
@@ -65,7 +65,7 @@ dev:
       - 9229:9229
 
   frontend:
-    image: okteto/node:14
+    image: okteto/node:20
     command: bash
     sync:
       - frontend:/usr/src/app


### PR DESCRIPTION
Follow-up on https://github.com/okteto/getting-started/pull/2

This PR updates the Node base image version from 14 to 20 from the summary manifest on the first page of the `get-started` tutorial to match the actual version used by the [`getting-started`](https://github.com/okteto/getting-started) project (upgraded in [this PR](https://github.com/okteto/getting-started/pull/2))