### PR TITLE
Document "context" property for Deploy on Remote

### DIFF
--- a/src/content/core/remote-execution.mdx
+++ b/src/content/core/remote-execution.mdx
@@ -72,7 +72,7 @@ When running on remote, Okteto will automatically synchronize your local folder 
 </p>
 
 Okteto mounts the [Okteto SSH Key](admin/private-repositories/ssh-key.mdx) within the container running inside Buildkit.
-This allows you to clone any git private repository as part of your commands execution as long as the [Okteto SSH Key](admin/private-repositories/ssh-key.mdx) has the appropriate access privileges.
+This allows you to clone any private git repository as part of your commands execution as long as the [Okteto SSH Key](admin/private-repositories/ssh-key.mdx) has the appropriate access privileges.
 
 ## Ignoring files
 

--- a/src/content/core/remote-execution.mdx
+++ b/src/content/core/remote-execution.mdx
@@ -71,13 +71,24 @@ When running on remote, Okteto will automatically synchronize your local folder 
   />
 </p>
 
-Okteto will connect your local SSH agent with the container running inside Buildkit.
-For example, this lets you clone any private repository as part of your commands execution as long as your local agent has the proper ssh key configured.
+Okteto mounts the [Okteto SSH Key](admin/private-repositories/ssh-key.mdx) within the container running inside Buildkit.
+This allows you to clone any git private repository as part of your commands execution as long as the [Okteto SSH Key](admin/private-repositories/ssh-key.mdx) has the appropriate access privileges.
 
 ## Ignoring files
 
-Okteto looks for a file named `.oktetoignore` in your local folder. If this file exists, the CLI will exclude any files and directories in the command group that match patterns in it.
-This helps to avoid unnecessarily synchronizing large or sensitive files and directories that are not used by the commands defined in the `deploy`, `destroy` or `test` section.
+By default, Okteto synchonizes all files in the folder where the Okteto Manifest is located to the container running inside Buildkit.
+You can also configure the folder to be synchronized using the `context` field:
+
+```yaml title="okteto.yaml"
+deploy:
+  image: runner:1.0
+  context: .
+  commands:
+    - helm upgrade --install movies chart
+```
+
+You can optimize which files are synchronized to the container running inside Buildkit by using a `.oktetoignore` file, located in the folder specified by the `context` field. If this file exists, the CLI will exclude from synchronization any files and directories that match patterns in it.
+This helps avoid unnecessarily synchronizing large or sensitive files and directories that are not used by the commands defined in your Okteto Manifest.
 
 An example `.oktetoignore` file would be the following:
 

--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -153,9 +153,12 @@ If you define an image in your `deploy` section, `okteto deploy` will run in rem
 ```yaml
 deploy:
   image: okteto/pipeline-runner:1.0.0
+  context: .
   commands:
     - helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
 ```
+
+The `context` field specifies the working directory for running the deploy commands. If left empty, it defaults to the directory containing the Okteto Manifest.
 
 If you don't define an image, you can run in remote mode adding the `remote` field to your manifest:
 
@@ -268,9 +271,12 @@ If you define an image in your `destroy` section, `okteto destroy` will run in r
 ```yaml
 destroy:
   image: okteto/tfenv-ci:1.4
+  context: .
   commands:
     - terraform destroy --auto-approve
 ```
+
+The `context` field specifies the working directory for running the destroy commands. If left empty, it defaults to the directory containing the Okteto Manifest.
 
 If you don't define an image, you can run in remote mode adding the `remote` field to your manifest:
 


### PR DESCRIPTION
Document the `context` field for remote execution and review some sections in the "Remote Execution" doc to align better with the new SSH agent behavior.