### PR TITLE
Remove manual migration steps for default-backend

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -25,7 +25,7 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 ### Breaking Changes
 
 - **Hostname Length Limit**: Deploys now fail if a service hostname exceeds 63 characters, showing an error message. Previously, the dev environment deployed successfully even if the endpoint didn’t work. This may affect environments that deployed without issues before
-- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](self-hosted/helm-configuration.mdx#manual-migration-steps-when-renaming-the-defaultbackend-service)
+- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](/docs/1.26/self-hosted/helm-configuration.mdx#manual-migration-steps-when-renaming-the-defaultbackend-service)
 - **Private Repository Deploys**: Deploying private repositories now uses the Okteto backend as the SSH agent, rather than mounting the local SSH agent. This change ensures feature parity between remote and local deploys but may impact scenarios where private repositories are cloned as part of commands defined in the deploy section during remote execution
 - **Buildkit Persistence Enabled**: Buildkit persistence is now enabled by default, with a 100Gi disk and cache set to 90% of the disk size. If you previously used `buildkit.persistence.cache`, adjust to the new ratio, as this setting is no longer applicable
 

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -25,7 +25,7 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 ### Breaking Changes
 
 - **Hostname Length Limit**: Deploys now fail if a service hostname exceeds 63 characters, showing an error message. Previously, the dev environment deployed successfully even if the endpoint didn’t work. This may affect environments that deployed without issues before
-- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](/docs/1.26/self-hosted/helm-configuration.mdx#manual-migration-steps-when-renaming-the-defaultbackend-service)
+- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](https://www.okteto.com/docs/1.26/self-hosted/helm-configuration/#manual-migration-steps-when-renaming-the-defaultbackend-service)
 - **Private Repository Deploys**: Deploying private repositories now uses the Okteto backend as the SSH agent, rather than mounting the local SSH agent. This change ensures feature parity between remote and local deploys but may impact scenarios where private repositories are cloned as part of commands defined in the deploy section during remote execution
 - **Buildkit Persistence Enabled**: Buildkit persistence is now enabled by default, with a 100Gi disk and cache set to 90% of the disk size. If you previously used `buildkit.persistence.cache`, adjust to the new ratio, as this setting is no longer applicable
 

--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -1250,6 +1250,6 @@ Since the Okteto chart creates multiple resources in Kubernetes, it employs spec
 
 The maximum length for the Okteto prefix is 34 characters. This limit is derived from the maximum name length allowed by Kubernetes (63 characters), minus the length of the longest Okteto component suffix ("-ingress-nginx-defaultbackend"). The 34 characters are then divided into 27 characters for the release name and 7 characters for the chart name ("-okteto").
 
-This limit can be extended to 40 characters by overriding the name of the defaultBackend component. To do this, set the `defaultBackend.nameOverride` value. If you rename the defaultBackend on an existing installation, be sure to follow [these steps](#manual-migration-steps-when-renaming-the-defaultbackend-service) to safely rename it.
+This limit can be extended to 40 characters by overriding the name of the defaultBackend component. To do this, set the `defaultBackend.nameOverride` value.
 
 If you need to use a release name longer than 40 characters, you can also use the [nameOverride](#nameoverride) or [fullnameOverride](#fullnameoverride) settings to make the prefix shorter.

--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -299,7 +299,7 @@ The defaultBackend receives errored requests from the ingress-controller and tra
   - `repository`: Registry and repository for the defaultBackend pods.
   - `tag`: Tag used for the defaultBackend pods.
 - `labels`: Labels to add to the defaultBackend pods.
-- `nameOverride`: String to override the full name of the defaultBackend service. If you rename an existing service, you need to [follow the manual migration steps documented below](#manual-migration-steps-when-renaming-the-defaultbackend-service).
+- `nameOverride`: String to override the full name of the defaultBackend service.
 - `port`: Internal port used for the defaultBackend. Defaults to `8080`.
 - `priorityClassName`: The priority class to be used by the defaultBackend pods. The PriorityClass must already exist in your cluster before using this setting. This value has precedence over `globals.priorityClassName` if both are set. If this value is not set, the pods will inherit the priority class defined by the value set in `globals.priorityClassName`.
 - `replicaCount`: The number of defaultBackend pods. It defaults to 2.
@@ -323,21 +323,6 @@ The defaultBackend provides the following features:
 tolerations:
   devPool: dev
 ```
-
-#### Manual migration steps when renaming the defaultBackend service
-
-If you rename the defaultBackend service using the `nameOverride` property, follow these steps to successfully upgrade Okteto in your cluster:
-
-1. Identify the current service name for your defaultBackend
-```
-kubectl get svc -l app.kubernetes.io/component=default-backend -n okteto
-```
-2. Patch the `defaultBackend` service adding the annotation: `helm.sh/resource-policy: keep`
-```
-kubectl patch service "<Your existing defaultBackend service name>" -n okteto -p '{"metadata":{"annotations":{"helm.sh/resource-policy": "keep"}}}'
-```
-3. Upgrade the Okteto Helm chart. This will create a new `defaultBackend` service with the new name.
-4. You can now safely delete the old `defaultBackend` service.
 
 ### frontend
 

--- a/versioned_docs/version-1.26/release-notes.mdx
+++ b/versioned_docs/version-1.26/release-notes.mdx
@@ -25,7 +25,7 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 ### Breaking Changes
 
 - **Hostname Length Limit**: Deploys now fail if a service hostname exceeds 63 characters, showing an error message. Previously, the dev environment deployed successfully even if the endpoint didn’t work. This may affect environments that deployed without issues before
-- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](./self-hosted/helm-configuration.mdx#manual-migration-steps-when-renaming-the-defaultbackend-service)
+- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](self-hosted/helm-configuration.mdx#manual-migration-steps-when-renaming-the-defaultbackend-service)
 - **Private Repository Deploys**: Deploying private repositories now uses the Okteto backend as the SSH agent, rather than mounting the local SSH agent. This change ensures feature parity between remote and local deploys but may impact scenarios where private repositories are cloned as part of commands defined in the deploy section during remote execution
 - **Buildkit Persistence Enabled**: Buildkit persistence is now enabled by default, with a 100Gi disk and cache set to 90% of the disk size. If you previously used `buildkit.persistence.cache`, adjust to the new ratio, as this setting is no longer applicable
 

--- a/versioned_docs/version-1.26/release-notes.mdx
+++ b/versioned_docs/version-1.26/release-notes.mdx
@@ -25,7 +25,7 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 ### Breaking Changes
 
 - **Hostname Length Limit**: Deploys now fail if a service hostname exceeds 63 characters, showing an error message. Previously, the dev environment deployed successfully even if the endpoint didn’t work. This may affect environments that deployed without issues before
-- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](self-hosted/helm-configuration.mdx#manual-migration-steps-when-renaming-the-defaultbackend-service)
+- **Helm Release Name Limit**: Helm release names are now limited in length. Use `defaultBackend.nameOverride` to shorten the default backend service name if needed. If changing this during an upgrade, [follow this guide as it may impact the installation](./self-hosted/helm-configuration.mdx#manual-migration-steps-when-renaming-the-defaultbackend-service)
 - **Private Repository Deploys**: Deploying private repositories now uses the Okteto backend as the SSH agent, rather than mounting the local SSH agent. This change ensures feature parity between remote and local deploys but may impact scenarios where private repositories are cloned as part of commands defined in the deploy section during remote execution
 - **Buildkit Persistence Enabled**: Buildkit persistence is now enabled by default, with a 100Gi disk and cache set to 90% of the disk size. If you previously used `buildkit.persistence.cache`, adjust to the new ratio, as this setting is no longer applicable
 


### PR DESCRIPTION
We introduced a change that makes it easier to migrate the default-backend, and requires no manual changes.

I've tested migration from `1.26` to "latest" and backwards, and the manual steps were not required as expected, so I am proposing to remove these steps that add additional friction in an upgrade and are no longer needed.

I would keep them in the `1.26` docs, as the change will be available from `1.27` onwards, so migrating from `1.27` to `1.28` will no require manual steps.