### PR TITLE
`1.20.1` + `1.19.4` release notes

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -58,6 +58,17 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 - Support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) has been removed in this release.
 
 
+## 1.19.4
+
+28 May 2024
+
+This version is compatible with Kubernetes versions 1.25 to 1.29
+
+### Improvements
+
+- Updated CLI version in the backend to 2.26.2  <!-- 8137 -->
+
+
 ## 1.19.3
 
 15 May 2024

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -13,7 +13,7 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 
 ### Bug Fixes
 
-- Updated CLI version in the backend to 2.27.3 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8135 -->
+- Updated the backend CLI to version 2.27.3 to resolve a panic issue that occurred when using Docker Compose with Okteto Manifests, specifically when the `image` field in a compose service referred to an environment variable  <!-- 4312, 8135 -->
 
 ## 1.20.0
 
@@ -65,7 +65,7 @@ This version is compatible with Kubernetes versions 1.25 to 1.29
 
 ### Bug Fixes
 
-- Updated CLI version in the backend to 2.26.2 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8137 -->
+- Updated the backend CLI to version 2.26.2 to resolve a panic issue that occurred when using Docker Compose with Okteto Manifests, specifically when the `image` field in a compose service referred to an environment variable  <!-- 4312, 8137 -->
 
 
 ## 1.19.3

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -5,6 +5,17 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.20.1
+
+28 May 2024
+
+This version is compatible with Kubernetes versions 1.26 to 1.29
+
+### Improvements
+
+- Updated CLI version in the backend to 2.27.3  <!-- 8135 -->
+
+
 ## 1.20.0
 
 21 May 2024

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -11,10 +11,9 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.26 to 1.29
 
-### Improvements
+### Bug Fixes
 
-- Updated CLI version in the backend to 2.27.3  <!-- 8135 -->
-
+- Updated CLI version in the backend to 2.27.3 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8135 -->
 
 ## 1.20.0
 
@@ -64,9 +63,9 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 
 This version is compatible with Kubernetes versions 1.25 to 1.29
 
-### Improvements
+### Bug Fixes
 
-- Updated CLI version in the backend to 2.26.2  <!-- 8137 -->
+- Updated CLI version in the backend to 2.26.2 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8137 -->
 
 
 ## 1.19.3

--- a/versioned_docs/version-1.19/release-notes.mdx
+++ b/versioned_docs/version-1.19/release-notes.mdx
@@ -13,7 +13,7 @@ This version is compatible with Kubernetes versions 1.25 to 1.29
 
 ### Bug Fixes
 
-- Updated CLI version in the backend to 2.26.2 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8137 -->
+- Updated the backend CLI to version 2.26.2 to resolve a panic issue that occurred when using Docker Compose with Okteto Manifests, specifically when the `image` field in a compose service referred to an environment variable  <!-- 4312, 8137 -->
 
 
 ## 1.19.3

--- a/versioned_docs/version-1.19/release-notes.mdx
+++ b/versioned_docs/version-1.19/release-notes.mdx
@@ -5,6 +5,17 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.19.4
+
+28 May 2024
+
+This version is compatible with Kubernetes versions 1.25 to 1.29
+
+### Bug Fixes
+
+- Updated CLI version in the backend to 2.26.2 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8137 -->
+
+
 ## 1.19.3
 
 15 May 2024

--- a/versioned_docs/version-1.20/release-notes.mdx
+++ b/versioned_docs/version-1.20/release-notes.mdx
@@ -5,6 +5,17 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.20.1
+
+28 May 2024
+
+This version is compatible with Kubernetes versions 1.26 to 1.29
+
+### Improvements
+
+- Updated CLI version in the backend to 2.27.3  <!-- 8135 -->
+
+
 ## 1.20.0
 
 21 May 2024

--- a/versioned_docs/version-1.20/release-notes.mdx
+++ b/versioned_docs/version-1.20/release-notes.mdx
@@ -11,9 +11,9 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.26 to 1.29
 
-### Improvements
+### Bug Fixes
 
-- Updated CLI version in the backend to 2.27.3  <!-- 8135 -->
+- Updated CLI version in the backend to 2.27.3 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8135 -->
 
 
 ## 1.20.0
@@ -63,9 +63,9 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 
 This version is compatible with Kubernetes versions 1.25 to 1.29
 
-### Improvements
+### Bug Fixes
 
-- Updated CLI version in the backend to 2.26.2  <!-- 8137 -->
+- Updated CLI version in the backend to 2.26.2 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8137 -->
 
 
 ## 1.19.3

--- a/versioned_docs/version-1.20/release-notes.mdx
+++ b/versioned_docs/version-1.20/release-notes.mdx
@@ -57,6 +57,16 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 
 - Support for Kubernetes [1.25](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) has been removed in this release.
 
+## 1.19.4
+
+28 May 2024
+
+This version is compatible with Kubernetes versions 1.25 to 1.29
+
+### Improvements
+
+- Updated CLI version in the backend to 2.26.2  <!-- 8137 -->
+
 
 ## 1.19.3
 

--- a/versioned_docs/version-1.20/release-notes.mdx
+++ b/versioned_docs/version-1.20/release-notes.mdx
@@ -13,7 +13,7 @@ This version is compatible with Kubernetes versions 1.26 to 1.29
 
 ### Bug Fixes
 
-- Updated CLI version in the backend to 2.27.3 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8135 -->
+- Updated the backend CLI to version 2.27.3 to resolve a panic issue that occurred when using Docker Compose with Okteto Manifests, specifically when the `image` field in a compose service referred to an environment variable  <!-- 4312, 8135 -->
 
 
 ## 1.20.0
@@ -65,7 +65,7 @@ This version is compatible with Kubernetes versions 1.25 to 1.29
 
 ### Bug Fixes
 
-- Updated CLI version in the backend to 2.26.2 to fix a panic when using Docker Compose and Okteto Manifests together, and the field image in a compose service was referring to an environment variable  <!-- 4312, 8137 -->
+- Updated the backend CLI to version 2.26.2 to resolve a panic issue that occurred when using Docker Compose with Okteto Manifests, specifically when the `image` field in a compose service referred to an environment variable  <!-- 4312, 8137 -->
 
 
 ## 1.19.3


### PR DESCRIPTION
This PR updates the release notes for the Okteto chart `1.20.1` and `1.19.4`.