### PR TITLE
Document persistent volume annotations, labels, access mode and volum…

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -537,8 +537,12 @@ More information about nodeSelector is [available here](https://kubernetes.io/do
 Allows you to configure the okteto persistent volume:
 
 - `enabled`: enable/disable the use of persistent volumes (default: `true`)
-- `storageClass`: the storage class of the volume (default: the `default` storage class)
+- `accessMode`: the okteto persistent volume [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) (default: `ReadWriteOnce`)
+- `annotations`: add annotations to the the okteto persistent volume
+- `labels`: add labels to the the okteto persistent volume
 - `size`: the size of the okteto persistent volume (default: `5Gi`)
+- `storageClass`: the storage class of the okteto persistent volume (default: the `default` storage class in your cluster)
+- `volumeMode`: the okteto persistent volume [mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode) (default: `Filesystem`)
 
 ```yaml
 persistentVolume:
@@ -551,7 +555,7 @@ Note the following limitations:
 
 - `persistentVolume.enabled` must be `true` if you use [services](reference/okteto-manifest.mdx#services-object-optional).
 - `persistentVolume.enabled` must be `true` if you use [volumes](reference/okteto-manifest.mdx#volumes-string-optional).
-- `persistentVolume.enabled` must be `true` if you want to share command history across development containers while developing an app.
+- `persistentVolume.enabled` must be `true` if you want to share command history across development containers between different `okteto up` sessions.
 
 #### probes (boolean, optional)
 


### PR DESCRIPTION
…e mode

By adding support to labels, annotations, access mode and volume node, users have more flexibility to customize the creation of the okteto persistent volume.
For example, this allows the creation of EFS volumes to be shared across nodes when using [services](https://www.okteto.com/docs/reference/okteto-manifest/#services-object-optional).