### PR TITLE
Update aws.mdx

### DIFF
--- a/src/content/admin/cloud-credentials/aws.mdx
+++ b/src/content/admin/cloud-credentials/aws.mdx
@@ -132,11 +132,11 @@ With the above configuration the following Okteto Manifest will be able to acces
 deploy:
   image: amazon/aws-cli
   commands:
-    - aws s3api create-bucket --bucket test-bucket
+    - aws s3 mb s3://test-bucket --region us-west-2
 destroy:
   image: amazon/aws-cli
   commands:
-    - aws s3api delete-bucket --bucket test-bucket
+    - aws s3 rb s3://test-bucket --region us-west-2
 test:
   aws:
     image: amazon/aws-cli


### PR DESCRIPTION
Improve commands in aws cloud credentials guide. `s3api` throws `IllegalLocationConstraintException` unless `--create-bucket-configuration` is used which is somewhat more verbose