### PR TITLE
feature: Add support for Trieve Site search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,13 +86,6 @@ module.exports = {
     prism: {
       theme: require('./src/theme/theme-okteto.js'),
     },
-    algolia: {
-      appId: 'RS9BKUCQCT',
-      apiKey: 'ac5c1ba5f3d4e8eceb4ce860d568da39',
-      indexName: 'okteto',
-      algoliaOptions: {},
-      position: 'left',
-    },
     navbar: {
       hideOnScroll: false,
       logo: {
@@ -321,4 +314,53 @@ module.exports = {
     ],
   ],
   scripts: ['//js.hs-scripts.com/5418301.js'],
+  themes: [
+    [
+      require.resolve('@trieve/docusaurus-search-theme'),
+      {
+        apiKey: 'tr-dxh5rknNGetbVdUJe16iJihRKUH6QKMN',
+        datasetId: 'e7ac9f62-1a01-41ad-8e37-4b0e0bfb8843',
+        defaultSearchQueries: [
+          'Namespaces',
+          'Preview Endpoints',
+          'CLI installation',
+        ],
+        defaultAiQuestions: [
+          'How does okteto test work?',
+          'How to use preview endpoints?',
+          'How to manage users on the admin dashboard',
+        ],
+        brandLogoImgSrcUrl: 'https://www.okteto.com/docs/img/logo.svg',
+        brandName: 'Okteto',
+        brandColor: '#00d1ca',
+        responsive: true,
+        searchOptions: {
+          search_type: "fulltext",
+          // Filter out versions that are not the current version (1.25)
+          filters: {
+            must_not: [
+              {
+                "field": "tag_set",
+                "match": [
+                  "1.26",
+                  "1.24",
+                  "1.23",
+                  "1.22",
+                  "1.21",
+                  "1.20",
+                  "1.19",
+                  "1.18",
+                  "1.17",
+                  "1.16",
+                  "1.15",
+                  "1.14",
+                ]
+              }
+            ]
+          }
+        },
+        debounceMs: 50,
+      },
+    ]
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@docusaurus/preset-classic": "^3.4.0",
     "@mdx-js/react": "^3.0.0",
     "@sanity/client": "^3.2.0",
+    "@trieve/docusaurus-search-theme": "^0.1.17",
     "classnames": "^2.3.1",
     "docusaurus": "^1.14.7",
     "docusaurus-gtm-plugin": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2924,6 +2924,18 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
   integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
 
+"@r2wc/core@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@r2wc/core/-/core-1.1.0.tgz#93c16cd5bf5bc6d9a52b23536aed4e6a4d2a6ef2"
+  integrity sha512-pEgtPXhfgg8mv/MooU83cb5sXC2aQOXPLm9UX7E7Oz/OXmrnP5r8hD/nJL1empWxC4wo1YeBXvrFu8fXsMgGZQ==
+
+"@r2wc/react-to-web-component@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@r2wc/react-to-web-component/-/react-to-web-component-2.0.3.tgz#3253067dbedf3f9d80cdaac3081c508729e5af57"
+  integrity sha512-nlDJ0LHiWLG/EFB5tBtA+9KLF2oMBeDSAXL08NUzAuj/ac+V0NkMl/RvCFdDFnyrPQqpzpD9uOvOY2E5IFpdCQ==
+  dependencies:
+    "@r2wc/core" "^1.0.0"
+
 "@sanity/client@^3.2.0":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@sanity/client/-/client-3.4.1.tgz#d1bd02bafc50eb0aac8d5b6fab942da52549652f"
@@ -3106,6 +3118,18 @@
   integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
   dependencies:
     defer-to-connect "^2.0.1"
+
+"@thumbmarkjs/thumbmarkjs@^0.14.8":
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/@thumbmarkjs/thumbmarkjs/-/thumbmarkjs-0.14.8.tgz#abe3a9ebd9ec949ea7f044acf4a5e0074b18cf97"
+  integrity sha512-J+/HnYBv24ufFCoyqbFhtZk1zTGKWzHfyN15sc6kJq/1D/6H1oaKt+W1yWxkUwzclMS1n36EaoHbNjFeiuDqDg==
+
+"@trieve/docusaurus-search-theme@^0.1.17":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@trieve/docusaurus-search-theme/-/docusaurus-search-theme-0.1.17.tgz#fb36c52033c00475b3796e4a84e3b057e447b562"
+  integrity sha512-P7q+GkQlZvUWMZHJeWHBhZ8RIb7NO4uCH4yMQlefDs8JzEiX1lWViDE2Q0TX47qG16RqRcWLLUbAtmG4j0D/9A==
+  dependencies:
+    trieve-search-component "^0.0.65"
 
 "@trysound/sax@0.2.0":
   version "0.2.0"
@@ -8079,6 +8103,11 @@ html-tags@^3.3.1:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
   integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
 
+html-url-attributes@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
+  integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
+
 html-void-elements@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
@@ -12278,6 +12307,22 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@types/react" "*"
 
+react-markdown@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-9.0.1.tgz#c05ddbff67fd3b3f839f8c648e6fb35d022397d1"
+  integrity sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    devlop "^1.0.0"
+    hast-util-to-jsx-runtime "^2.0.0"
+    html-url-attributes "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    remark-parse "^11.0.0"
+    remark-rehype "^11.0.0"
+    unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
 react-router-config@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-router-config/-/react-router-config-5.1.1.tgz#0f4263d1a80c6b2dc7b9c1902c9526478194a988"
@@ -14045,6 +14090,21 @@ tree-node-cli@^1.2.5:
     commander "^5.0.0"
     fast-folder-size "1.6.1"
     pretty-bytes "^5.6.0"
+
+trieve-search-component@^0.0.65:
+  version "0.0.65"
+  resolved "https://registry.yarnpkg.com/trieve-search-component/-/trieve-search-component-0.0.65.tgz#cd50be833c4b0d532f1910bdbd6eb10dc44dc0ae"
+  integrity sha512-9xTXOg9BH55eZIxnmintaXGfHBdL/97BouNBdTezNOWv6evBkQjuvNvIfp3D235BMI9Q8906QM0l8uml6e9OJg==
+  dependencies:
+    "@r2wc/react-to-web-component" "^2.0.3"
+    "@thumbmarkjs/thumbmarkjs" "^0.14.8"
+    react-markdown "^9.0.1"
+    trieve-ts-sdk "*"
+
+trieve-ts-sdk@*:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/trieve-ts-sdk/-/trieve-ts-sdk-0.0.14.tgz#006a604f8de11d9e311077deb77f576250f8aa67"
+  integrity sha512-fAMZPZOPxs+ufuqQnE14dEX3Xd0RDjTBOmDqh7r4KzfHvrbCTiQimwdHgohSqmCT1/12SIqXEDVX1NUJxrNVJw==
 
 trim-lines@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Description

This site replaces the algolia docsearch component in favor for the Trieve Site Search component. 

Adds [trieve](https://github.com/devflowinc/trieve)'s modal component for search and chat functionality.
Features:
- open search with ctrl + k ⌨
- AI chat mode 🗨
- scraping crawler that re-indexes the site every 24hrs 🕛

Comes with Analytics that tracks: 📈
- How many searches and conversations happen
- Searches and messages that result in clicks
- Position of result in search when there is a click (and # of results w/ click)
- All user messages and responses for chat for evaluation to take place
- Feedback button for AI chat mode

Check out a basic preview basic [here](https://api.trieve.ai/public_page/e7ac9f62-1a01-41ad-8e37-4b0e0bfb8843)

To see how it looks in action, refer to the gif!
![okteto](https://github.com/user-attachments/assets/5d54c08e-63fe-490f-8596-52c939906e0a)
