### PR TITLE
DEV-863: Remove support of Kubernetes version 1.28

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -5,6 +5,33 @@ sidebar_label: Release notes
 id: release-notes
 ---
 
+## 1.30.0
+
+XX March 2025
+
+This version is compatible with Kubernetes versions 1.29 to 1.31 \
+Okteto Chart release 1.30 is designed to work with [Okteto CLI 3.5.x](https://github.com/okteto/okteto/releases/tag/3.5.0)
+
+### Breaking Changes {#breaking-changes-1.30}
+
+TBC
+
+### New Features {#new-features-1.30}
+
+TBC
+
+### Improvements {#improvements-1.30}
+
+TBC
+
+### Bug Fixes {#bug-fixes-1.30}
+
+TBC
+
+### Removal Notice {#removal-notice-1.30}
+
+- Support for Kubernetes [1.28](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md) has been removed in this release.
+
 ## 1.29.0
 
 7 February 2025

--- a/src/content/variables.json
+++ b/src/content/variables.json
@@ -1,7 +1,7 @@
 {
-  "kubernetesMinVersion": "1.28",
+  "kubernetesMinVersion": "1.29",
   "kubernetesMaxVersion": "1.31",
-  "cliVersion": "3.4.0",
-  "chartVersion": "1.29.0",
+  "cliVersion": "3.5.0",
+  "chartVersion": "1.30.0",
   "syncthingVersion": "1.29.2"
 }


### PR DESCRIPTION
Changes to reflect that `1.30` version of Okteto will not support Kubernetes version `1.28`. 

@codyjlandstrom Do we want to mention something about now supporting one less version of Kubernetes per release, or it is fine just the regular removal notice?