### PR TITLE
Added 'output' flag for the namespace list command

### DIFF
--- a/src/content/reference/okteto-cli.mdx
+++ b/src/content/reference/okteto-cli.mdx
@@ -444,6 +444,10 @@ demos-cindy     Active
 cindy *         Active
 ```
 
+| Options                                        | Type   | Description                           | Default     |
+| ---------------------------------------------- | :----: | ------------------------------------- | :---------- |
+| <em className="no-wrap">_-o, --output_</em>    | string | Output format. One of: `json`, `yaml` | `json` |
+
 #### use
 
 Configure the default namespace of the Okteto Context. `okteto namespace use` is an alias of `okteto namespace`.


### PR DESCRIPTION
CLI `3.8.0` includes a new option for the `okteto namespace list` command to indicate the command output. This PR addes the flag to the command documentation