### PR TITLE
Adjust heading levels on `amazon-ecr` page

### DIFF
--- a/src/content/admin/registry-credentials/amazon-ecr.mdx
+++ b/src/content/admin/registry-credentials/amazon-ecr.mdx
@@ -11,7 +11,7 @@ It's recommended that you have the [AWS CLI installed](https://docs.aws.amazon.c
 
 ECR credentials can be configured with either static credentials belonging to an IAM user or using OIDC federation to assume an IAM Role via Web Identity.
 
-# Using IAM User credentials
+## Using IAM User credentials
 
 The steps to configure your private ECR with Okteto are: 
 
@@ -19,7 +19,7 @@ The steps to configure your private ECR with Okteto are:
 - Retrieve the user credentials
 - Configure the credentials in Okteto
 
-## Step 1: Create a user with access to your private ECR
+### Step 1: Create a user with access to your private ECR
 
 Create IAM user with the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/iam/create-user.html) by executing:
 
@@ -33,7 +33,7 @@ aws iam attach-user-policy \
   --user-name private-registry-user
 ```
 
-## Step 2: Retrieve the user credentials
+### Step 2: Retrieve the user credentials
 
 Once we have the `User` created, we need to retrieve their credentials.
 Create IAM user access key with the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/iam/create-access-key.html) by executing:
@@ -56,7 +56,7 @@ aws iam create-access-key --user-name private-registry-user
 
 Remember the value of `AccessKeyId` and `SecretAccessKey`. You will need them in the next step.
 
-## Step 3: Configure the credentials in Okteto
+### Step 3: Configure the credentials in Okteto
 
 Add the following registry credentials to the [Admin Registry Credentials view](index.mdx#add-registry-credentials):
 
@@ -65,9 +65,9 @@ Add the following registry credentials to the [Admin Registry Credentials view](
 - **Username**: `AccessKeyId` from the previous step
 - **Password**: `SecretAccessKey` from the previous step
 
-# Using OIDC Federation
+## Using OIDC Federation
 
-## Step 1: Create the Identity Provider
+### Step 1: Create the Identity Provider
 
 ```bash
 OIDC_ENDPOINT=https://container.googleapis.com/v1/projects/my-project-12345/locations/us-central1/clusters/development
@@ -102,7 +102,7 @@ your-okteto-instance.com/your-region
 ```
 
 
-## Step 2: Create the Role
+### Step 2: Create the Role
 
 
 First create the role and allow it to access EC2:
@@ -166,7 +166,7 @@ aws iam attach-role-policy --role-name my-private-registry --policy-arn arn:aws:
 If you only need read access you can use `AmazonEC2ContainerRegistryReadOnly` instead.
 
 
-## Step 3: Configure the credentials in Okteto
+### Step 3: Configure the credentials in Okteto
 
 Add the following registry credentials to the [Admin Registry Credentials view](index.mdx#add-registry-credentials):
 


### PR DESCRIPTION
It looks like using `h1` tags in the content of a page is discouraged, here is a [conversation](https://github.com/facebook/docusaurus/issues/1828) in the Docusaurus repository about it. Docusaurus doesn't inject an ID for first-level headings so we cannot have links directly to these sections. In the [official docs](https://docusaurus.io/docs/markdown-features/toc#markdown-headings) they only talk about `2`, `3` and `4` levels, not mention about `1` AFAIK, but it looks like it generates some issues, e.g. the main title of the page just disappears if there are other `h1`:

|Before|After|
|---|---|
|<img width="900" alt="image" src="https://github.com/okteto/docs/assets/13395148/3d880975-fb71-4377-8221-d8e0696b8556">|<img width="900" alt="image" src="https://github.com/okteto/docs/assets/13395148/bed79328-66ba-4950-bfae-5bcd94927d07">|

I don't know if we have a policy about how to use headings but it would be great to agree on that and to fix other possible issues like this one that could exist in the project.

(The preview won't work until https://github.com/okteto/docs/pull/769 is merged)
