### PR TITLE
Refactor The Okteto CLI installation instructions

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -12,6 +12,7 @@ module.exports = {
       label: 'Get Started',
       link: { type: 'doc', id: 'index' },
       items: [
+        "get-started/install-okteto-cli",
         {
           type: "category",
           label: "For Platform Engineers",
@@ -29,7 +30,6 @@ module.exports = {
                 "get-started/install/openshift"
               ]
             },
-            "get-started/install-okteto-cli",
             {
               type: "category",
               label: "Deploy your app",

--- a/src/content/get-started/deploy-your-app/index.mdx
+++ b/src/content/get-started/deploy-your-app/index.mdx
@@ -12,7 +12,7 @@ This guide explains how to deploy your first app to Okteto.
 Before you start this tutorial, make sure you fulfill the following requirements:
 
 - You have access to an Okteto instance. Otherwise, follow our [installation guide](get-started/install/index.mdx)
-- You have [installed the Okteto CLI](get-started/install-okteto-cli.mdx) and configure the Okteto Context with your Okteto instance
+- You have [installed the Okteto CLI](get-started/install-okteto-cli.mdx) and configured the Okteto Context with your Okteto instance
 
 ## What you will be building
 

--- a/src/content/get-started/deploy-your-app/index.mdx
+++ b/src/content/get-started/deploy-your-app/index.mdx
@@ -12,7 +12,7 @@ This guide explains how to deploy your first app to Okteto.
 Before you start this tutorial, make sure you fulfill the following requirements:
 
 - You have access to an Okteto instance. Otherwise, follow our [installation guide](get-started/install/index.mdx)
-- You have [configured the Okteto CLI](get-started/install-okteto-cli.mdx) with your Okteto instance
+- You have [installed the Okteto CLI](get-started/install-okteto-cli.mdx) and configure the Okteto Context with your Okteto instance
 
 ## What you will be building
 

--- a/src/content/get-started/dev-quickstart.mdx
+++ b/src/content/get-started/dev-quickstart.mdx
@@ -38,7 +38,7 @@ Welcome to the Okteto Quick Start Guide! This guide will help you, as a develope
 ## Step 3: Deploy a Development Environment
 
 1. Click the **Deploy Dev Environment** button in the Okteto UI.
-2. The Okteto Catalog will appear. This catalog contains a list of preconfigured applications provided by your organization’s platform team. A dev environment in Okteto is a version of your application deployed to a Namespace which syncs your local code with the code running on the cloud.
+2. The Okteto Catalog will appear. This catalog contains a list of pre-configured applications provided by your organization’s platform team. A dev environment in Okteto is a version of your application deployed to a Namespace which syncs your local code with the code running on the cloud.
 3. From the Okteto Catalog, select the application you want to develop. Okteto will begin deploying the chosen application.
 4. Once the application is deployed, your dev environment is ready. Okteto will create endpoints for all the microservices and external resources (if configured by the platform team) as part of your application and give you the links view them.
 

--- a/src/content/get-started/dev-quickstart.mdx
+++ b/src/content/get-started/dev-quickstart.mdx
@@ -74,16 +74,17 @@ You’ll be taken to the browser and asked to authenticate. Once that is done, O
 
 ## Step 7: Begin Development
 
-1. Once the development container is up, you will have terminal access inside of the Development Container.
-2. Execute the appropriate command to start your application. For instance, if you're working on the frontend service of a React-based application:
+1. Once the Development Container is up, you will have terminal access inside of the Development Container.
+2. From the terminal, execute the appropriate command to start your application. For instance, if you're working on the frontend service of a React-based application:
 
    ```bash
    yarn start
    ```
 
-## Step 8: Sync Code and View Changes
+## Step 8: Sync Code, Debug and View Changes
 
-- The dev container syncs all your local code changes with application running on Okteto.
+- The Development Container syncs all your local code changes with your application running on Okteto.
+- Your code is executing in Okteto, but you can debug it and add breakpoints from your favorite IDE without any extra tools
 - Any changes you make locally will be reflected in the endpoints shown in the Okteto UI, allowing you to see your changes in a production-like environment instantly.
 
 ## Benefits of Using Okteto

--- a/src/content/get-started/dev-quickstart.mdx
+++ b/src/content/get-started/dev-quickstart.mdx
@@ -46,52 +46,16 @@ Welcome to the Okteto Quick Start Guide! This guide will help you, as a develope
 
 The Okteto CLI is our [open-source](https://github.com/okteto/okteto) tool that let's you develop your applications on Okteto.
 
-### Installing the Okteto CLI
-
-#### MacOS / Linux
-
-```bash
-curl https://get.okteto.com -sSfL | sh
-```
-
-If you need a specific version you can set the OKTETO_VERSION environment variable:
-
-<CodeBlock language="bash">
-  {`curl https://get.okteto.com -sSfL | OKTETO_VERSION=${variables.cliVersion} sh`}
-</CodeBlock>
-
-You can also install it via [brew](https://brew.sh/) by running:
-
-```bash
-brew install okteto
-```
-
-#### Windows
-
-Download https://downloads.okteto.com/cli/stable/okteto.exe and add it to your `$PATH`.
-
-You can also install it via [scoop](https://scoop.sh/) by running:
-
-```bash
-scoop install okteto
-```
-
-:::tip
-
-For updating okteto with scoop, you might need to `scoop unhold okteto & scoop update okteto` or `scoop uninstall okteto & scoop install okteto`
-
-:::
+Follow [the Okteto CLI installation steps](get-started/install-okteto-cli.mdx) before continuing this guide.
 
 ## Step 5: Configure the Okteto CLI
 
 The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-Open a terminal and point the Okteto CLI to your Okteto instance by running:
+Open a terminal and point the Okteto CLI to your Okteto instance by running (replace `https://okteto.example.com` with your Okteto instance URL):
 
 ```bash
-okteto context
+okteto context use https://okteto.example.com
 ```
-And then typing in the URL for your Okteto instance when prompted.
-
 You’ll be taken to the browser and asked to authenticate. Once that is done, Okteto CLI is configured and ready to be used with your development environments.
 
 ## Step 6: Start Your Development Container
@@ -110,8 +74,8 @@ You’ll be taken to the browser and asked to authenticate. Once that is done, O
 
 ## Step 7: Begin Development
 
-1. Once the development container is up, you will have terminal access inside of the dev container.
-2. Start the development process by executing the appropriate command for your application. For instance, if you're working on the frontend service of a React-based application:
+1. Once the development container is up, you will have terminal access inside of the Development Container.
+2. Execute the appropriate command to start your application. For instance, if you're working on the frontend service of a React-based application:
 
    ```bash
    yarn start
@@ -119,7 +83,7 @@ You’ll be taken to the browser and asked to authenticate. Once that is done, O
 
 ## Step 8: Sync Code and View Changes
 
-- The dev container syncs all your local code changes with the code running on the cloud cluster.
+- The dev container syncs all your local code changes with application running on Okteto.
 - Any changes you make locally will be reflected in the endpoints shown in the Okteto UI, allowing you to see your changes in a production-like environment instantly.
 
 ## Benefits of Using Okteto

--- a/src/content/get-started/install-okteto-cli.mdx
+++ b/src/content/get-started/install-okteto-cli.mdx
@@ -3,7 +3,6 @@ title: Install and Configure the Okteto CLI
 description: This guide will help you get started by installing and configuring Okteto's Development Environments.
 sidebar_label: Install the Okteto CLI
 id: install-okteto-cli
-pagination_prev: get-started/install/index
 ---
 
 import variables from '../variables.json';
@@ -55,29 +54,10 @@ For updating okteto with scoop, you might need to `scoop unhold okteto & scoop u
 
 Alternatively, you can directly download the binary [from GitHub](https://github.com/okteto/okteto/releases) or build it directly from the source code.
 
-
-## Configure the Okteto CLI
-
-The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-To do this, run the command below replacing https://okteto.example.com in your instance URL:
-
-```bash
-okteto context use https://okteto.example.com
-```
-
-You can confirm that your CLI is configured by running the command below:
-
-```bash
-okteto context list
-```
-
-```bash
-Name                          Namespace       Builder                                 Registry
-https://okteto.example.com *  cindy           tcp://buildkit.okteto.example.com:1234  registry.okteto.example.com
-```
-
 ## Next Steps
 
-In this section we installed Okteto CLI on our machine and configured it to work with your Okteto instance 🚀
+In this section you installed the Okteto CLI on your machine 🚀
 
-In the next step of this getting started guide, you are going to [deploy your first app](get-started/deploy-your-app/index.mdx) to Okteto 😎
+If you are a developer and Okteto is already installed in your cluster, jump to the [Quickstart for Developers](get-started/dev-quickstart.mdx) guide.
+
+If you are looking to install Okteto in your cluster, jump to our [Okteto SH installation](get-started/install/index.mdx) guides.

--- a/src/content/get-started/install-okteto-cli.mdx
+++ b/src/content/get-started/install-okteto-cli.mdx
@@ -60,4 +60,4 @@ In this section you installed the Okteto CLI on your machine 🚀
 
 If you are a developer and Okteto is already installed in your cluster, jump to the [Quickstart for Developers](get-started/dev-quickstart.mdx) guide.
 
-If you are looking to install Okteto in your cluster, jump to our [Okteto SH installation](get-started/install/index.mdx) guides.
+If you are a platform engineer looking to install Okteto in your cluster, jump to our [Okteto SH installation](get-started/install/index.mdx) guides.

--- a/src/content/get-started/install/amazon-eks.mdx
+++ b/src/content/get-started/install/amazon-eks.mdx
@@ -187,7 +187,7 @@ curl \
 ```
 
 :::note
-`kubernetes-sigs/aws-load-balancer-controller` maintainers recomends further scoping down this configuration based on the VPC ID or the Cluster Name resource tag. Checkout [their docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/deploy/installation/#option-a-recommended-iam-roles-for-service-accounts-irsa) for official instructions on it.
+`kubernetes-sigs/aws-load-balancer-controller` maintainers recommends further scoping down this configuration based on the VPC ID or the Cluster Name resource tag. Checkout [their docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/deploy/installation/#option-a-recommended-iam-roles-for-service-accounts-irsa) for official instructions on it.
 :::
 
 Create the IAM Policy for the Load Balancer Controller IAM Role:
@@ -329,7 +329,7 @@ After a successful installation, you can access your Okteto instance at `https:/
 ### Configure the Okteto CLI
 
 The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-To do this, run the command below replacing:
+To do this, run the command below replacing `SUBDOMAIN`:
 
 ```bash
 okteto context use `https://okteto.SUBDOMAIN`

--- a/src/content/get-started/install/amazon-eks.mdx
+++ b/src/content/get-started/install/amazon-eks.mdx
@@ -4,7 +4,7 @@ description: How to install Okteto onto Amazon Elastic Kubernetes Service (EKS)
 sidebar_label: Amazon EKS
 id: amazon-eks
 pagination_prev: get-started/install/index
-pagination_next: get-started/install-okteto-cli
+pagination_next: get-started/deploy-your-app/index
 ---
 
 import variables from '../../variables.json';
@@ -326,7 +326,16 @@ You'll need to take the `EXTERNAL-IP` address (`a519c8b3b27f94...elb.amazonaws.c
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.
 
-Once your Okteto instance is up and running, you're going to [install and configure the Okteto CLI](get-started/install-okteto-cli.mdx) with your Okteto instance.
+### Configure the Okteto CLI
+
+The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
+To do this, run the command below replacing:
+
+```bash
+okteto context use `https://okteto.SUBDOMAIN`
+```
+
+Once your Okteto instance is up and running and your Okteto CLI properly configured, you are going to [deploy your first app](get-started/deploy-your-app/index.mdx) to Okteto 😎
 
 ## Optional: Configure access to your Amazon ECR
 

--- a/src/content/get-started/install/civo.mdx
+++ b/src/content/get-started/install/civo.mdx
@@ -4,7 +4,7 @@ description: How to install Okteto onto Civo
 sidebar_label: Civo
 id: civo
 pagination_prev: get-started/install/index
-pagination_next: get-started/install-okteto-cli
+pagination_next: get-started/deploy-your-app/index
 ---
 
 import Image from "@theme/Image";
@@ -150,4 +150,13 @@ Click on the "Add Record" button to create the DNS record.
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.
 
-Once your Okteto instance is up and running, you're going to [install and configure the Okteto CLI](get-started/install-okteto-cli.mdx) with your Okteto instance.
+### Configure the Okteto CLI
+
+The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
+To do this, run the command below replacing:
+
+```bash
+okteto context use `https://okteto.SUBDOMAIN`
+```
+
+Once your Okteto instance is up and running, you are going to [deploy your first app](get-started/deploy-your-app/index.mdx) to Okteto 😎

--- a/src/content/get-started/install/civo.mdx
+++ b/src/content/get-started/install/civo.mdx
@@ -153,7 +153,7 @@ After a successful installation, you can access your Okteto instance at `https:/
 ### Configure the Okteto CLI
 
 The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-To do this, run the command below replacing:
+To do this, run the command below replacing `SUBDOMAIN`:
 
 ```bash
 okteto context use `https://okteto.SUBDOMAIN`

--- a/src/content/get-started/install/digitalocean-doks.mdx
+++ b/src/content/get-started/install/digitalocean-doks.mdx
@@ -4,7 +4,7 @@ description: How to install Okteto onto DigitalOcean Kubernetes
 sidebar_label: DigitalOcean DOKS
 id: digitalocean-doks
 pagination_prev: get-started/install/index
-pagination_next: get-started/install-okteto-cli
+pagination_next: get-started/deploy-your-app/index
 ---
 
 import variables from '../../variables.json';
@@ -132,4 +132,13 @@ You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the do
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.
 
-Once your Okteto instance is up and running, you're going to [install and configure the Okteto CLI](get-started/install-okteto-cli.mdx) with your Okteto instance.
+### Configure the Okteto CLI
+
+The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
+To do this, run the command below replacing:
+
+```bash
+okteto context use `https://okteto.SUBDOMAIN`
+```
+
+Once your Okteto instance is up and running and your Okteto CLI properly configured, you are going to [deploy your first app](get-started/deploy-your-app/index.mdx) to Okteto 😎

--- a/src/content/get-started/install/digitalocean-doks.mdx
+++ b/src/content/get-started/install/digitalocean-doks.mdx
@@ -135,7 +135,7 @@ After a successful installation, you can access your Okteto instance at `https:/
 ### Configure the Okteto CLI
 
 The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-To do this, run the command below replacing:
+To do this, run the command below replacing `SUBDOMAIN`:
 
 ```bash
 okteto context use `https://okteto.SUBDOMAIN`

--- a/src/content/get-started/install/google-gke.mdx
+++ b/src/content/get-started/install/google-gke.mdx
@@ -135,7 +135,7 @@ After a successful installation, you can access your Okteto instance at `https:/
 ### Configure the Okteto CLI
 
 The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-To do this, run the command below replacing:
+To do this, run the command below replacing `SUBDOMAIN`:
 
 ```bash
 okteto context use `https://okteto.SUBDOMAIN`

--- a/src/content/get-started/install/google-gke.mdx
+++ b/src/content/get-started/install/google-gke.mdx
@@ -4,7 +4,7 @@ description: How to install Okteto onto Google Kubernetes Engine (GKE)
 sidebar_label: Google GKE
 id: google-gke
 pagination_prev: get-started/install/index
-pagination_next: get-started/install-okteto-cli
+pagination_next: get-started/deploy-your-app/index
 ---
 
 import variables from '../../variables.json';
@@ -132,7 +132,16 @@ You'll need to take the `EXTERNAL-IP` address, and add it to your DNS for the do
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.
 
-Once your Okteto instance is up and running, you're going to [install and configure the Okteto CLI](get-started/install-okteto-cli.mdx) with your Okteto instance.
+### Configure the Okteto CLI
+
+The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
+To do this, run the command below replacing:
+
+```bash
+okteto context use `https://okteto.SUBDOMAIN`
+```
+
+Once your Okteto instance is up and running and your Okteto CLI properly configured, you are going to [deploy your first app](get-started/deploy-your-app/index.mdx) to Okteto 😎
 
 ## Optional: Configure access to your Google Artifact Registry
 

--- a/src/content/get-started/install/index.mdx
+++ b/src/content/get-started/install/index.mdx
@@ -22,6 +22,7 @@ Okteto is distributed as a Helm chart. These cloud-specific guides walk you thro
 - [Install Okteto in DigitalOcean Kubernetes](get-started/install/digitalocean-doks.mdx)
 - [Install Okteto in Google Kubernetes Engine](get-started/install/google-gke.mdx)
 - [Install Okteto in Microsoft Azure Kubernetes Service](get-started/install/microsoft-aks.mdx)
+- [Install Okteto in Red Hat OpenShift](get-started/install/openshift.mdx)
 
 ## Video Tutorials
 

--- a/src/content/get-started/install/microsoft-aks.mdx
+++ b/src/content/get-started/install/microsoft-aks.mdx
@@ -4,7 +4,7 @@ description: How to install Okteto onto Azure Kubernetes Service (AKS)
 sidebar_label: Microsoft AKS
 id: microsoft-aks
 pagination_prev: get-started/install/index
-pagination_next: get-started/install-okteto-cli
+pagination_next: get-started/deploy-your-app/index
 ---
 
 import variables from '../../variables.json';
@@ -130,7 +130,16 @@ You'll need to take the `EXTERNAL-IP` address and add it to your DNS for the dom
 
 After a successful installation, you can access your Okteto instance at `https://okteto.SUBDOMAIN`. Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.
 
-Once your Okteto instance is up and running, you're going to [install and configure the Okteto CLI](get-started/install-okteto-cli.mdx) with your Okteto instance.
+### Configure the Okteto CLI
+
+The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
+To do this, run the command below replacing:
+
+```bash
+okteto context use `https://okteto.SUBDOMAIN`
+```
+
+Once your Okteto instance is up and running and your Okteto CLI properly configured, you are going to [deploy your first app](get-started/deploy-your-app/index.mdx) to Okteto 😎
 
 ## Optional: Configure access to your Azure Container Registry
 

--- a/src/content/get-started/install/microsoft-aks.mdx
+++ b/src/content/get-started/install/microsoft-aks.mdx
@@ -133,7 +133,7 @@ After a successful installation, you can access your Okteto instance at `https:/
 ### Configure the Okteto CLI
 
 The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-To do this, run the command below replacing:
+To do this, run the command below replacing `SUBDOMAIN`:
 
 ```bash
 okteto context use `https://okteto.SUBDOMAIN`

--- a/src/content/get-started/install/openshift.mdx
+++ b/src/content/get-started/install/openshift.mdx
@@ -82,7 +82,7 @@ This command grants the `privileged` SCC to the `okteto-buildkit` service accoun
 
 By default, access to the host is restricted by default in Red Hat OpenShift.
 This restriction impacts the he [Okteto Daemon](self-hosted/helm-configuration.mdx#daemonset) service.
-To grant the necessary permissionsto the Okteto Daemon, run:
+To grant the necessary permissions to the Okteto Daemon, run:
 
 ```bash
 oc adm policy add-scc-to-user hostaccess -z okteto -n okteto
@@ -205,7 +205,7 @@ Your account will be automatically created as part of the login process. The fir
 ### Configure the Okteto CLI
 
 The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
-To do this, run the command below replacing:
+To do this, run the command below replacing `SUBDOMAIN`:
 
 ```bash
 okteto context use `https://okteto.SUBDOMAIN`

--- a/src/content/get-started/install/openshift.mdx
+++ b/src/content/get-started/install/openshift.mdx
@@ -4,7 +4,7 @@ description: How to install Okteto onto Red Hat OpenShift
 sidebar_label: Red Hat OpenShift
 id: openshift
 pagination_prev: get-started/install/index
-pagination_next: get-started/install-okteto-cli
+pagination_next: get-started/deploy-your-app/index
 ---
 
 import variables from '../../variables.json';
@@ -202,4 +202,13 @@ After a successful installation, you can access your Okteto instance at `https:/
 
 Your account will be automatically created as part of the login process. The first user to successfully login into the instance will be automatically assigned the `administrator` role.
 
-Once your Okteto instance is up and running, you're going to [install and configure the Okteto CLI](get-started/install-okteto-cli.mdx) with your Okteto instance.
+### Configure the Okteto CLI
+
+The first thing you need to do before using the Okteto CLI is to set the Okteto CLI context with your Okteto instance.
+To do this, run the command below replacing:
+
+```bash
+okteto context use `https://okteto.SUBDOMAIN`
+```
+
+Once your Okteto instance is up and running and your Okteto CLI properly configured, you are going to [deploy your first app](get-started/deploy-your-app/index.mdx) to Okteto 😎


### PR DESCRIPTION
I have been experimenting with the location of the Okteto CLI installation instructions. In the current layout, it's inside the "Getting Started for Platform Engineers" section, which looks weird.

This PR moves the Okteto installation guide to the top of the "Get Started" section. This can also be useful if we start implementing Okteto CLI commands to help with the Okteto Chart installation.

Other changes:
- Remove the Okteto CLI configuration step from the CLI installation guide
- Explain how to configure the CLI as part of the Chart installation guide
- Use the Okteto CLI installation guide as a single point of true and link to it from the Developer's Quickstart