### PR TITLE
Update reference to cli image from "okteto/okteto:stable" to "okteto/…

### DIFF
--- a/src/content/previews/using-gitlab-cicd.mdx
+++ b/src/content/previews/using-gitlab-cicd.mdx
@@ -77,7 +77,7 @@ The `.gitlab-ci.yml` looks like this:
 
 ```yaml
 # file: .gitlab.ci.yml
-image: okteto/okteto:stable
+image: okteto/okteto:latest
 
 stages:
   - review


### PR DESCRIPTION
…okteto:latest"

As part of the CLI 3.0 release, we are standarizing on "latest" vs "stable" to refer to the last official release.
Our GH Actions samples already use `latest`, this PR updates the GitLab sample.