### PR TITLE
Add documentation for the support of the field ReadOnlyRootFilesystem in the Okteto manifest

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -754,7 +754,7 @@ secrets:
 
 Allows you to override the pod security context of your development container.
 
-Okteto supports overriding the `fsGroup`, `runAsUser`, `runAsGroup`, `runAsNonRoot`, `allowPrivilegeEscalation` and `capabilities` values.
+Okteto supports overriding the `fsGroup`, `runAsUser`, `runAsGroup`, `runAsNonRoot`, `allowPrivilegeEscalation`, `readOnlyRootFilesystem` and `capabilities` values.
 They're not set by default, and they follow the [same syntax used in Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 ```yaml
@@ -764,6 +764,7 @@ securityContext:
   fsGroup: 3000
   runAsNonRoot: false
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
   capabilities:
     add:
       - SYS_PTRACE


### PR DESCRIPTION
Add documentation for the support of the field ReadOnlyRootFilesystem in the Okteto manifest as part of the `dev` section. This will be available in `3.11` version of the CLI