### PR TITLE
Update previews to use github action concurrency

### DIFF
--- a/src/content/previews/using-github-actions.mdx
+++ b/src/content/previews/using-github-actions.mdx
@@ -37,6 +37,11 @@ on:
     branches:
       - main
 
+concurrency:
+  # more info here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+  
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -54,16 +59,7 @@ jobs:
         with:
           name: pr-${{ github.event.number }}
           timeout: 15m
-          scope: global
 ```
-
-:::info
-There are two different scopes for preview environments:
-- `personal`, where the only one who has access to the environment is the own user; and
-- `global`, where all cluster members have access.
-
-This example creates a preview environment with global scope and requires administrator permissions using [admin access tokens](admin/dashboard.mdx#admin-access-tokens). To follow this example as a non-admin, use a [Personal Access Token](core/credentials/personal-access-tokens.mdx)
-:::
 
 ## Step 2: Configure your secrets
 

--- a/src/content/previews/using-gitlab-cicd.mdx
+++ b/src/content/previews/using-gitlab-cicd.mdx
@@ -87,7 +87,7 @@ review:
   variables:
     APP: review-$CI_COMMIT_REF_SLUG
   script:
-    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --scope global --branch $CI_COMMIT_REF_NAME --repository $CI_PROJECT_URL --wait
+    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --branch $CI_COMMIT_REF_NAME --repository $CI_PROJECT_URL --wait
 
 
   environment:
@@ -114,14 +114,6 @@ stop-review:
   except:
     - master
 ```
-
-:::info
-There are two different scopes for preview environments:
-- `personal`, where the only one who has access to the environment is the own user; and
-- `global`, where all cluster members have access.
-
-This example creates a preview environment with global scope and requires administrator permissions using [admin access tokens](admin/dashboard.mdx#admin-access-tokens). To follow this example as a non-admin, use a [Personal Access Token](core/credentials/personal-access-tokens.mdx)
-:::
 
 A few recommendations when creating your preview environment:
 

--- a/versioned_docs/version-1.22/previews/using-github-actions.mdx
+++ b/versioned_docs/version-1.22/previews/using-github-actions.mdx
@@ -37,6 +37,11 @@ on:
     branches:
       - main
 
+concurrency:
+  # more info here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+  
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -54,16 +59,7 @@ jobs:
         with:
           name: pr-${{ github.event.number }}
           timeout: 15m
-          scope: global
 ```
-
-:::info
-There are two different scopes for preview environments:
-- `personal`, where the only one who has access to the environment is the own user; and
-- `global`, where all cluster members have access.
-
-This example creates a preview environment with global scope and requires administrator permissions using [admin access tokens](admin/dashboard.mdx#admin-access-tokens). To follow this example as a non-admin, use a [Personal Access Token](core/credentials/personal-access-tokens.mdx)
-:::
 
 ## Step 2: Configure your secrets
 

--- a/versioned_docs/version-1.22/previews/using-gitlab-cicd.mdx
+++ b/versioned_docs/version-1.22/previews/using-gitlab-cicd.mdx
@@ -87,7 +87,7 @@ review:
   variables:
     APP: review-$CI_COMMIT_REF_SLUG
   script:
-    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --scope global --branch $CI_COMMIT_REF_NAME --repository $CI_PROJECT_URL --wait
+    - okteto preview deploy review-$CI_COMMIT_REF_SLUG --branch $CI_COMMIT_REF_NAME --repository $CI_PROJECT_URL --wait
 
 
   environment:
@@ -114,14 +114,6 @@ stop-review:
   except:
     - master
 ```
-
-:::info
-There are two different scopes for preview environments:
-- `personal`, where the only one who has access to the environment is the own user; and
-- `global`, where all cluster members have access.
-
-This example creates a preview environment with global scope and requires administrator permissions using [admin access tokens](admin/dashboard.mdx#admin-access-tokens). To follow this example as a non-admin, use a [Personal Access Token](core/credentials/personal-access-tokens.mdx)
-:::
 
 A few recommendations when creating your preview environment:
 


### PR DESCRIPTION
- Update the GitHub Action to deploy preview environments to use GitHub Actions concurrency.
- Also, remove references to `scope` from the getting started guides, since we default to `scope: global` now and using `scope: personal` is an advanced scenario that doesn't need to be introduced in the getting started guide

Related PRs:
- https://github.com/okteto/deploy-preview/pull/58
- https://github.com/okteto/build/pull/23