### PR TITLE
fix OKTETO_REGISTRY_URL var

### DIFF
--- a/src/content/core/container-registry.mdx
+++ b/src/content/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/src/content/core/container-registry.mdx
+++ b/src/content/core/container-registry.mdx
@@ -73,7 +73,7 @@ For example:
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart.
@@ -87,7 +87,7 @@ After that you can push the packaged Helm chart to the registry.
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 ## Pull Helm chart to the Okteto Registry
@@ -96,6 +96,6 @@ Once the packaged chart has been pushed to the Okteto Registry, you can pull it 
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
-  - helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/src/content/core/container-registry.mdx
+++ b/src/content/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy` commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.12/cloud/registry.mdx
+++ b/versioned_docs/version-1.12/cloud/registry.mdx
@@ -69,7 +69,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
 helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}

--- a/versioned_docs/version-1.12/cloud/registry.mdx
+++ b/versioned_docs/version-1.12/cloud/registry.mdx
@@ -72,7 +72,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart. 
@@ -84,11 +84,11 @@ helm package ./chart
 After that you can push the packaged Helm chart to the registry.
 
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
 ```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.13/cloud/registry.mdx
+++ b/versioned_docs/version-1.13/cloud/registry.mdx
@@ -69,7 +69,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
 helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}

--- a/versioned_docs/version-1.13/cloud/registry.mdx
+++ b/versioned_docs/version-1.13/cloud/registry.mdx
@@ -72,7 +72,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart. 
@@ -84,11 +84,11 @@ helm package ./chart
 After that you can push the packaged Helm chart to the registry.
 
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
 ```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.14/cloud/registry.mdx
+++ b/versioned_docs/version-1.14/cloud/registry.mdx
@@ -69,7 +69,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
 helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}

--- a/versioned_docs/version-1.14/cloud/registry.mdx
+++ b/versioned_docs/version-1.14/cloud/registry.mdx
@@ -72,7 +72,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart. 
@@ -84,11 +84,11 @@ helm package ./chart
 After that you can push the packaged Helm chart to the registry.
 
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
 ```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.15/cloud/registry.mdx
+++ b/versioned_docs/version-1.15/cloud/registry.mdx
@@ -69,7 +69,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
 helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}

--- a/versioned_docs/version-1.15/cloud/registry.mdx
+++ b/versioned_docs/version-1.15/cloud/registry.mdx
@@ -72,7 +72,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart. 
@@ -84,11 +84,11 @@ helm package ./chart
 After that you can push the packaged Helm chart to the registry.
 
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
 ```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.16/core/components/container-registry.mdx
+++ b/versioned_docs/version-1.16/core/components/container-registry.mdx
@@ -69,7 +69,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
 helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}

--- a/versioned_docs/version-1.16/core/components/container-registry.mdx
+++ b/versioned_docs/version-1.16/core/components/container-registry.mdx
@@ -72,7 +72,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart. 
@@ -84,11 +84,11 @@ helm package ./chart
 After that you can push the packaged Helm chart to the registry.
 
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
 ```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.17/core/components/container-registry.mdx
+++ b/versioned_docs/version-1.17/core/components/container-registry.mdx
@@ -69,7 +69,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
 helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}

--- a/versioned_docs/version-1.17/core/components/container-registry.mdx
+++ b/versioned_docs/version-1.17/core/components/container-registry.mdx
@@ -72,7 +72,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart. 
@@ -84,11 +84,11 @@ helm package ./chart
 After that you can push the packaged Helm chart to the registry.
 
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
 ```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.18/core/components/container-registry.mdx
+++ b/versioned_docs/version-1.18/core/components/container-registry.mdx
@@ -69,7 +69,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 }
 ```
 
-You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
+You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
 helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}

--- a/versioned_docs/version-1.18/core/components/container-registry.mdx
+++ b/versioned_docs/version-1.18/core/components/container-registry.mdx
@@ -72,7 +72,7 @@ Just as you can push images to the Okteto Registry, you also have the option to 
 You can retrieve your username, password (token), and the domain for your registry from the output. Using the [deploy section](https://www.okteto.com/docs/reference/cli/#deploy) of the manifest, you can use these values using the `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` environment variables since Okteto will resolve their values for you. If the commands are not executed through the manifest, then you must define the values for these environment variables.
 
 ```
-helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart. 
@@ -84,11 +84,11 @@ helm package ./chart
 After that you can push the packaged Helm chart to the registry.
 
 ```
-helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 Once the packaged chart has been pushed to the Okteto Registry, you can pull it by using the command below:
 
 ```
-helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.19/core/container-registry.mdx
+++ b/versioned_docs/version-1.19/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.19/core/container-registry.mdx
+++ b/versioned_docs/version-1.19/core/container-registry.mdx
@@ -73,7 +73,7 @@ For example:
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart.
@@ -87,7 +87,7 @@ After that you can push the packaged Helm chart to the registry.
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 ## Pull Helm chart to the Okteto Registry
@@ -96,6 +96,6 @@ Once the packaged chart has been pushed to the Okteto Registry, you can pull it 
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
-  - helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.19/core/container-registry.mdx
+++ b/versioned_docs/version-1.19/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy` commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.20/core/container-registry.mdx
+++ b/versioned_docs/version-1.20/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.20/core/container-registry.mdx
+++ b/versioned_docs/version-1.20/core/container-registry.mdx
@@ -73,7 +73,7 @@ For example:
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart.
@@ -87,7 +87,7 @@ After that you can push the packaged Helm chart to the registry.
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 ## Pull Helm chart to the Okteto Registry
@@ -96,6 +96,6 @@ Once the packaged chart has been pushed to the Okteto Registry, you can pull it 
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
-  - helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.20/core/container-registry.mdx
+++ b/versioned_docs/version-1.20/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy` commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.21/core/container-registry.mdx
+++ b/versioned_docs/version-1.21/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.21/core/container-registry.mdx
+++ b/versioned_docs/version-1.21/core/container-registry.mdx
@@ -73,7 +73,7 @@ For example:
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart.
@@ -87,7 +87,7 @@ After that you can push the packaged Helm chart to the registry.
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 ## Pull Helm chart to the Okteto Registry
@@ -96,6 +96,6 @@ Once the packaged chart has been pushed to the Okteto Registry, you can pull it 
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
-  - helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.21/core/container-registry.mdx
+++ b/versioned_docs/version-1.21/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy` commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.22/core/container-registry.mdx
+++ b/versioned_docs/version-1.22/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.22/core/container-registry.mdx
+++ b/versioned_docs/version-1.22/core/container-registry.mdx
@@ -73,7 +73,7 @@ For example:
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart.
@@ -87,7 +87,7 @@ After that you can push the packaged Helm chart to the registry.
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 ## Pull Helm chart to the Okteto Registry
@@ -96,6 +96,6 @@ Once the packaged chart has been pushed to the Okteto Registry, you can pull it 
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
-  - helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.22/core/container-registry.mdx
+++ b/versioned_docs/version-1.22/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy` commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.23/core/container-registry.mdx
+++ b/versioned_docs/version-1.23/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"

--- a/versioned_docs/version-1.23/core/container-registry.mdx
+++ b/versioned_docs/version-1.23/core/container-registry.mdx
@@ -73,7 +73,7 @@ For example:
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
 ```
 
 Once you are logged in you will need to package the chart.
@@ -87,7 +87,7 @@ After that you can push the packaged Helm chart to the registry.
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}
+  - helm push ./movies-api-0.1.0.tgz oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}
 ```
 
 ## Pull Helm chart to the Okteto Registry
@@ -96,6 +96,6 @@ Once the packaged chart has been pushed to the Okteto Registry, you can pull it 
 
 ```yaml title="okteto.yaml"
 deploy:
-  - helm registry login ${OKTETO_REGISTRY} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
-  - helm pull oci://${OKTETO_REGISTRY}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
+  - helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
+  - helm pull oci://${OKTETO_REGISTRY_URL}/${OKTETO_NAMESPACE}/movies-api --version 0.1.0
 ```

--- a/versioned_docs/version-1.23/core/container-registry.mdx
+++ b/versioned_docs/version-1.23/core/container-registry.mdx
@@ -68,7 +68,7 @@ This command will show you information about the current okteto context in use:
 ```
 
 You can retrieve your username, password (token), and the domain for your registry from the output.
-You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy`commands of your Okteto Manifest.
+You can also use the environment variables `OKTETO_USERNAME`, `OKTETO_TOKEN`, `OKTETO_NAMESPACE` and `OKTETO_REGISTRY_URL` if your script is running as part of the `deploy` commands of your Okteto Manifest.
 For example:
 
 ```yaml title="okteto.yaml"


### PR DESCRIPTION
I think this is an old typo we never noticed because `OKTETO_REGISTRY` does not exist, nor appears to have existed in the past.

I've checked [Okteto CLI 2.0.0](https://github.com/okteto/okteto/blob/release-2.0/pkg/model/const.go#L202) and it was still called `OKTETO_REGISTRY_URL` like today: https://github.com/okteto/okteto/blob/master/pkg/model/const.go#L150

To validate run `okteto deploy` with this manifest

```
deploy:
  - env | grep OKTETO_REG
```
