### PR TITLE
Announce okteto autoscaler deprecation

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -11,6 +11,10 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.26 to 1.29
 
+### Deprecation Notice
+
+- Announced [deprecation of Okteto Autoscaler](self-hosted/helm-configuration.mdx#autoscaler-deprecated). We recommend relying on cpu/memory requests to autoscale your cluster
+
 ### New Features
 
 - The platform will now only obfuscate variables that are longer than 5 characters  <!-- 8090 -->

--- a/versioned_docs/version-1.21/release-notes.mdx
+++ b/versioned_docs/version-1.21/release-notes.mdx
@@ -11,6 +11,10 @@ id: release-notes
 
 This version is compatible with Kubernetes versions 1.26 to 1.29
 
+### Deprecation Notice
+
+- Announced [deprecation of Okteto Autoscaler](self-hosted/helm-configuration.mdx#autoscaler-deprecated). We recommend relying on cpu/memory requests to autoscale your cluster
+
 ### New Features
 
 - The platform will now only obfuscate variables that are longer than 5 characters  <!-- 8090 -->


### PR DESCRIPTION
The okteto autoscaler was deprecated a few releases ago, but we didn't mention it in the release notes