### PR TITLE
make it more evident that we are talking about Kubernetes services 

### DIFF
--- a/src/content/core/endpoints/automatic-ssl.mdx
+++ b/src/content/core/endpoints/automatic-ssl.mdx
@@ -15,15 +15,7 @@ If you've configured Endpoints but they aren't appearing, please check our [FAQ 
 
 ## Auto create ingresses from services
 
-Okteto can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the annotation below to your service's manifest:
-
-```yaml
-metadata:
-  annotations:
-    dev.okteto.com/auto-ingress: "true"
-```
-
-For example:
+Okteto can automatically create an SSL endpoint for your deployments. In order to take advantage of this feature, add the `dev.okteto.com/auto-ingress: "true"` annotation to your Service definition.
 
 ```yaml
 apiVersion: v1
@@ -64,15 +56,7 @@ Keep in mind that all the hosts you use in your ingress must end with`-$NAMESPAC
 
 ### Let Okteto generate the host
 
-Okteto can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the annotation below to your ingress' manifest.
-
-```yaml
-metadata:
-  annotations:
-    dev.okteto.com/generate-host: "true"
-```
-
-Full example:
+Okteto can automatically inject the right host names during the creation of your ingresses, while leaving the rest of the configuration intact. In order to take advantage of this feature, add the `dev.okteto.com/generate-host: "true"` annotation to your Ingress definition.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -178,9 +162,12 @@ endpoints:
 If your application communicates over HTTPS instead of HTTP, you'll need to create a dedicated ingress, as demonstrated in the [Bring Your Own Ingress](#bring-your-own-ingress) section, and add the following annotation to it:
 
 ```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+...
 ```
 
 Please note that this won't pass through the certificate served by your application to the requester. Instead, the wildcard certificate of the Okteto instance will be used.


### PR DESCRIPTION
make it more evident that annotation examples we are showing in [are talking about Kubernetes services ](https://www.okteto.com/docs/core/endpoints/automatic-ssl/#auto-create-ingresses-from-services) are about Kubernetes services and not Okteto manifests