### PR TITLE
docs: remove aws section for metrics server

### DIFF
--- a/src/content/get-started/install/amazon-eks.mdx
+++ b/src/content/get-started/install/amazon-eks.mdx
@@ -17,7 +17,7 @@ This guide will walk you through the process of installing Okteto in Amazon Elas
 Before you start, make sure you have the following CLIs installed in your machine:
 
 - `okteto` >= {variables.cliVersion} ([okteto installation guides](get-started/install-okteto-cli.mdx))
-- `eksctl` >= 0.171 ([eksctl installation guides](https://eksctl.io/installation/))
+- `eksctl` >= 0.201 ([eksctl installation guides](https://eksctl.io/installation/))
 - `aws` >= 2.15 ([aws installation guides](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions))
 - `kubectl` >= 1.28 ([kubectl installation guides](https://kubernetes.io/docs/tasks/tools/#kubectl))
 - `helm` >= 3.14 ([helm installation guides](https://helm.sh/docs/intro/install/))
@@ -122,25 +122,6 @@ Ensure the Kubernetes version you select meets the following requirements:
 :::
 
 Follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) for more details.
-
-### Deploy Kubernetes Metrics Server Addon
-
-Okteto requires the Kubernetes Metrics Server for the following features to work:
-- [Resource Manager](admin/resource-manager.mdx)
-- [Okteto Insights](admin/okteto-insights.mdx)
-
-To install the Kubernetes Metrics Server, run the following command:
-
-```bash
-eksctl create addon \
-  --region="${AWS_REGION}" \
-  --name="metrics-server" \
-  --cluster="${CLUSTER_NAME}"
-```
-
-:::info
-The Kubernetes Metrics Server provides alternative installation options. For more details, consult the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html) and [official repository](https://github.com/kubernetes-sigs/metrics-server).
-:::
 
 ### Create EBS CSI Addon IAM Role
 


### PR DESCRIPTION
[eksctl 0.201](https://github.com/eksctl-io/eksctl/releases?page=2) now creates clusters with metric server addon by default:
- https://github.com/eksctl-io/eksctl/pull/8118