### PR TITLE
Document "jobs.ttlSecondsAfterFinished"

### DIFF
--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -722,6 +722,37 @@ The maximum length for `fullnameOverride` is 34 characters. Check how to [extend
 
 Global settings applicable to all Okteto components.
 
+#### jobs
+
+Specifies global configuration for jobs created in the `okteto` namespace:
+
+- `ttlSecondsAfterFinished`: time in seconds to wait until a finished job is deleted (defaults to `86400` - 1 day).
+
+
+```yaml
+globals:
+  jobs:
+    ttlSecondsAfterFinished: 86400
+```
+
+#### nodeSelectors
+
+Specifies the node selectors to be applied to pods, categorized under `okteto` or `dev`:
+
+- `okteto`: Node selectors applied to pods running in the `okteto` namespace, excluding the [Okteto Daemonset](#daemonset).
+- `dev`: Node selectors applied to pods created by user applications, which run in namespaces managed by Okteto. This also applies to the [Okteto Daemonset](#daemonset).
+
+
+```yaml
+globals:
+  nodeSelectors:
+    okteto:
+      okteto-node-label: okteto
+    dev:
+      okteto-node-label: dev
+      region: east
+```
+
 #### priorityClassName
 
 Defines the priority class to be used by all pods in the okteto namespace.
@@ -752,24 +783,6 @@ globals:
       operator: "Equal"
       value: "arm64dev"
       effect: "NoSchedule"
-```
-
-#### nodeSelectors
-
-Specifies the node selectors to be applied to pods, categorized under `okteto` or `dev`:
-
-- `okteto`: Node selectors applied to pods running in the `okteto` namespace, excluding the [Okteto Daemonset](#daemonset).
-- `dev`: Node selectors applied to pods created by user applications, which run in namespaces managed by Okteto. This also applies to the [Okteto Daemonset](#daemonset).
-
-
-```yaml
-globals:
-  nodeSelectors:
-    okteto:
-      okteto-node-label: okteto
-    dev:
-      okteto-node-label: dev
-      region: east
 ```
 
 ### ingress


### PR DESCRIPTION
Document the new globals field to define the ttlSecondsAfterFinished for jobs created by the Okteto Control Plane