### PR TITLE
Refer to Kubernetes secrets when documenting the backup/restore process

### DIFF
--- a/src/content/self-hosted/manage/backup-restore.mdx
+++ b/src/content/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.

--- a/versioned_docs/version-1.17/self-hosted/manage/backup-restore.mdx
+++ b/versioned_docs/version-1.17/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.

--- a/versioned_docs/version-1.18/self-hosted/manage/backup-restore.mdx
+++ b/versioned_docs/version-1.18/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.

--- a/versioned_docs/version-1.19/self-hosted/manage/backup-restore.mdx
+++ b/versioned_docs/version-1.19/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.

--- a/versioned_docs/version-1.20/self-hosted/manage/backup-restore.mdx
+++ b/versioned_docs/version-1.20/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.

--- a/versioned_docs/version-1.21/self-hosted/manage/backup-restore.mdx
+++ b/versioned_docs/version-1.21/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.

--- a/versioned_docs/version-1.22/self-hosted/manage/backup-restore.mdx
+++ b/versioned_docs/version-1.22/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.

--- a/versioned_docs/version-1.23/self-hosted/manage/backup-restore.mdx
+++ b/versioned_docs/version-1.23/self-hosted/manage/backup-restore.mdx
@@ -12,7 +12,7 @@ This guide outlines the steps to recover an Okteto instance in the event of an u
 The most important resources to backup so you can effectively recover an Okteto instance are:
 
 - **Service Accounts**: A Kubernetes service account is created for every user that logs in to Okteto. Backing up all the service accounts in the `okteto` namespace with the label `dev.okteto.com: "true"` will ensure your users do not need to recreate their Okteto accounts.
-- **Variables**: This consists of all Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up this data will save a lot of time reconfiguring all of these during a recovery process.
+- **Secrets**: Kubernetes secrets store Okteto variables, tokens, certificates, ssh keypairs, and any other secrets in the `okteto` namespace. Backing up secrets will save a lot of time reconfiguring all of these during a recovery process.
 - **Custom Resources**: Any Custom Resources in the `okteto` namespace corresponding to the Okteto CRDs. These CRDs can be identified with the label `app.kubernetes.io/part-of: okteto`. Okteto uses CRDs to store your Catalog, Container Registry Credentials, and more
 
 We recommend to backup these resources every 24h.


### PR DESCRIPTION
Fixing a reference to secrets in our backup/restore.
We probably introduced this error when renaming "Secrets" to "Variables" in the product