### PR TITLE
Remove nested headers in private endpoints page

### DIFF
--- a/src/content/core/endpoints/private-endpoints.mdx
+++ b/src/content/core/endpoints/private-endpoints.mdx
@@ -65,12 +65,10 @@ spec:
 ```
 
 :::note
-
 Private Endpoints generated this way follow the same rules and restrictions than [Automatic SSL Endpoints](core/endpoints/automatic-ssl.mdx).
-
 :::
 
-### Advanced Scenarios
+**Advanced Scenarios**
 
 You can also use this feature with your own ingresses. This is useful when you have more complex configurations, or when you only want to protect a subset of your application's endpoints.
 
@@ -127,7 +125,7 @@ services:
       - 8080:8080
 ```
 
-### Advanced Scenarios
+**Advanced Scenarios**
 
 You can also define this at the `endpoint` level if needed.
 

--- a/versioned_docs/version-1.33/core/endpoints/private-endpoints.mdx
+++ b/versioned_docs/version-1.33/core/endpoints/private-endpoints.mdx
@@ -70,7 +70,7 @@ Private Endpoints generated this way follow the same rules and restrictions than
 
 :::
 
-### Advanced Scenarios
+**Advanced Scenarios**
 
 You can also use this feature with your own ingresses. This is useful when you have more complex configurations, or when you only want to protect a subset of your application's endpoints.
 
@@ -127,7 +127,7 @@ services:
       - 8080:8080
 ```
 
-### Advanced Scenarios
+**Advanced Scenarios**
 
 You can also define this at the `endpoint` level if needed.
 

--- a/versioned_docs/version-1.34/core/endpoints/private-endpoints.mdx
+++ b/versioned_docs/version-1.34/core/endpoints/private-endpoints.mdx
@@ -70,7 +70,7 @@ Private Endpoints generated this way follow the same rules and restrictions than
 
 :::
 
-### Advanced Scenarios
+**Advanced Scenarios**
 
 You can also use this feature with your own ingresses. This is useful when you have more complex configurations, or when you only want to protect a subset of your application's endpoints.
 
@@ -127,7 +127,7 @@ services:
       - 8080:8080
 ```
 
-### Advanced Scenarios
+**Advanced Scenarios**
 
 You can also define this at the `endpoint` level if needed.
 


### PR DESCRIPTION
Headers nested in the tabs of the private endpoints page created dead anchor links in the sidebar. Replacing these so there is no confusion.