### PR TITLE
docs: wrong ident

### DIFF
--- a/src/content/admin/cloud-credentials/gcp.mdx
+++ b/src/content/admin/cloud-credentials/gcp.mdx
@@ -73,7 +73,7 @@ gcloud iam workload-identity-pools providers create-oidc myCluster \
   --allowed-audiences=${AUDIENCE}
 ```
 
-### Step 3: Create the IAM Policy Binding
+## Step 3: Create the IAM Policy Binding
 
 Now, grant the Okteto Kubernetes service account the permissions required to access the specified GCP resources.
 

--- a/versioned_docs/version-1.25/admin/cloud-credentials/gcp.mdx
+++ b/versioned_docs/version-1.25/admin/cloud-credentials/gcp.mdx
@@ -73,7 +73,7 @@ gcloud iam workload-identity-pools providers create-oidc myCluster \
   --allowed-audiences=${AUDIENCE}
 ```
 
-### Step 3: Create the IAM Policy Binding
+## Step 3: Create the IAM Policy Binding
 
 Now, grant the Okteto Kubernetes service account the permissions required to access the specified GCP resources.
 


### PR DESCRIPTION
Fixes wrong heading ident in gcp cloud credentials doc.