### PR TITLE
Added missed clarification on Okta deprovisioning config for 1.32 version

### DIFF
--- a/versioned_docs/version-1.32/admin/integrations/okta-user-deprovisioning.mdx
+++ b/versioned_docs/version-1.32/admin/integrations/okta-user-deprovisioning.mdx
@@ -57,7 +57,7 @@ To be able to receive this event and all subsequent `deactivate` and `delete` ev
 
 To configure deprovisioning in Okteto:
 1. Navigate to **Admin → Integrations → Okta Deprovisioning** in the Okteto Admin Dashboard
-1. Enter the Okta Event Hook Token used in your Okta event hook configuration
+1. Enter the Okta Event Hook Token used as `Authentication Secret` in your Okta event hook configuration
 1. Click Enable to activate deprovisioning
 
 Once your event hook is created and Okteto is configured to receive events, you can verify the webhook in the **Okta admin console**.


### PR DESCRIPTION
In this PR I added some clarification about Okta clarification https://github.com/okteto/docs/pull/1030, but in the `1.32` version I forgot to add one change I did in the other versions, so, sending this to have the same in the different versions