### PR TITLE
Clarified where Okta deprovision config is provided in Okteto

### DIFF
--- a/src/content/admin/integrations/okta-user-deprovisioning.mdx
+++ b/src/content/admin/integrations/okta-user-deprovisioning.mdx
@@ -27,7 +27,7 @@ Within your Okta management console, navigate to `Workflows -> Event Hooks` and 
 - **Name**: A descriptive name for the event hook
 - **URL**: `https://okteto.YOUR_SUBDOMAIN.com/api/okta`
 - **Authentication Field**: It must be set to `Authorization` as this is the field that Okteto uses to authenticate the request
-- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Helm config (more info below)
+- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Admin Dashboard in the next step (more info below)
 - **Events**: Select the `User Deactivated` and/or `User Deleted` events
 
 :::tip
@@ -57,7 +57,7 @@ To be able to receive this event and all subsequent `deactivate` and `delete` ev
 
 To configure deprovisioning in Okteto:
 1. Navigate to **Admin → Integrations → Okta Deprovisioning** in the Okteto Admin Dashboard
-1. Enter the Okta Event Hook Token used in your Okta event hook configuration
+1. Enter the Okta Event Hook Token used as `Authentication Secret` in your Okta event hook configuration
 1. Click Enable to activate deprovisioning
 
 Once your event hook is created and Okteto is configured to receive events, you can verify the webhook in the **Okta admin console**.

--- a/versioned_docs/version-1.30/admin/integrations/okta-user-deprovisioning.mdx
+++ b/versioned_docs/version-1.30/admin/integrations/okta-user-deprovisioning.mdx
@@ -27,7 +27,7 @@ Within your Okta management console, navigate to `Workflows -> Event Hooks` and 
 - **Name**: A descriptive name for the event hook
 - **URL**: `https://okteto.YOUR_SUBDOMAIN.com/api/okta`
 - **Authentication Field**: It must be set to `Authorization` as this is the field that Okteto uses to authenticate the request
-- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Helm config (more info below)
+- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Admin Dashboard in the next step (more info below)
 - **Events**: Select the `User Deactivated` and/or `User Deleted` events
 
 :::tip
@@ -57,7 +57,7 @@ To be able to receive this event and all subsequent `deactivate` and `delete` ev
 
 To configure deprovisioning in Okteto:
 1. Navigate to **Admin → Integrations → Okta Deprovisioning** in the Okteto Admin Dashboard
-1. Enter the Okta Event Hook Token used in your Okta event hook configuration
+1. Enter the Okta Event Hook Token used as `Authentication Secret` in your Okta event hook configuration
 1. Click Enable to activate deprovisioning
 
 Once your event hook is created and Okteto is configured to receive events, you can verify the webhook in the **Okta admin console**.

--- a/versioned_docs/version-1.31/admin/integrations/okta-user-deprovisioning.mdx
+++ b/versioned_docs/version-1.31/admin/integrations/okta-user-deprovisioning.mdx
@@ -27,7 +27,7 @@ Within your Okta management console, navigate to `Workflows -> Event Hooks` and 
 - **Name**: A descriptive name for the event hook
 - **URL**: `https://okteto.YOUR_SUBDOMAIN.com/api/okta`
 - **Authentication Field**: It must be set to `Authorization` as this is the field that Okteto uses to authenticate the request
-- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Helm config (more info below)
+- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Admin Dashboard in the next step (more info below)
 - **Events**: Select the `User Deactivated` and/or `User Deleted` events
 
 :::tip
@@ -57,7 +57,7 @@ To be able to receive this event and all subsequent `deactivate` and `delete` ev
 
 To configure deprovisioning in Okteto:
 1. Navigate to **Admin → Integrations → Okta Deprovisioning** in the Okteto Admin Dashboard
-1. Enter the Okta Event Hook Token used in your Okta event hook configuration
+1. Enter the Okta Event Hook Token used as `Authentication Secret` in your Okta event hook configuration
 1. Click Enable to activate deprovisioning
 
 Once your event hook is created and Okteto is configured to receive events, you can verify the webhook in the **Okta admin console**.

--- a/versioned_docs/version-1.32/admin/integrations/okta-user-deprovisioning.mdx
+++ b/versioned_docs/version-1.32/admin/integrations/okta-user-deprovisioning.mdx
@@ -27,7 +27,7 @@ Within your Okta management console, navigate to `Workflows -> Event Hooks` and 
 - **Name**: A descriptive name for the event hook
 - **URL**: `https://okteto.YOUR_SUBDOMAIN.com/api/okta`
 - **Authentication Field**: It must be set to `Authorization` as this is the field that Okteto uses to authenticate the request
-- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Helm config (more info below)
+- **Authentication Secret**: Provide a secret value that will be used to authenticate the request. This value should match the value provided in the Okteto Admin Dashboard in the next step (more info below)
 - **Events**: Select the `User Deactivated` and/or `User Deleted` events
 
 :::tip


### PR DESCRIPTION
For the Okta Deprovision config we were referring to Helm setting, but Okta deprovisioning is not configured through helm values. 

Clarified that, and indicate that the value used in the `Okta Event Hook Token` is the Authorization secret defined in the Okta side