### PR TITLE
Add Docker Compose endpoints section to getting started guide

### DIFF
--- a/src/content/get-started/deploy-your-app/endpoints.mdx
+++ b/src/content/get-started/deploy-your-app/endpoints.mdx
@@ -96,6 +96,37 @@ Finally, you can access the endpoint of the Movies app to see something like thi
   />
 </p>
 
+## Using Endpoints with Docker Compose
+
+If you're using Docker Compose instead of Kubernetes manifests, you can expose your application using the `endpoints` section directly in your `docker-compose.yml` file:
+
+```yaml title="docker-compose.yml"
+services:
+  frontend:
+    build: ./frontend
+    ports:
+      - 3000:3000
+  
+  api:
+    build: ./api
+    ports:
+      - 8080:8080
+
+endpoints:
+  - path: /
+    service: frontend
+    port: 3000
+  - path: /api
+    service: api
+    port: 8080
+```
+
+When you run `okteto deploy`, your application will be accessible at URLs like `https://movies-cindy.okteto.example.com`.
+
+:::note
+Learn more about [configuring endpoints with Docker Compose](reference/docker-compose.mdx#endpoints-object-optional)
+:::
+
 ## Next Steps
 
 The Movies app is using pre-built images to deploy your Development Environment...


### PR DESCRIPTION
## Summary

This PR adds a concise section about using endpoints with Docker Compose to the getting started guide for deploying applications.

## Changes

- Added a new "Using Endpoints with Docker Compose" section to 
- Includes a practical example showing how to configure endpoints in a docker-compose.yml file
- Explains the basic concept and links to comprehensive documentation
- Positioned after the Kubernetes Ingress section for logical flow

## Why this change?

The current endpoints documentation only covers Kubernetes Ingress resources, but many users start with Docker Compose. This addition provides a quick introduction to Docker Compose endpoints while keeping the getting started guide concise.

## Testing

- Verified MDX syntax is correct
- Ensured all code blocks are properly formatted
- Confirmed the link to the Docker Compose reference documentation is accurate