### PR TITLE
Add dependencies to manifest documentation. Add namespace to last versioned docs.

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -96,6 +96,8 @@ Follow this document for a list of [environment variables](reference/okteto-cli.
 
 Use `okteto deploy --dependencies` to force the redeployment of your dependencies.
 
+### dependencies - extended notation (object, optional)
+
 There is also an extended notation to configure how to deploy your dependency:
 
 ```yaml
@@ -111,22 +113,45 @@ dependencies:
     timeout: 15m
 ```
 
-Or:
+#### repository (string)
+
+A reference to a git repository that holds the manifest for your dependency.
+
+#### manifest (string, optional)
+
+A path in the dependency repository that points to an Okteto YAML. When specifying the manifest path, the dependency deployment will use this path where the manifest is defined as the context.
+
+#### branch (string, optional)
+
+The branch to use for your dependency git repository.
+
+#### variables (map[string]string, optional)
+
+Variables to pass to the dependency in string map format.
 
 ```yaml
-dependencies:
-  frontend:
-    repository: https://github.com/okteto/movies-frontend
-    manifest: okteto.yaml
-    branch: main
-    variables:
-      - ENVIRONMENT: development
-      - DEBUG: true
-    wait: true
-    timeout: 15m
+variables:
+  ENVIRONMENT: development
+  DEBUG: true
 ```
 
-When specifying the manifest path, the dependency deployment will use this path where the manifest is defined as the context.
+#### variables ([string], optional)
+
+Variables to pass to the dependency in a list of strings format.
+
+```yaml
+variables:
+  - ENVIRONMENT: development
+  - DEBUG: true
+```
+
+#### wait (boolean, optional)
+
+Wait for all resources in the dependency to become healthy before continuing.
+
+#### timeout (string, optional)
+
+Maximum time to be waiting for creating the dependency until an error is returned.
 
 ### deploy ([string], optional)
 

--- a/versioned_docs/version-1.24/reference/okteto-manifest.mdx
+++ b/versioned_docs/version-1.24/reference/okteto-manifest.mdx
@@ -112,6 +112,8 @@ Follow this document for a list of [environment variables](reference/okteto-cli.
 
 Use `okteto deploy --dependencies` to force the redeployment of your dependencies.
 
+### dependencies - extended notation (object, optional)
+
 There is also an extended notation to configure how to deploy your dependency:
 
 ```yaml
@@ -127,22 +129,49 @@ dependencies:
     timeout: 15m
 ```
 
-Or:
+#### repository (string)
+
+A reference to a git repository that holds the manifest for your dependency.
+
+#### manifest (string, optional)
+
+A path in the dependency repository that points to an Okteto YAML. When specifying the manifest path, the dependency deployment will use this path where the manifest is defined as the context.
+
+#### branch (string, optional)
+
+The branch to use for your dependency git repository.
+
+#### variables (map[string]string, optional)
+
+Variables to pass to the dependency in string map format.
 
 ```yaml
-dependencies:
-  frontend:
-    repository: https://github.com/okteto/movies-frontend
-    manifest: okteto.yaml
-    branch: main
-    variables:
-      - ENVIRONMENT: development
-      - DEBUG: true
-    wait: true
-    timeout: 15m
+variables:
+  ENVIRONMENT: development
+  DEBUG: true
 ```
 
-When specifying the manifest path, the dependency deployment will use this path where the manifest is defined as the context.
+#### variables ([string], optional)
+
+Variables to pass to the dependency in a list of strings format.
+
+```yaml
+variables:
+  - ENVIRONMENT: development
+  - DEBUG: true
+```
+
+#### wait (boolean, optional)
+
+Wait for all resources in the dependency to become healthy before continuing.
+
+#### timeout (string, optional)
+
+Maximum time to be waiting for creating the dependency until an error is returned.
+
+#### namespace (string, optional)
+
+The target namespace to deploy the dependency to, if not the current namespace.
 
 ### deploy ([string], optional)
 


### PR DESCRIPTION
Resolves #420 
This adds documentation to the extended notation for dependencies in the Okteto manifest.

The contributing docs mentions that only current documentation should be modified but I am not sure how that works with documentation changes that are both present in previous versions and about to change with the 3.x release, so I have added an extra change to the 1.24 version documentation.

If this is not ideal then I'm glad to amend the commit. 