### PR TITLE
fix key for ingress-nginx and okteto-nginx in the airgap docs

### DIFF
--- a/src/content/self-hosted/manage/air-gapped.mdx
+++ b/src/content/self-hosted/manage/air-gapped.mdx
@@ -78,13 +78,14 @@ cli:
     registry: <<your-registry-url>>
 
 ingress-nginx:
-  global:
+  controller:
     image:
       registry: <<your-registry-url>>
 
 okteto-nginx:
-  global:
-    image: <<your-registry-url>>
+  controller:
+    image:
+      registry: <<your-registry-url>>
 
 reloader:
   reloader:
@@ -98,7 +99,7 @@ redis:
 ```
 
 
-## Step 4: Install or Upgrade Okteto 
+## Step 4: Install or Upgrade Okteto
 
 Run the following command to install Okteto for the first time or to upgrade an existing instance:
 

--- a/versioned_docs/version-1.27/self-hosted/manage/air-gapped.mdx
+++ b/versioned_docs/version-1.27/self-hosted/manage/air-gapped.mdx
@@ -78,13 +78,14 @@ cli:
     registry: <<your-registry-url>>
 
 ingress-nginx:
-  global:
+  controller:
     image:
       registry: <<your-registry-url>>
 
 okteto-nginx:
-  global:
-    image: <<your-registry-url>>
+  controller:
+    image:
+      registry: <<your-registry-url>>
 
 reloader:
   reloader:
@@ -98,7 +99,7 @@ redis:
 ```
 
 
-## Step 4: Install or Upgrade Okteto 
+## Step 4: Install or Upgrade Okteto
 
 Run the following command to install Okteto for the first time or to upgrade an existing instance:
 


### PR DESCRIPTION
Using the key as documented on https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx/4.11.2#:~:text=controller.image.registry,registry.k8s.io%22

Change is on https://deploy-preview-949--okteto-docs.netlify.app/docs/self-hosted/manage/air-gapped/#step-3-update-helm-configuration