### PR TITLE
Changed instructions about the URls to configure when creating a github app

### DIFF
--- a/src/content/self-hosted/install/github.mdx
+++ b/src/content/self-hosted/install/github.mdx
@@ -42,8 +42,7 @@ Once this configuration has been completed, your instance of Okteto will use the
 1. Complete the following fields as follows:
    - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
    - `Homepage URL:` https://okteto.$SUBDOMAIN
-   - `Callback URL:` https://okteto.$SUBDOMAIN
-   - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
+   - `Callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.

--- a/versioned_docs/version-1.35/self-hosted/install/github.mdx
+++ b/versioned_docs/version-1.35/self-hosted/install/github.mdx
@@ -42,8 +42,7 @@ Once this configuration has been completed, your instance of Okteto will use the
 1. Complete the following fields as follows:
    - `GitHub App Name:` enter an appropriate name for your application (e.g. `okteto-$YOUR_GITHUB_ORGANIZATION`)
    - `Homepage URL:` https://okteto.$SUBDOMAIN
-   - `Callback URL:` https://okteto.$SUBDOMAIN
-   - `Authorization callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
+   - `Callback URL:` https://okteto.$SUBDOMAIN/auth/callback?origin=github (Necessary if you are going to use GitHub as your auth provider)
 1. Uncheck the `Expire user authorization tokens` option.
 1. Check the `Request user authorization (OAuth) during installation` option.
 1. On the `Post Installation` section, check the `Redirect on update` option.


### PR DESCRIPTION
GitHub App creation dialog doesn't have an `Authorization callback URL` field (it might had it in the past, but now it is not present). So, I'm changing it to add the callback URL, and set the one it should be in the `Authorization callback URL`