### PR TITLE
Some fixes for 1.27 release

### DIFF
--- a/src/content/admin/custom-installer-image.mdx
+++ b/src/content/admin/custom-installer-image.mdx
@@ -7,6 +7,9 @@ id: custom-installer-image
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import variables from '../variables.json';
+import CodeBlock from '@theme/CodeBlock';
+
 
 You can specify a custom installer image to deploy your Development Environments. Use this if you want to use tools, frameworks, or custom configurations not included in the [default installer image](https://github.com/okteto/pipeline-runner).
 
@@ -20,21 +23,20 @@ When creating your image, we recommend extending the image from [the latest vers
 
 Your image can include anything that you need when deploying Development Environments for your organization. The example below shows you how to include `wget`:
 
-```
-FROM okteto/pipeline-runner:1.0.3
+<CodeBlock language="dockerfile">
+  {`FROM okteto/pipeline-runner:${variables.chartVersion}
 
-RUN apt-get upgrade && \
-  apt-get install wget
-```
+RUN apt-get upgrade && apt-get install wget`}
+</CodeBlock>
 
 ### Build and Publish the Custom Image
 
 Once the image has been defined, build it and push it to your container registry. 
 
-```
-docker build -t YOUR_COMPANY/pipeline-installer:1.0.3
-docker push YOUR_COMPANY/pipeline-installer:1.0.3
-```
+<CodeBlock language="bashh">
+  {`docker build -t YOUR_REGISTRY/pipeline-installer:${variables.chartVersion}
+docker push YOUR_REGISTRY/pipeline-installer:${variables.chartVersion}`}
+</CodeBlock>
 
 ## Configure your Custom Image
 
@@ -51,7 +53,8 @@ To enable the custom image, update your Okteto Helm configuration file with the 
 
 ```yaml
 installer:
-  runner: YOUR_COMPANY/pipeline-runner:1
+  runner:
+    registry: YOUR_REGISTRY
 ```
 
 </TabItem>
@@ -65,5 +68,6 @@ If your instance is hosted by Okteto, contact support to configure your custom i
 
 ## Using the Custom Image
 
-Once the configuration has been applied, all the Development Environments will be deployed using your custom image.  In order to help you troubleshoot any issues, the name of the image used during deployment is included in the pipeline logs. You can consult this in the Okteto UI.
+Once the configuration has been applied, all the Development Environments will be deployed using your custom image.
+In order to help you troubleshoot any issues, the name of the image used during deployment is included in the pipeline logs. You can consult this in the Okteto UI.
 

--- a/src/content/core/remote-execution.mdx
+++ b/src/content/core/remote-execution.mdx
@@ -25,17 +25,13 @@ deploy:
 Remote execution is always enabled for `okteto test`
 :::
 
-By default, your commands will run in a remote container using our [default container image](https://github.com/okteto/pipeline-runner).
+By default, your commands will run in a remote container using our [default container image](https://github.com/okteto/pipeline-runner) in the workdir `/okteto/src`.
 The default container image is a Debian Linux container with the following tools preinstalled:
 
 - `bash`
-- `cue`
-- `curl`
-- `envsubst`
 - `git`
 - `helm`
 - `kubectl`
-- `kustomize`
 - `make`
 - `okteto`
 - `openssh`

--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -282,7 +282,7 @@ The daemonset performs the following tasks on each node:
 
 You can restrict the nodes where the daemonset is deployed using `dev` [tolerations](self-hosted/helm-configuration.mdx#tolerations) and [nodeSelectors](self-hosted/helm-configuration.mdx#nodeselectors):
 
-```
+```yaml
 tolerations:
   devPool: dev
 ```
@@ -319,7 +319,7 @@ The defaultBackend provides the following features:
 - Autowake namespaces: when a user access an endpoint from an slept namespace, the defaultBackend will issue a wake command.
 - Custom error pages: when a user access an endpoint and an error is produced, the defaultBackend will return a custom error page with hints on how to solve it.
 
-```
+```yaml
 tolerations:
   devPool: dev
 ```


### PR DESCRIPTION
This PR documents the workdir of remote execution and updates the "custom installer image" docs to accommodate to the new chart image format.