### PR TITLE
Fix formatting of appId in GitHub installation instructions

### DIFF
--- a/src/content/self-hosted/install/github.mdx
+++ b/src/content/self-hosted/install/github.mdx
@@ -77,7 +77,7 @@ Add the values we generated in the previous steps to your existing Helm configur
 ```yaml
 github:
   enabled: true
-  appId: ${YOUR_APP_ID}
+  appId: "${YOUR_APP_ID}"
   clientId: ${YOUR_CLIENT_ID}
   clientSecret: ${YOUR_CLIENT_SECRET}
   installationUrl: https://github.com/apps/${YOUR_GITHUB_APP_NAME}/installations/new

--- a/versioned_docs/version-1.30/self-hosted/install/github.mdx
+++ b/versioned_docs/version-1.30/self-hosted/install/github.mdx
@@ -77,7 +77,7 @@ Add the values we generated in the previous steps to your existing Helm configur
 ```yaml
 github:
   enabled: true
-  appId: ${YOUR_APP_ID}
+  appId: "${YOUR_APP_ID}"
   clientId: ${YOUR_CLIENT_ID}
   clientSecret: ${YOUR_CLIENT_SECRET}
   installationUrl: https://github.com/apps/${YOUR_GITHUB_APP_NAME}/installations/new


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

Add double quotes in appId. It could be converted into a exponential and fail. Double quoting makes helm treat it like a string