### PR TITLE
Added missing version 1.23.3 for release notes

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -150,6 +150,16 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 
 - Support for Kubernetes [1.26](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md) has been removed in this release.
 
+## 1.23.3
+
+9 September 2024
+
+This version is compatible with Kubernetes versions 1.26 to 1.30
+
+### Bug Fixes
+
+- Fix deploy of development environments from the UI when the git URL is from a self-hosted GitLab instance and it refers to repositories within Groups and Subgroups
+
 ## 1.23.2
 
 16 August 2024

--- a/versioned_docs/version-1.24/release-notes.mdx
+++ b/versioned_docs/version-1.24/release-notes.mdx
@@ -63,6 +63,16 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 
 - Support for Kubernetes [1.26](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md) has been removed in this release.
 
+## 1.23.3
+
+9 September 2024
+
+This version is compatible with Kubernetes versions 1.26 to 1.30
+
+### Bug Fixes
+
+- Fix deploy of development environments from the UI when the git URL is from a self-hosted GitLab instance and it refers to repositories within Groups and Subgroups
+
 ## 1.23.2
 
 16 August 2024

--- a/versioned_docs/version-1.25/release-notes.mdx
+++ b/versioned_docs/version-1.25/release-notes.mdx
@@ -102,6 +102,16 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 
 - Support for Kubernetes [1.26](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md) has been removed in this release.
 
+## 1.23.3
+
+9 September 2024
+
+This version is compatible with Kubernetes versions 1.26 to 1.30
+
+### Bug Fixes
+
+- Fix deploy of development environments from the UI when the git URL is from a self-hosted GitLab instance and it refers to repositories within Groups and Subgroups
+
 ## 1.23.2
 
 16 August 2024

--- a/versioned_docs/version-1.26/release-notes.mdx
+++ b/versioned_docs/version-1.26/release-notes.mdx
@@ -150,6 +150,16 @@ This version is compatible with Kubernetes versions 1.27 to 1.30
 
 - Support for Kubernetes [1.26](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md) has been removed in this release.
 
+## 1.23.3
+
+9 September 2024
+
+This version is compatible with Kubernetes versions 1.26 to 1.30
+
+### Bug Fixes
+
+- Fix deploy of development environments from the UI when the git URL is from a self-hosted GitLab instance and it refers to repositories within Groups and Subgroups
+
 ## 1.23.2
 
 16 August 2024


### PR DESCRIPTION
I detected that `1.23.3` version was missing in the release notes for `1.24` and higher versions. We added it only for the `1.23` versioned docs. Added such version in all missing versioned docs