### PR TITLE
Remove hash part in URLs of deploy button examples

### DIFF
--- a/src/content/development/deploy/deploy-from-git.mdx
+++ b/src/content/development/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/src/content/development/deploy/develop-on-okteto-button.mdx
+++ b/src/content/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.14/cloud/deploy-from-git.mdx
+++ b/versioned_docs/version-1.14/cloud/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud, our free cloud service.
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.14/cloud/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.14/cloud/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud, our free cloud service.
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.14/samples/ruby.mdx
+++ b/versioned_docs/version-1.14/samples/ruby.mdx
@@ -7,7 +7,7 @@ id: ruby
 
 import Image from "@theme/Image";
 
-[Okteto Cloud](https://example.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto Cloud](https://example.okteto.com/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
 This tutorial will show you how to develop and debug a Ruby application using Okteto.
 

--- a/versioned_docs/version-1.15/cloud/deploy-from-git.mdx
+++ b/versioned_docs/version-1.15/cloud/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud, our free cloud service.
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.15/cloud/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.15/cloud/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) on Okteto Cloud, our free cloud service.
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.15/samples/ruby.mdx
+++ b/versioned_docs/version-1.15/samples/ruby.mdx
@@ -7,7 +7,7 @@ id: ruby
 
 import Image from "@theme/Image";
 
-[Okteto Cloud](https://example.okteto.com/#/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
+[Okteto Cloud](https://example.okteto.com/?origin=docs) gives instant access to secure Kubernetes namespaces to enable developers to code, build, and run Kubernetes applications entirely in the cloud.
 
 This tutorial will show you how to develop and debug a Ruby application using Okteto.
 

--- a/versioned_docs/version-1.16/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.16/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https:/okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https:/okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.16/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.16/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.17/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.17/deploy/deploy-from-git.mdx
@@ -87,7 +87,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.17/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.17/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.18/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.18/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.18/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.18/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.19/development/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.19/development/deploy/deploy-from-git.mdx
@@ -95,7 +95,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.19/development/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.19/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.20/development/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.20/development/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.20/development/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.20/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.21/development/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.21/development/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.21/development/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.21/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.22/development/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.22/development/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.22/development/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.22/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.23/development/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.23/development/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.23/development/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.23/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.24/development/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.24/development/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.24/development/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.24/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements

--- a/versioned_docs/version-1.25/development/deploy/deploy-from-git.mdx
+++ b/versioned_docs/version-1.25/development/deploy/deploy-from-git.mdx
@@ -91,7 +91,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that shows you how to deploy [the Movies App](https://github.com/okteto/movies) on an Okteto instance:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 ### Adding the Develop on Okteto button
 

--- a/versioned_docs/version-1.25/development/deploy/develop-on-okteto-button.mdx
+++ b/versioned_docs/version-1.25/development/deploy/develop-on-okteto-button.mdx
@@ -14,7 +14,7 @@ Use this instead of writing a never-ending list of manual steps on how to deploy
 
 Here's an example button that deploys [the Movies App](https://github.com/okteto/movies) using Okteto:
 
-[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/#/deploy?repository=https://github.com/okteto/movies)
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://okteto.example.com/deploy?repository=https://github.com/okteto/movies)
 
 
 ### Requirements


### PR DESCRIPTION
The hash-based routing was replaced over ~1½y ago (_v1.**8**_), but we apparently missed to update these examples. So it's safe to change these to use the expected pathname structure used since. 

Note that we still have a fallback redirects in place on the actual app, so any existing URLs that continue to use deploy button with this `/#/` prefix will continue to work nevertheless. But it would be preferable if we could figure out if any customers actually use this and get them updated.