### PR TITLE
Add missing `echo` for `$OKTETO_ENV` examples

### DIFF
--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -180,7 +180,7 @@ deploy:
     - terraform output -json > tfout.json
 
     # I configure the external resource URL
-    - OKTETO_EXTERNAL_SQS_ENDPOINTS_QUEUE_URL=$(cat tfout.json | jq -r '.queue_url') >> $OKTETO_ENV
+    - echo OKTETO_EXTERNAL_SQS_ENDPOINTS_QUEUE_URL=$(cat tfout.json | jq -r '.queue_url') >> $OKTETO_ENV
 
 external:
   sqs:

--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -121,7 +121,7 @@ test:
         - terraform output -json > tfout.json
 
         # I make the following var available to other steps
-        - SERVICE_ENDPOINT=$(cat tfout.json | jq -r '.service_endpoint') >> $OKTETO_ENV
+        - echo SERVICE_ENDPOINT=$(cat tfout.json | jq -r '.service_endpoint') >> $OKTETO_ENV
 
         # the following step will have access to SERVICE_ENDPOINT
         - echo "Running tests against ${SERVICE_ENDPOINT}..."

--- a/versioned_docs/version-1.20/core/okteto-variables.mdx
+++ b/versioned_docs/version-1.20/core/okteto-variables.mdx
@@ -180,7 +180,7 @@ deploy:
     - terraform output -json > tfout.json
 
     # I configure the external resource URL
-    - OKTETO_EXTERNAL_SQS_ENDPOINTS_QUEUE_URL=$(cat tfout.json | jq -r '.queue_url') >> $OKTETO_ENV
+    - echo OKTETO_EXTERNAL_SQS_ENDPOINTS_QUEUE_URL=$(cat tfout.json | jq -r '.queue_url') >> $OKTETO_ENV
 
 external:
   sqs:

--- a/versioned_docs/version-1.20/core/okteto-variables.mdx
+++ b/versioned_docs/version-1.20/core/okteto-variables.mdx
@@ -121,7 +121,7 @@ test:
         - terraform output -json > tfout.json
 
         # I make the following var available to other steps
-        - SERVICE_ENDPOINT=$(cat tfout.json | jq -r '.service_endpoint') >> $OKTETO_ENV
+        - echo SERVICE_ENDPOINT=$(cat tfout.json | jq -r '.service_endpoint') >> $OKTETO_ENV
 
         # the following step will have access to SERVICE_ENDPOINT
         - echo "Running tests against ${SERVICE_ENDPOINT}..."

--- a/versioned_docs/version-1.21/core/okteto-variables.mdx
+++ b/versioned_docs/version-1.21/core/okteto-variables.mdx
@@ -180,7 +180,7 @@ deploy:
     - terraform output -json > tfout.json
 
     # I configure the external resource URL
-    - OKTETO_EXTERNAL_SQS_ENDPOINTS_QUEUE_URL=$(cat tfout.json | jq -r '.queue_url') >> $OKTETO_ENV
+    - echo OKTETO_EXTERNAL_SQS_ENDPOINTS_QUEUE_URL=$(cat tfout.json | jq -r '.queue_url') >> $OKTETO_ENV
 
 external:
   sqs:

--- a/versioned_docs/version-1.21/core/okteto-variables.mdx
+++ b/versioned_docs/version-1.21/core/okteto-variables.mdx
@@ -121,7 +121,7 @@ test:
         - terraform output -json > tfout.json
 
         # I make the following var available to other steps
-        - SERVICE_ENDPOINT=$(cat tfout.json | jq -r '.service_endpoint') >> $OKTETO_ENV
+        - echo SERVICE_ENDPOINT=$(cat tfout.json | jq -r '.service_endpoint') >> $OKTETO_ENV
 
         # the following step will have access to SERVICE_ENDPOINT
         - echo "Running tests against ${SERVICE_ENDPOINT}..."


### PR DESCRIPTION
I've noticed that the docs has missing `echo` for `$OKTETO_ENV` to work.