### PR TITLE
Fix typo in `$OKTETO_ENV` example

### DIFF
--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -137,7 +137,7 @@ deploy:
       set -e
       bucketName="${OKTETO_NAMESPACE}-okteto-tacos-shop"
       terraform apply -input=false -var "bucket_name=$bucketName" -auto-approve
-      echo "S3_BUCKET_NAME=$resourceName" >> "$OKTETO_ENV"
+      echo "S3_BUCKET_NAME=$bucketName" >> "$OKTETO_ENV"
 
   - name: Create .env
     command: |

--- a/versioned_docs/version-1.20/core/okteto-variables.mdx
+++ b/versioned_docs/version-1.20/core/okteto-variables.mdx
@@ -137,7 +137,7 @@ deploy:
       set -e
       bucketName="${OKTETO_NAMESPACE}-okteto-tacos-shop"
       terraform apply -input=false -var "bucket_name=$bucketName" -auto-approve
-      echo "S3_BUCKET_NAME=$resourceName" >> "$OKTETO_ENV"
+      echo "S3_BUCKET_NAME=$bucketName" >> "$OKTETO_ENV"
 
   - name: Create .env
     command: |

--- a/versioned_docs/version-1.21/core/okteto-variables.mdx
+++ b/versioned_docs/version-1.21/core/okteto-variables.mdx
@@ -137,7 +137,7 @@ deploy:
       set -e
       bucketName="${OKTETO_NAMESPACE}-okteto-tacos-shop"
       terraform apply -input=false -var "bucket_name=$bucketName" -auto-approve
-      echo "S3_BUCKET_NAME=$resourceName" >> "$OKTETO_ENV"
+      echo "S3_BUCKET_NAME=$bucketName" >> "$OKTETO_ENV"
 
   - name: Create .env
     command: |

--- a/versioned_docs/version-1.22/core/okteto-variables.mdx
+++ b/versioned_docs/version-1.22/core/okteto-variables.mdx
@@ -137,7 +137,7 @@ deploy:
       set -e
       bucketName="${OKTETO_NAMESPACE}-okteto-tacos-shop"
       terraform apply -input=false -var "bucket_name=$bucketName" -auto-approve
-      echo "S3_BUCKET_NAME=$resourceName" >> "$OKTETO_ENV"
+      echo "S3_BUCKET_NAME=$bucketName" >> "$OKTETO_ENV"
 
   - name: Create .env
     command: |


### PR DESCRIPTION
In the example we refer to `$resourceName` instead of `$bucketName`