### PR TITLE
docs(aws): metric server install steps (PLAT-770)

### DIFF
--- a/src/content/get-started/install/amazon-eks.mdx
+++ b/src/content/get-started/install/amazon-eks.mdx
@@ -117,6 +117,25 @@ Ensure the Kubernetes version you select meets the following requirements:
 
 Follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) for more details.
 
+### Deploy Kubernetes Metrics Server Addon
+
+Okteto requires the Kubernetes Metrics Server for the following features to work:
+- [Resource Manager](admin/resource-manager.mdx)
+- [Okteto Insights](admin/okteto-insights.mdx)
+
+To install the Kubernetes Metrics Server, run the following command:
+
+```bash
+eksctl create addon \
+  --region="${AWS_REGION}" \
+  --name="metrics-server" \
+  --cluster="${CLUSTER_NAME}"
+```
+
+:::info
+The Kubernetes Metrics Server provides alternative installation options. For more details, consult the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html) and [official repository](https://github.com/kubernetes-sigs/metrics-server).
+:::
+
 ### Create EBS CSI Addon IAM Role
 
 Okteto requires the EBS CSI Addon to be able to create persistent volumes.


### PR DESCRIPTION
Metrics server is required for important Okteto features. It doesn't ship with EKS. This PR adds steps for installing it as an EKS addon.