### PR TITLE
Indicate removed binaries in the release notes, and restore `kustomize` binary as part of the default runner image

### DIFF
--- a/src/content/core/remote-execution.mdx
+++ b/src/content/core/remote-execution.mdx
@@ -49,6 +49,7 @@ The default container image is a Debian Linux container with the following tools
 
 - `bash`
 - `curl`
+- `envsubst`
 - `git`
 - `helm`
 - `kubectl`

--- a/src/content/core/remote-execution.mdx
+++ b/src/content/core/remote-execution.mdx
@@ -48,9 +48,11 @@ By default, your commands will run in a remote container using our [default cont
 The default container image is a Debian Linux container with the following tools preinstalled:
 
 - `bash`
+- `curl`
 - `git`
 - `helm`
 - `kubectl`
+- `kustomize`
 - `make`
 - `okteto`
 - `openssh`

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -5,12 +5,23 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.27.1
+
+17 December 2024
+
+This version is compatible with Kubernetes versions 1.27 to 1.30 \
+Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.x](https://github.com/okteto/okteto/releases/tag/3.2.1)
+
+### Bug Fixes
+
+- Recovered `kustomize` binary as part of our default runner image.
+
 ## 1.27.0
 
 12 December 2024
 
 This version is compatible with Kubernetes versions 1.27 to 1.30 \
-Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.1](https://github.com/okteto/okteto/releases/tag/3.2.1)
+Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.x](https://github.com/okteto/okteto/releases/tag/3.2.1)
 
 ### Breaking Changes
 

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -17,6 +17,7 @@ Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.1](https://gi
 - Remove code for our deprecated Quickstarts feature <!-- 8842 -->
 - Helm chart now separates registry and repository fields for overwriting container images.
 Update configurations for `backend.image`, `frontend.image`, `buildkit.image`, `buildkit.rootless.image`, `registry.image` following [this guide](self-hosted/manage/air-gapped.mdx#step-2-set-up-a-private-registry-for-required-images) if you have previously overwritten these.
+- `cue` and `envsubst` binaries were removed from the Okteto's default pipeline runner image. If you need some of those binaries in your pipelines, you can use [your own runner image](admin/custom-installer-image.mdx).
 
 ### New Features
 

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -28,7 +28,7 @@ Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.x](https://gi
 - Remove code for our deprecated Quickstarts feature <!-- 8842 -->
 - Helm chart now separates registry and repository fields for overwriting container images.
 Update configurations for `backend.image`, `frontend.image`, `buildkit.image`, `buildkit.rootless.image`, `registry.image` following [this guide](self-hosted/manage/air-gapped.mdx#step-2-set-up-a-private-registry-for-required-images) if you have previously overwritten these.
-- `cue` and `envsubst` binaries were removed from the Okteto's default pipeline runner image. If you need some of those binaries in your pipelines, you can use [your own runner image](admin/custom-installer-image.mdx).
+- `cue`, `helmfile`, `kustomize`, `yq` and `docker-credential-ecr-login` binaries were removed from the Okteto's default pipeline runner image. If you need some of those binaries in your pipelines, you can build [your own runner image](admin/custom-installer-image.mdx).
 
 ### New Features
 

--- a/versioned_docs/version-1.27/core/remote-execution.mdx
+++ b/versioned_docs/version-1.27/core/remote-execution.mdx
@@ -49,6 +49,7 @@ The default container image is a Debian Linux container with the following tools
 
 - `bash`
 - `curl`
+- `envsubst`
 - `git`
 - `helm`
 - `kubectl`

--- a/versioned_docs/version-1.27/core/remote-execution.mdx
+++ b/versioned_docs/version-1.27/core/remote-execution.mdx
@@ -48,9 +48,11 @@ By default, your commands will run in a remote container using our [default cont
 The default container image is a Debian Linux container with the following tools preinstalled:
 
 - `bash`
+- `curl`
 - `git`
 - `helm`
 - `kubectl`
+- `kustomize`
 - `make`
 - `okteto`
 - `openssh`

--- a/versioned_docs/version-1.27/release-notes.mdx
+++ b/versioned_docs/version-1.27/release-notes.mdx
@@ -17,6 +17,7 @@ Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.1](https://gi
 - Remove code for our deprecated Quickstarts feature <!-- 8842 -->
 - Helm chart now separates registry and repository fields for overwriting container images.
 Update configurations for `backend.image`, `frontend.image`, `buildkit.image`, `buildkit.rootless.image`, `registry.image` following [this guide](self-hosted/manage/air-gapped.mdx#step-2-set-up-a-private-registry-for-required-images) if you have previously overwritten these.
+- `cue` and `envsubst` binaries were removed from the Okteto's default pipeline runner image. If you need some of those binaries in your pipelines, you can build [your own runner image](admin/custom-installer-image.mdx).
 
 ### New Features
 

--- a/versioned_docs/version-1.27/release-notes.mdx
+++ b/versioned_docs/version-1.27/release-notes.mdx
@@ -28,7 +28,7 @@ Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.x](https://gi
 - Remove code for our deprecated Quickstarts feature <!-- 8842 -->
 - Helm chart now separates registry and repository fields for overwriting container images.
 Update configurations for `backend.image`, `frontend.image`, `buildkit.image`, `buildkit.rootless.image`, `registry.image` following [this guide](self-hosted/manage/air-gapped.mdx#step-2-set-up-a-private-registry-for-required-images) if you have previously overwritten these.
-- `cue` and `envsubst` binaries were removed from the Okteto's default pipeline runner image. If you need some of those binaries in your pipelines, you can build [your own runner image](admin/custom-installer-image.mdx).
+- `cue`, `helmfile`, `kustomize`, `yq` and `docker-credential-ecr-login` binaries were removed from the Okteto's default pipeline runner image. If you need some of those binaries in your pipelines, you can build [your own runner image](admin/custom-installer-image.mdx).
 
 ### New Features
 

--- a/versioned_docs/version-1.27/release-notes.mdx
+++ b/versioned_docs/version-1.27/release-notes.mdx
@@ -5,12 +5,23 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.27.1
+
+17 December 2024
+
+This version is compatible with Kubernetes versions 1.27 to 1.30 \
+Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.x](https://github.com/okteto/okteto/releases/tag/3.2.1)
+
+### Bug Fixes
+
+- Restored `kustomize` binary as part of our default runner image.
+
 ## 1.27.0
 
 12 December 2024
 
 This version is compatible with Kubernetes versions 1.27 to 1.30 \
-Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.1](https://github.com/okteto/okteto/releases/tag/3.2.1)
+Okteto Chart release 1.27 is designed to work with [Okteto CLI 3.2.x](https://github.com/okteto/okteto/releases/tag/3.2.1)
 
 ### Breaking Changes
 


### PR DESCRIPTION
This PR includes:
* A bullet point in the release notes indicating that some binaries were removed from the Okteto's default runner image
* Restore `kustomize` (and `curl` this was never deleted from the imaged, but it was from the docs) as binary included in the default runner image
* Add entry for `1.27.1` version of chart where we will restore the `kustomize` binary