### PR TITLE
Document `deploy.compose` object notation

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -210,7 +210,6 @@ Images specified in the `build` section of the Okteto Manifest overrides the ima
 :::
 
 If you want to deploy only a subset of the services in the Docker compose file, you can use the `services` field. By default, all services are deployed.
-Only the `volumes` and `endpoints` of the services specified in the `services` field are deployed.
 
 ```yaml
 deploy:
@@ -220,7 +219,7 @@ deploy:
       - frontend
 ```
 
-There is an extended notation to deploy several Docker Compose files and [endpoints](reference/docker-compose.mdx#endpoints-object-optional):
+There is an extended notation to deploy several Docker Compose files and [endpoints](reference/docker-compose.mdx#endpoints-object-optional). Only the `volumes` and `endpoints` of the services specified in the `services` field are deployed:
 
 ```yaml
 deploy:

--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -209,6 +209,16 @@ deploy:
 Images specified in the `build` section of the Okteto Manifest overrides the image associated with services sharing the same name in your Docker Compose files.
 :::
 
+If you want to deploy only a subset of the services in the Docker compose file, you can use the `services` field. By default, all services are deployed.
+Only the `volumes` and `endpoints` of the services specified in the `services` field are deployed.
+
+```yaml
+deploy:
+  compose:
+    file: docker-compose.yml
+    services:
+      - frontend
+```
 
 There is an extended notation to deploy several Docker Compose files and [endpoints](reference/docker-compose.mdx#endpoints-object-optional):
 
@@ -229,9 +239,6 @@ deploy:
       service: api
       port: 8080
 ```
-
-The `services` field allows us to deploy only a subset of the services in the Docker compose file (default to all services).
-Only the `volumes` and `endpoints` of the services specified in the `services` field are deployed.
 
 You can combine deploy commands with Docker Compose files:
 


### PR DESCRIPTION
This PR is adding documentation for a missing manifest reference for `deploy.compose` which can also be declared using the object notation.

| Before                                                                                                                                           | After                                                                                                                                            |
|--------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1068" alt="Screenshot 2024-12-10 at 09 54 11" src="https://github.com/user-attachments/assets/6c8cf6f5-3fe1-435f-b7ff-7a4ebb4c2220"> | <img width="1074" alt="Screenshot 2024-12-10 at 09 53 50" src="https://github.com/user-attachments/assets/abaf6e48-5341-40bd-b95d-394fda0f9c1f"> |