### PR TITLE
Updated metric-server add-on docu on eks installation page

### DIFF
--- a/versioned_docs/version-1.33/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.33/get-started/install/amazon-eks.mdx
@@ -17,7 +17,7 @@ This guide will walk you through the process of installing Okteto in Amazon Elas
 Before you start, make sure you have the following CLIs installed in your machine:
 
 - `okteto` >= {variables.cliVersion} ([okteto installation guides](get-started/install-okteto-cli.mdx))
-- `eksctl` >= 0.171 ([eksctl installation guides](https://eksctl.io/installation/))
+- `eksctl` >= 0.208 ([eksctl installation guides](https://eksctl.io/installation/))
 - `aws` >= 2.15 ([aws installation guides](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions))
 - `kubectl` >= 1.28 ([kubectl installation guides](https://kubernetes.io/docs/tasks/tools/#kubectl))
 - `helm` >= 3.14 ([helm installation guides](https://helm.sh/docs/intro/install/))
@@ -123,24 +123,33 @@ Ensure the Kubernetes version you select meets the following requirements:
 
 Follow Amazon's [cluster creation guide](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) for more details.
 
-### Deploy Kubernetes Metrics Server Addon
+### Kubernetes Metrics Server in EKS
 
-Okteto requires the Kubernetes Metrics Server for the following features to work:
-- [Resource Manager](admin/resource-manager.mdx)
+Okteto uses the Kubernetes Metrics Server to enable key features, including:
+- [Resource Manager](admin/resource-manager.mdx)  
 - [Okteto Insights](admin/okteto-insights.mdx)
 
-To install the Kubernetes Metrics Server, run the following command:
+If you're using **EKS**, the Metrics Server is now installed **by default** when creating a new cluster with `eksctl`. No additional action is typically required.
+
+To confirm the addon is installed, you can run:
+
+```bash
+eksctl get addons --cluster "${CLUSTER_NAME}" --region "${AWS_REGION}"
+```
+
+If needed, you can manually install the Metrics Server using:
 
 ```bash
 eksctl create addon \
-  --region="${AWS_REGION}" \
-  --name="metrics-server" \
-  --cluster="${CLUSTER_NAME}"
+  --name "metrics-server" \
+  --cluster "${CLUSTER_NAME}" \
+  --region "${AWS_REGION}"
 ```
 
 :::info
-The Kubernetes Metrics Server provides alternative installation options. For more details, consult the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html) and [official repository](https://github.com/kubernetes-sigs/metrics-server).
+Alternative installation methods are available. For more information, refer to the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html) and the [official Metrics Server GitHub repository](https://github.com/kubernetes-sigs/metrics-server).
 :::
+
 
 ### Create EBS CSI Addon IAM Role
 


### PR DESCRIPTION
With the newer version of eksctl the metric-server add-on is installed by default.