### PR TITLE
docs: clarify okteto destroy

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -284,9 +284,9 @@ deploy:
 
 A list of commands to destroy external resources created by your development environment.
 
-`okteto destroy` automatically takes care of destroying all the Kubernetes resources created by `okteto deploy`.
+`okteto destroy` automatically takes care of destroying all the Kubernetes resources created by `okteto deploy` in your namespace.
 
-Use the `destroy` section if you create resources out of the scope of Kubernetes, like s3 buckets or RDS databases.
+Use the `destroy` section if you create resources outside of your namespace, like clusterroles, or out of the scope of Kubernetes, like s3 buckets or RDS databases.
 
 ```yaml
 destroy:


### PR DESCRIPTION
By default, `okteto destroy` for non Helm managed resources is scoped to resources in your namespace only. This PR clarifies that.