### PR TITLE
Fix inline code blocks to look vertically balanced

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -51,7 +51,7 @@
 
   --ifm-font-family-monospace: #{$code-font};
   --ifm-code-background: #{$light-blue};
-  --ifm-code-font-size: 16px;
+  --ifm-code-font-size: 18px;
 
   --ifm-tabs-padding-vertical: 12px;
 }
@@ -126,11 +126,10 @@ h1, h2, h3, h4, h5, h6 {
 
   }
 
-  p {
+  p, li {
     code {
-      border-radius: 3px;
-      font-size: 16px;
-      border: 1px solid rgba(0, 0, 0, 0.1);
+      vertical-align: baseline;
+      border-width: 1px;
     }
   }
 


### PR DESCRIPTION
The base paragraph text is actually 18px, but for whatever reason the code block was at some point changed 16px. This causes the text to look misaligned and wonky when there's a mix of regular and inline `code` texts present on same lines.

It appears the vertical align was set to _middle_ to [fix alignment in the default Docusaurus styles](https://github.com/facebookincubator/infima/pull/113) (aka [Infirma](https://docusaurus.io/docs/next/styling-layout#styling-your-site-with-infima)), but that clashes with our custom body and code fonts.

Fixed by setting 18px as default size also for inline code blocks, and resetting the `vertical-align` to _baseline_ instead.

While at it, also removing unnecessary props like `border-radius` and `border` that are already set through the underlying default styles.

## Testing done

Reviewing changes in all evergreen browsers, comparing with main, e.g.

| Before | After |
| -- | -- |
| <img width="688" alt="Screenshot 2024-10-01 at 15 55 36" src="https://github.com/user-attachments/assets/c31b6465-9ef9-4999-a7e3-472a25fbc89f"> | <img width="678" alt="Screenshot 2024-10-01 at 15 55 31" src="https://github.com/user-attachments/assets/fab7452e-3f56-4926-beb0-f48354b69155"> |
| <img width="963" alt="Screenshot 2024-10-01 at 15 56 04" src="https://github.com/user-attachments/assets/f264a2fe-969a-4fa4-ad7a-335c3d62a65f"> | <img width="972" alt="Screenshot 2024-10-01 at 15 56 19" src="https://github.com/user-attachments/assets/3b1481f6-7e77-44dc-b617-c16441f18bc4"> |
| <img width="930" alt="Screenshot 2024-10-01 at 15 57 56" src="https://github.com/user-attachments/assets/643c345e-a0db-4126-abf3-e6aa68b1e3a3"> | <img width="942" alt="Screenshot 2024-10-01 at 15 58 05" src="https://github.com/user-attachments/assets/16bde8c0-2f6e-4946-97f5-db559f320f6b"> |

