### PR TITLE
Update summary and manifest on the `get-started` first page

### DIFF
--- a/src/content/get-started/deploy-your-app/index.mdx
+++ b/src/content/get-started/deploy-your-app/index.mdx
@@ -55,20 +55,6 @@ deploy:
         --set seed.enabled=true \
         --set api.image=${OKTETO_BUILD_API_IMAGE} \
         --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
-
-dev:
-  api:
-    command: yarn start
-    sync:
-      - api:/src
-    forward:
-      - 9229:9229
-
-  frontend:
-    image: okteto/node:20
-    command: bash
-    sync:
-      - frontend:/usr/src/app
 ```
 
 This guide will take you through the following sections:
@@ -76,6 +62,5 @@ This guide will take you through the following sections:
 - `build`: Configure a list of images to build for your application
 - `dependencies`: Configure a list of git repositories to deploy as part of your application
 - `deploy`: Configure a list of commands to deploy your application
-- `dev`: Configures hot reloading and debuggers for developing your application
 
 Now that you know what your are building, [start the tutorial](deploy.mdx) and deploy your app to Okteto 😎

--- a/src/content/get-started/deploy-your-app/index.mdx
+++ b/src/content/get-started/deploy-your-app/index.mdx
@@ -36,6 +36,8 @@ In order to deploy the Movies app, you will create your first [Okteto Manifest](
 This is what your Okteto Manifest will look like at the end of the tutorial:
 
 ```yaml title="okteto.yaml"
+name: movies
+
 build:
   api:
     context: api

--- a/versioned_docs/version-1.18/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.18/get-started/deploy-your-app/index.mdx
@@ -56,20 +56,6 @@ deploy:
         --set seed.enabled=true \
         --set api.image=${OKTETO_BUILD_API_IMAGE} \
         --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
-
-dev:
-  api:
-    command: yarn start
-    sync:
-      - api:/src
-    forward:
-      - 9229:9229
-
-  frontend:
-    image: okteto/node:20
-    command: bash
-    sync:
-      - frontend:/usr/src/app
 ```
 
 This guide will take you through the following sections:
@@ -77,6 +63,5 @@ This guide will take you through the following sections:
 - `build`: Configure a list of images to build for your application
 - `dependencies`: Configure a list of git repositories to deploy as part of your application
 - `deploy`: Configure a list of commands to deploy your application
-- `dev`: Configures hot reloading and debuggers for developing your application
 
 Now that you know what your are building, [start the tutorial](deploy.mdx) and deploy your app to Okteto 😎

--- a/versioned_docs/version-1.18/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.18/get-started/deploy-your-app/index.mdx
@@ -37,6 +37,8 @@ In order to deploy the Movies app, you will create your first [Okteto Manifest](
 This is what your Okteto Manifest will look like at the end of the tutorial:
 
 ```yaml
+name: movies
+
 build:
   api:
     context: api

--- a/versioned_docs/version-1.19/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.19/get-started/deploy-your-app/index.mdx
@@ -55,20 +55,6 @@ deploy:
         --set seed.enabled=true \
         --set api.image=${OKTETO_BUILD_API_IMAGE} \
         --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
-
-dev:
-  api:
-    command: yarn start
-    sync:
-      - api:/src
-    forward:
-      - 9229:9229
-
-  frontend:
-    image: okteto/node:20
-    command: bash
-    sync:
-      - frontend:/usr/src/app
 ```
 
 This guide will take you through the following sections:
@@ -76,6 +62,5 @@ This guide will take you through the following sections:
 - `build`: Configure a list of images to build for your application
 - `dependencies`: Configure a list of git repositories to deploy as part of your application
 - `deploy`: Configure a list of commands to deploy your application
-- `dev`: Configures hot reloading and debuggers for developing your application
 
 Now that you know what your are building, [start the tutorial](deploy.mdx) and deploy your app to Okteto 😎

--- a/versioned_docs/version-1.19/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.19/get-started/deploy-your-app/index.mdx
@@ -36,6 +36,8 @@ In order to deploy the Movies app, you will create your first [Okteto Manifest](
 This is what your Okteto Manifest will look like at the end of the tutorial:
 
 ```yaml title="okteto.yaml"
+name: movies
+
 build:
   api:
     context: api

--- a/versioned_docs/version-1.20/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.20/get-started/deploy-your-app/index.mdx
@@ -55,20 +55,6 @@ deploy:
         --set seed.enabled=true \
         --set api.image=${OKTETO_BUILD_API_IMAGE} \
         --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
-
-dev:
-  api:
-    command: yarn start
-    sync:
-      - api:/src
-    forward:
-      - 9229:9229
-
-  frontend:
-    image: okteto/node:20
-    command: bash
-    sync:
-      - frontend:/usr/src/app
 ```
 
 This guide will take you through the following sections:
@@ -76,6 +62,5 @@ This guide will take you through the following sections:
 - `build`: Configure a list of images to build for your application
 - `dependencies`: Configure a list of git repositories to deploy as part of your application
 - `deploy`: Configure a list of commands to deploy your application
-- `dev`: Configures hot reloading and debuggers for developing your application
 
 Now that you know what your are building, [start the tutorial](deploy.mdx) and deploy your app to Okteto 😎

--- a/versioned_docs/version-1.20/get-started/deploy-your-app/index.mdx
+++ b/versioned_docs/version-1.20/get-started/deploy-your-app/index.mdx
@@ -36,6 +36,8 @@ In order to deploy the Movies app, you will create your first [Okteto Manifest](
 This is what your Okteto Manifest will look like at the end of the tutorial:
 
 ```yaml title="okteto.yaml"
+name: movies
+
 build:
   api:
     context: api


### PR DESCRIPTION
Related: https://github.com/okteto/docs/pull/744

Currently, we don't have a `dev` section as part of the `get-started` tutorial but the final manifest we are supposed to obtain by following the tutorial does, so I think it's better to remove these references for now to match the actual content of the tutorial. We can always recover this part if we finally decide to include this section.

See: https://www.okteto.com/docs/get-started/deploy-your-app/#what-you-will-be-building

So for now, in case you agree, I'm removing the `dev` section from the final manifest and the summary of the sections.

Also added the `name` field to strictly match that manifest on the first page of the tutorial with the one resulted after following all the steps.