### PR TITLE
Updated supported fields for the securityContext section of the Okteto Manifest

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -657,7 +657,7 @@ secrets:
 
 Allows you to override the pod security context of your development container.
 
-Okteto supports overriding the `fsGroup`, `runAsUser`, `runAsGroup` and `capabilities` values.
+Okteto supports overriding the `fsGroup`, `runAsUser`, `runAsGroup`, `runAsNonRoot`, `allowPrivilegeEscalation` and `capabilities` values.
 They're not set by default, and they follow the [same syntax used in Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 ```yaml
@@ -665,6 +665,8 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 2000
   fsGroup: 3000
+  runAsNonRoot: false
+  allowPrivilegeEscalation: false
   capabilities:
     add:
       - SYS_PTRACE

--- a/versioned_docs/version-1.26/reference/okteto-manifest.mdx
+++ b/versioned_docs/version-1.26/reference/okteto-manifest.mdx
@@ -657,7 +657,9 @@ secrets:
 
 Allows you to override the pod security context of your development container.
 
-Okteto supports overriding the `fsGroup`, `runAsUser`, `runAsGroup` and `capabilities` values.
+Allows you to override the pod security context of your development container.
+
+Okteto supports overriding the `fsGroup`, `runAsUser`, `runAsGroup`, `runAsNonRoot`, `allowPrivilegeEscalation` and `capabilities` values.
 They're not set by default, and they follow the [same syntax used in Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 ```yaml
@@ -665,6 +667,8 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 2000
   fsGroup: 3000
+  runAsNonRoot: false
+  allowPrivilegeEscalation: false
   capabilities:
     add:
       - SYS_PTRACE


### PR DESCRIPTION
We were missing `runAsNonRoot` and `allowPrivilegeEscalation` from the list of supported fields for the `securityContext` section of the Okteto Manifest. I just updated ongoing and current versions