### PR TITLE
Clarification in divert section of the manifest to indicate that okteto-divert is a key within the baggage header

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -285,10 +285,10 @@ deploy:
 - `driver`: Specifies the backend to divert requests. Use `nginx` (or leave this field unspecified) to use the default Nginx driver.
 - `namespace`: The namespace that holds the full shareable environment. When a request is directed to a service that wasn't created by the `deploy` command, Okteto will automatically direct it to the environment running on this namespace.
 
-When `divert` is enabled, Okteto injects the header `baggage.okteto-divert` into every request that passes through your development ingress. This header allows Okteto to route the request intelligently between services running in your personal namespace and services running in a shared environment.
+When `divert` is enabled, Okteto injects the key `okteto-divert` within the header [`baggage`](https://www.w3.org/TR/baggage/) into every request that passes through your development ingress. This header allows Okteto to route the request intelligently between services running in your personal namespace and services running in a shared environment.
 
 :::tip
-To maintain request routing across service boundaries, we recommend propagating the `baggage.okteto-divert` header to all downstream service calls.
+To maintain request routing across service boundaries, we recommend propagating the `baggage` (at least the key `okteto-divert`) header to all downstream service calls.
 Beyond request routing, this header can also be used to:
 - Route messages to different queues or topics
 - Redirect requests to services in other namespaces
@@ -303,7 +303,7 @@ Check out [this GitHub repository](https://github.com/okteto-community/divert-sh
 
 Use the `istio` driver if your development environments use Istio for managing service-to-service communication.
 
-When divert is enabled, Okteto injects the header `baggage.okteto-divert` to every request coming from the developer Namespace.
+When divert is enabled, Okteto injects the the key `okteto-divert` within the header [`baggage`](https://www.w3.org/TR/baggage/) to every request coming from the developer Namespace.
 If a request reaches the shared Namespace and matches a diverted virtual service, Okteto automatically redirects the request back to the developer Namespace.
 
 To divert a virtual service as part of your development environment, use the following notation:
@@ -327,7 +327,7 @@ deploy:
 
 - `driver`: Specifies the backend to divert requests. Use `istio` to use the Istio driver.
 - `virtualServices`: A list of virtual services to divert. Each virtual service is defined by it's name, Namespace, and an optional list of routes to be diverted. By default, all routes are diverted.
-- `hosts`: The list of hosts you want to divert in the developer namespace. Requests to these virtual services will have the header `baggage.okteto-divert` injected.
+- `hosts`: The list of hosts you want to divert in the developer namespace. Requests to these virtual services will have the key `okteto-divert` as part of the `baggage` header injected.
 </TabItem>
 </Tabs>
 

--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -288,7 +288,7 @@ deploy:
 When `divert` is enabled, Okteto injects the key `okteto-divert` within the header [`baggage`](https://www.w3.org/TR/baggage/) into every request that passes through your development ingress. This header allows Okteto to route the request intelligently between services running in your personal namespace and services running in a shared environment.
 
 :::tip
-To maintain request routing across service boundaries, we recommend propagating the `baggage` (at least the key `okteto-divert`) header to all downstream service calls.
+To maintain request routing across service boundaries, we recommend propagating the `baggage` (with the key `okteto-divert`) header to all downstream service calls.
 Beyond request routing, this header can also be used to:
 - Route messages to different queues or topics
 - Redirect requests to services in other namespaces

--- a/versioned_docs/version-1.31/reference/okteto-manifest.mdx
+++ b/versioned_docs/version-1.31/reference/okteto-manifest.mdx
@@ -285,10 +285,10 @@ deploy:
 - `driver`: Specifies the backend to divert requests. Use `nginx` (or leave this field unspecified) to use the default Nginx driver.
 - `namespace`: The namespace that holds the full shareable environment. When a request is directed to a service that wasn't created by the `deploy` command, Okteto will automatically direct it to the environment running on this namespace.
 
-When `divert` is enabled, Okteto injects the key `okteto-divert` within the header [`baggage`](https://www.w3.org/TR/baggage/) into every request that passes through your development ingress. This header allows Okteto to route the request intelligently between services running in your personal namespace and services running in a shared environment.
+When `divert` is enabled, Okteto injects the header `baggage.okteto-divert` into every request that passes through your development ingress. This header allows Okteto to route the request intelligently between services running in your personal namespace and services running in a shared environment.
 
 :::tip
-To maintain request routing across service boundaries, we recommend propagating the `baggage` (at least the key `okteto-divert`) header to all downstream service calls.
+To maintain request routing across service boundaries, we recommend propagating the `baggage.okteto-divert` header to all downstream service calls.
 Beyond request routing, this header can also be used to:
 - Route messages to different queues or topics
 - Redirect requests to services in other namespaces
@@ -303,7 +303,7 @@ Check out [this GitHub repository](https://github.com/okteto-community/divert-sh
 
 Use the `istio` driver if your development environments use Istio for managing service-to-service communication.
 
-When divert is enabled, Okteto injects the the key `okteto-divert` within the header [`baggage`](https://www.w3.org/TR/baggage/) to every request coming from the developer Namespace.
+When divert is enabled, Okteto injects the header `baggage.okteto-divert` to every request coming from the developer Namespace.
 If a request reaches the shared Namespace and matches a diverted virtual service, Okteto automatically redirects the request back to the developer Namespace.
 
 To divert a virtual service as part of your development environment, use the following notation:
@@ -327,7 +327,7 @@ deploy:
 
 - `driver`: Specifies the backend to divert requests. Use `istio` to use the Istio driver.
 - `virtualServices`: A list of virtual services to divert. Each virtual service is defined by it's name, Namespace, and an optional list of routes to be diverted. By default, all routes are diverted.
-- `hosts`: The list of hosts you want to divert in the developer namespace. Requests to these virtual services will have the key `okteto-divert` as part of the `baggage` header injected.
+- `hosts`: The list of hosts you want to divert in the developer namespace. Requests to these virtual services will have the header `baggage.okteto-divert` injected.
 </TabItem>
 </Tabs>
 

--- a/versioned_docs/version-1.31/reference/okteto-manifest.mdx
+++ b/versioned_docs/version-1.31/reference/okteto-manifest.mdx
@@ -285,10 +285,10 @@ deploy:
 - `driver`: Specifies the backend to divert requests. Use `nginx` (or leave this field unspecified) to use the default Nginx driver.
 - `namespace`: The namespace that holds the full shareable environment. When a request is directed to a service that wasn't created by the `deploy` command, Okteto will automatically direct it to the environment running on this namespace.
 
-When `divert` is enabled, Okteto injects the header `baggage.okteto-divert` into every request that passes through your development ingress. This header allows Okteto to route the request intelligently between services running in your personal namespace and services running in a shared environment.
+When `divert` is enabled, Okteto injects the key `okteto-divert` within the header [`baggage`](https://www.w3.org/TR/baggage/) into every request that passes through your development ingress. This header allows Okteto to route the request intelligently between services running in your personal namespace and services running in a shared environment.
 
 :::tip
-To maintain request routing across service boundaries, we recommend propagating the `baggage.okteto-divert` header to all downstream service calls.
+To maintain request routing across service boundaries, we recommend propagating the `baggage` (at least the key `okteto-divert`) header to all downstream service calls.
 Beyond request routing, this header can also be used to:
 - Route messages to different queues or topics
 - Redirect requests to services in other namespaces
@@ -303,7 +303,7 @@ Check out [this GitHub repository](https://github.com/okteto-community/divert-sh
 
 Use the `istio` driver if your development environments use Istio for managing service-to-service communication.
 
-When divert is enabled, Okteto injects the header `baggage.okteto-divert` to every request coming from the developer Namespace.
+When divert is enabled, Okteto injects the the key `okteto-divert` within the header [`baggage`](https://www.w3.org/TR/baggage/) to every request coming from the developer Namespace.
 If a request reaches the shared Namespace and matches a diverted virtual service, Okteto automatically redirects the request back to the developer Namespace.
 
 To divert a virtual service as part of your development environment, use the following notation:
@@ -327,7 +327,7 @@ deploy:
 
 - `driver`: Specifies the backend to divert requests. Use `istio` to use the Istio driver.
 - `virtualServices`: A list of virtual services to divert. Each virtual service is defined by it's name, Namespace, and an optional list of routes to be diverted. By default, all routes are diverted.
-- `hosts`: The list of hosts you want to divert in the developer namespace. Requests to these virtual services will have the header `baggage.okteto-divert` injected.
+- `hosts`: The list of hosts you want to divert in the developer namespace. Requests to these virtual services will have the key `okteto-divert` as part of the `baggage` header injected.
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
As we already had issues in the past thinking that the HTTP header we are including as part of divert is `baggage.okteto-divert` instead of the key `okteto-divert` **within** the `baggage` header (Istio driver was injecting the right header, while nginx one was injecting the wrong one), I modified the divert section to indicate that we inject a new key in the `baggage` header, instead of injecting a `baggage.okteto-divert` independent header.

I think this makes it clearer until we have a dedicated documentation for divert, but no problem on declining the changes if we don't consider this an improvement