### PR TITLE
Fine tune configuration for ArgoCD ignore

### DIFF
--- a/src/content/self-hosted/manage/argocd.mdx
+++ b/src/content/self-hosted/manage/argocd.mdx
@@ -80,21 +80,27 @@ ignoreDifferences:
       - '/data/tls.crt'
       - '/data/tls.key'
 
-  # Webhook cabundles patched by Okteto
-  - group: 'admissionregistration.k8s.io'
+  # Mutation webhook cabundles patched by Okteto
+  - group: admissionregistration.k8s.io
+    kind: MutatingWebhookConfiguration
+    jqPathExpressions:
+      - .webhooks[].clientConfig.caBundle
+
+  # Validation webhook cabundles patched by Okteto
+  - group: admissionregistration.k8s.io
+    kind: ValidatingWebhookConfiguration
+    jqPathExpressions:
+      - .webhooks[].clientConfig.caBundle
+
+  # Internal service account managed by Okteto
+  - kind: ServiceAccount
+    name: okteto-bot
     jsonPointers:
-      - '/webhooks/0/clientConfig/caBundle'
-      - '/webhooks/1/clientConfig/caBundle'
-      - '/webhooks/2/clientConfig/caBundle'
-      - '/webhooks/3/clientConfig/caBundle'
-      - '/webhooks/4/clientConfig/caBundle'
-      - '/webhooks/5/clientConfig/caBundle'
-      - '/webhooks/6/clientConfig/caBundle'
-      - '/webhooks/7/clientConfig/caBundle'
-      - '/webhooks/8/clientConfig/caBundle'
-      - '/webhooks/9/clientConfig/caBundle'
-      - '/webhooks/10/clientConfig/caBundle'
-      - '/webhooks/11/clientConfig/caBundle'
+      - /metadata/labels/app
+      - /metadata/labels/app.kubernetes.io~1instance
+      - /metadata/labels/chart
+      - /metadata/labels/heritage
+      - /metadata/labels/release
 
   # Internal service account managed by Okteto
   - kind: 'ServiceAccount'


### PR DESCRIPTION
Adding a rule to ignore some fields in the `okteto-bot` service account created as part of the installation, and also improved the current rule for the mutatingwebhookconfiguration, as we had to manually add more lines if we include more webhooks on it. I also took the chance to create specific rules for validating and mutating webhooks (previous rule wasn't specifying the kind, so it was considering everything under the group `admissionregistration.k8s.io`