### PR TITLE
Add documentation for buildkit.service.loadBalancerSourceRanges

### DIFF
--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -210,6 +210,7 @@ The build service. It's used in combination with `okteto build` to build contain
 - `serviceAccount.name`: Buildkit service account name. Defaults to `okteto-buildkit`.
 - `serviceAccount.annotations`: Annotations for the buildkit service account.
 - `serviceAccount.labels`: Labels for the buildkit service account.
+- `service.loadBalancerSourceRanges`: List of CIDR blocks allowed to access the BuildKit service when using a LoadBalancer. Defaults to `[]`. Ignored for other service types.
 - `persistence.enabled`: Configures a persistence volume for buildkit. Enabled by default.
 - `persistence.class`: The storage class of the persistence volume attached to every buildkit pod.
 - `persistence.size`: The size of the persistence volume attached to every buildkit pod. Defaults to `750Gi`.


### PR DESCRIPTION
This documents the `buildkit.service.loadBalancerSourceRanges` option added to the Helm chart. 
It allows restricting access to the BuildKit service when exposed as a LoadBalancer.

Defaults to `[]`. Ignored for other service types.