### PR TITLE
Update '30-day trial' to 'Free Tier (5 seats, 1 year)' across documentation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,7 +145,7 @@ module.exports = {
         },
         {
           href: 'https://www.okteto.com/free-trial',
-          label: 'Get Free Trial',
+          label: 'Get Started',
           position: 'right',
           target: '_self',
           className: 'Button teal GetFreeTrialButton',

--- a/src/content/admin/cleanup.mdx
+++ b/src/content/admin/cleanup.mdx
@@ -203,9 +203,7 @@ Namespaces and all the resources and data contained within will be deleted if th
 This only affects [Non-Personal Namespaces](core/namespaces.mdx), Personal Namespaces are not automatically deleted when idle.
 :::
 
-## Persistent resources {#persistent-resources}
-
-<TiersList tiers="Scale Enterprise Self-Hosted" />
+## Persistent resources <TiersList tiers="Scale Enterprise Self-Hosted" /> {#persistent-resources}
 
 In case you are interested in the Garbage Collector but you want to skip a specific Namespace, you can mark it as `persistent`.
 To do so, you can add the label `dev.okteto.com/persistent` to it or [use the Admin Dashboard](admin/dashboard.mdx#namespaces).

--- a/src/content/admin/cleanup.mdx
+++ b/src/content/admin/cleanup.mdx
@@ -203,7 +203,9 @@ Namespaces and all the resources and data contained within will be deleted if th
 This only affects [Non-Personal Namespaces](core/namespaces.mdx), Personal Namespaces are not automatically deleted when idle.
 :::
 
-## Persistent resources <TiersList tiers="Scale Enterprise Self-Hosted" />
+## Persistent resources {#persistent-resources}
+
+<TiersList tiers="Scale Enterprise Self-Hosted" />
 
 In case you are interested in the Garbage Collector but you want to skip a specific Namespace, you can mark it as `persistent`.
 To do so, you can add the label `dev.okteto.com/persistent` to it or [use the Admin Dashboard](admin/dashboard.mdx#namespaces).

--- a/src/content/archived-release-notes.mdx
+++ b/src/content/archived-release-notes.mdx
@@ -557,7 +557,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/src/content/get-started/install/amazon-eks.mdx
+++ b/src/content/get-started/install/amazon-eks.mdx
@@ -38,7 +38,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/src/content/get-started/install/civo.mdx
+++ b/src/content/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/src/content/get-started/install/digitalocean-doks.mdx
+++ b/src/content/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/src/content/get-started/install/google-gke.mdx
+++ b/src/content/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/src/content/get-started/install/microsoft-aks.mdx
+++ b/src/content/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
+- 🎁 [Sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -6,7 +6,7 @@ description: An overview of Okteto and how it helps teams build, test, and deplo
 ## Build modern development experiences with Okteto
 Okteto transforms the way developers code, test, and deploy applications by offering a seamless, cloud-native development experience. Say goodbye to the complexities of setting up local environments and the discrepancies between development and production. With Okteto, you get **ephemeral cloud-based environments**, **instant code sync**, **remote debugging**, and **built-in automations** all designed to improve developer productivity and platform team efficiency.
 
-[Start your 30-day free trial](https://www.okteto.com/free-trial/)
+[Start with our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 ## Why Platform Teams choose Okteto?
 
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Claim your free 30-day trial](https://www.okteto.com/free-trial/)
+- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/src/content/self-hosted/digitalocean/marketplace.md
+++ b/src/content/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/src/content/self-hosted/manage/okteto-license.mdx
+++ b/src/content/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.24/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.24/get-started/install/amazon-eks.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.24/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.24/get-started/install/civo.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.24/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.24/get-started/install/digitalocean-doks.mdx
@@ -29,7 +29,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.24/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.24/get-started/install/google-gke.mdx
@@ -29,7 +29,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.24/get-started/install/index.mdx
+++ b/versioned_docs/version-1.24/get-started/install/index.mdx
@@ -11,7 +11,7 @@ If you are interested in using Okteto's SaaS offering, you can ignore this page 
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## Deploying Okteto
 

--- a/versioned_docs/version-1.24/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.24/get-started/install/microsoft-aks.mdx
@@ -29,7 +29,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.24/index.md
+++ b/versioned_docs/version-1.24/index.md
@@ -38,4 +38,4 @@ Maximize efficiency and minimize costs with [Okteto's Garbage Collector](admin/c
 ## Get started today
 Jump into our [installation guide](get-started/install/index.mdx) to get started with Okteto. Or [Talk to us](https://okteto.com/schedule/) to let us show you how.
 
-Need a license key? [Sign-up for a free 30-day trial](https://www.okteto.com/free-trial/).
+Need a license key? [Sign-up for a Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/).

--- a/versioned_docs/version-1.24/release-notes.mdx
+++ b/versioned_docs/version-1.24/release-notes.mdx
@@ -615,7 +615,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.24/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.24/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.24/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.24/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.24/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.24/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.25/archived-release-notes.mdx
+++ b/versioned_docs/version-1.25/archived-release-notes.mdx
@@ -15,7 +15,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.25/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.25/get-started/install/amazon-eks.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.25/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.25/get-started/install/civo.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.25/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.25/get-started/install/digitalocean-doks.mdx
@@ -29,7 +29,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.25/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.25/get-started/install/google-gke.mdx
@@ -29,7 +29,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.25/get-started/install/index.mdx
+++ b/versioned_docs/version-1.25/get-started/install/index.mdx
@@ -11,7 +11,7 @@ If you are interested in using Okteto's SaaS offering, you can ignore this page 
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## Deploying Okteto
 

--- a/versioned_docs/version-1.25/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.25/get-started/install/microsoft-aks.mdx
@@ -29,7 +29,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.25/index.md
+++ b/versioned_docs/version-1.25/index.md
@@ -38,4 +38,4 @@ Maximize efficiency and minimize costs with [Okteto's Garbage Collector](admin/c
 ## Get started today
 Jump into our [installation guide](get-started/install/index.mdx) to get started with Okteto. Or [Talk to us](https://okteto.com/schedule/) to let us show you how.
 
-Need a license key? [Sign-up for a free 30-day trial](https://www.okteto.com/free-trial/).
+Need a license key? [Sign-up for a Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/).

--- a/versioned_docs/version-1.25/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.25/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.25/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.25/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.25/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.25/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.26/archived-release-notes.mdx
+++ b/versioned_docs/version-1.26/archived-release-notes.mdx
@@ -78,7 +78,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.26/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.26/get-started/install/amazon-eks.mdx
@@ -32,7 +32,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.26/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.26/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.26/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.26/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.26/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.26/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.26/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.26/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.26/index.md
+++ b/versioned_docs/version-1.26/index.md
@@ -38,4 +38,4 @@ Maximize efficiency and minimize costs with [Okteto's Garbage Collector](admin/c
 ## Get started today
 Jump into our [installation guide](get-started/install/index.mdx) to get started with Okteto. Or [Talk to us](https://okteto.com/schedule/) to let us show you how.
 
-Need a license key? [Sign-up for a free 30-day trial](https://www.okteto.com/free-trial/).
+Need a license key? [Sign-up for a Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/).

--- a/versioned_docs/version-1.26/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.26/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.26/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.26/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.26/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.26/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.27/archived-release-notes.mdx
+++ b/versioned_docs/version-1.27/archived-release-notes.mdx
@@ -78,7 +78,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.27/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.27/get-started/install/amazon-eks.mdx
@@ -32,7 +32,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.27/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.27/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.27/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.27/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.27/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.27/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.27/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.27/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.27/index.md
+++ b/versioned_docs/version-1.27/index.md
@@ -38,4 +38,4 @@ Maximize efficiency and minimize costs with [Okteto's Garbage Collector](admin/c
 ## Get started today
 Jump into our [installation guide](get-started/install/index.mdx) to get started with Okteto. Or [Talk to us](https://okteto.com/schedule/) to let us show you how.
 
-Need a license key? [Sign-up for a free 30-day trial](https://www.okteto.com/free-trial/).
+Need a license key? [Sign-up for a Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/).

--- a/versioned_docs/version-1.27/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.27/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.27/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.27/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.27/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.27/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.28/archived-release-notes.mdx
+++ b/versioned_docs/version-1.28/archived-release-notes.mdx
@@ -114,7 +114,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.28/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.28/get-started/install/amazon-eks.mdx
@@ -32,7 +32,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.28/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.28/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.28/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.28/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.28/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.28/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.28/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.28/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.28/index.md
+++ b/versioned_docs/version-1.28/index.md
@@ -38,4 +38,4 @@ Maximize efficiency and minimize costs with [Okteto's Garbage Collector](admin/c
 ## Get started today
 Jump into our [installation guide](get-started/install/index.mdx) to get started with Okteto. Or [Talk to us](https://okteto.com/schedule/) to let us show you how.
 
-Need a license key? [Sign-up for a free 30-day trial](https://www.okteto.com/free-trial/).
+Need a license key? [Sign-up for a Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/).

--- a/versioned_docs/version-1.28/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.28/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.28/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.28/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.28/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.28/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.29/archived-release-notes.mdx
+++ b/versioned_docs/version-1.29/archived-release-notes.mdx
@@ -159,7 +159,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.29/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.29/get-started/install/amazon-eks.mdx
@@ -32,7 +32,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.29/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.29/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.29/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.29/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.29/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.29/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.29/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.29/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.29/index.md
+++ b/versioned_docs/version-1.29/index.md
@@ -38,4 +38,4 @@ Maximize efficiency and minimize costs with [Okteto's Garbage Collector](admin/c
 ## Get started today
 Jump into our [installation guide](get-started/install/index.mdx) to get started with Okteto. Or [Talk to us](https://okteto.com/schedule/) to let us show you how.
 
-Need a license key? [Sign-up for a free 30-day trial](https://www.okteto.com/free-trial/).
+Need a license key? [Sign-up for a Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/).

--- a/versioned_docs/version-1.29/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.29/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.29/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.29/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.29/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.29/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.30/archived-release-notes.mdx
+++ b/versioned_docs/version-1.30/archived-release-notes.mdx
@@ -185,7 +185,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.30/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.30/get-started/install/amazon-eks.mdx
@@ -32,7 +32,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.30/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.30/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.30/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.30/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.30/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.30/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.30/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.30/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.30/index.md
+++ b/versioned_docs/version-1.30/index.md
@@ -38,4 +38,4 @@ Maximize efficiency and minimize costs with [Okteto's Garbage Collector](admin/c
 ## Get started today
 Jump into our [installation guide](get-started/install/index.mdx) to get started with Okteto. Or [Talk to us](https://okteto.com/schedule/) to let us show you how.
 
-Need a license key? [Sign-up for a free 30-day trial](https://www.okteto.com/free-trial/).
+Need a license key? [Sign-up for a Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/).

--- a/versioned_docs/version-1.30/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.30/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.30/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.30/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.30/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.30/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.31/archived-release-notes.mdx
+++ b/versioned_docs/version-1.31/archived-release-notes.mdx
@@ -234,7 +234,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.31/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.31/get-started/install/amazon-eks.mdx
@@ -38,7 +38,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.31/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.31/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.31/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.31/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.31/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.31/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.31/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.31/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.31/index.md
+++ b/versioned_docs/version-1.31/index.md
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
+- 🎁 [Sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.31/index.md
+++ b/versioned_docs/version-1.31/index.md
@@ -6,7 +6,7 @@ description: An overview of Okteto and how it helps teams build, test, and deplo
 ## Build modern development experiences with Okteto
 Okteto transforms the way developers code, test, and deploy applications by offering a seamless, cloud-native development experience. Say goodbye to the complexities of setting up local environments and the discrepancies between development and production. With Okteto, you get **ephemeral cloud-based environments**, **instant code sync**, **remote debugging**, and **built-in automations** all designed to improve developer productivity and platform team efficiency.
 
-[Start your 30-day free trial](https://www.okteto.com/free-trial/)
+[Start with our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 ## Why Platform Teams choose Okteto?
 
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Claim your free 30-day trial](https://www.okteto.com/free-trial/)
+- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.31/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.31/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.31/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.31/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.31/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.31/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.32/archived-release-notes.mdx
+++ b/versioned_docs/version-1.32/archived-release-notes.mdx
@@ -330,7 +330,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.32/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.32/get-started/install/amazon-eks.mdx
@@ -38,7 +38,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.32/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.32/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.32/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.32/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.32/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.32/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.32/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.32/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.32/index.md
+++ b/versioned_docs/version-1.32/index.md
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
+- 🎁 [Sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.32/index.md
+++ b/versioned_docs/version-1.32/index.md
@@ -6,7 +6,7 @@ description: An overview of Okteto and how it helps teams build, test, and deplo
 ## Build modern development experiences with Okteto
 Okteto transforms the way developers code, test, and deploy applications by offering a seamless, cloud-native development experience. Say goodbye to the complexities of setting up local environments and the discrepancies between development and production. With Okteto, you get **ephemeral cloud-based environments**, **instant code sync**, **remote debugging**, and **built-in automations** all designed to improve developer productivity and platform team efficiency.
 
-[Start your 30-day free trial](https://www.okteto.com/free-trial/)
+[Start with our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 ## Why Platform Teams choose Okteto?
 
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Claim your free 30-day trial](https://www.okteto.com/free-trial/)
+- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.32/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.32/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.32/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.32/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.32/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.32/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.33/archived-release-notes.mdx
+++ b/versioned_docs/version-1.33/archived-release-notes.mdx
@@ -382,7 +382,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.33/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.33/get-started/install/amazon-eks.mdx
@@ -38,7 +38,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.33/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.33/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.33/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.33/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.33/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.33/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.33/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.33/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.33/index.md
+++ b/versioned_docs/version-1.33/index.md
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
+- 🎁 [Sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.33/index.md
+++ b/versioned_docs/version-1.33/index.md
@@ -6,7 +6,7 @@ description: An overview of Okteto and how it helps teams build, test, and deplo
 ## Build modern development experiences with Okteto
 Okteto transforms the way developers code, test, and deploy applications by offering a seamless, cloud-native development experience. Say goodbye to the complexities of setting up local environments and the discrepancies between development and production. With Okteto, you get **ephemeral cloud-based environments**, **instant code sync**, **remote debugging**, and **built-in automations** all designed to improve developer productivity and platform team efficiency.
 
-[Start your 30-day free trial](https://www.okteto.com/free-trial/)
+[Start with our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 ## Why Platform Teams choose Okteto?
 
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Claim your free 30-day trial](https://www.okteto.com/free-trial/)
+- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.33/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.33/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.33/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.33/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.33/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.33/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.34/archived-release-notes.mdx
+++ b/versioned_docs/version-1.34/archived-release-notes.mdx
@@ -442,7 +442,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.34/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.34/get-started/install/amazon-eks.mdx
@@ -38,7 +38,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.34/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.34/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.34/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.34/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.34/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.34/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.34/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.34/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.34/index.md
+++ b/versioned_docs/version-1.34/index.md
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
+- 🎁 [Sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.34/index.md
+++ b/versioned_docs/version-1.34/index.md
@@ -6,7 +6,7 @@ description: An overview of Okteto and how it helps teams build, test, and deplo
 ## Build modern development experiences with Okteto
 Okteto transforms the way developers code, test, and deploy applications by offering a seamless, cloud-native development experience. Say goodbye to the complexities of setting up local environments and the discrepancies between development and production. With Okteto, you get **ephemeral cloud-based environments**, **instant code sync**, **remote debugging**, and **built-in automations** all designed to improve developer productivity and platform team efficiency.
 
-[Start your 30-day free trial](https://www.okteto.com/free-trial/)
+[Start with our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 ## Why Platform Teams choose Okteto?
 
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Claim your free 30-day trial](https://www.okteto.com/free-trial/)
+- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.34/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.34/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.34/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.34/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.34/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.34/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 

--- a/versioned_docs/version-1.35/archived-release-notes.mdx
+++ b/versioned_docs/version-1.35/archived-release-notes.mdx
@@ -495,7 +495,7 @@ This version is compatible with Kubernetes versions 1.24 to 1.26.
 
 ### Breaking Changes
 
-Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [30 day free trial](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
+Okteto requires you to use a valid license as part of the installation. If you were running a previous version of Okteto and you don't have a valid license, signup for our [Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/) or [reach out to us](https://www.okteto.com/contact/).
 
 ### Improvements
 

--- a/versioned_docs/version-1.35/get-started/install/amazon-eks.mdx
+++ b/versioned_docs/version-1.35/get-started/install/amazon-eks.mdx
@@ -38,7 +38,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.35/get-started/install/civo.mdx
+++ b/versioned_docs/version-1.35/get-started/install/civo.mdx
@@ -31,7 +31,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.35/get-started/install/digitalocean-doks.mdx
+++ b/versioned_docs/version-1.35/get-started/install/digitalocean-doks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.35/get-started/install/google-gke.mdx
+++ b/versioned_docs/version-1.35/get-started/install/google-gke.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.35/get-started/install/microsoft-aks.mdx
+++ b/versioned_docs/version-1.35/get-started/install/microsoft-aks.mdx
@@ -30,7 +30,7 @@ You'll also need the following:
 
 A license is mandatory to use Okteto. You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial](https://www.okteto.com/free-trial/). No credit card required.
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/). No credit card required.
 
 ## A Domain and the ability to create wildcard DNS records for it
 

--- a/versioned_docs/version-1.35/index.md
+++ b/versioned_docs/version-1.35/index.md
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
+- 🎁 [Sign up for our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.35/index.md
+++ b/versioned_docs/version-1.35/index.md
@@ -6,7 +6,7 @@ description: An overview of Okteto and how it helps teams build, test, and deplo
 ## Build modern development experiences with Okteto
 Okteto transforms the way developers code, test, and deploy applications by offering a seamless, cloud-native development experience. Say goodbye to the complexities of setting up local environments and the discrepancies between development and production. With Okteto, you get **ephemeral cloud-based environments**, **instant code sync**, **remote debugging**, and **built-in automations** all designed to improve developer productivity and platform team efficiency.
 
-[Start your 30-day free trial](https://www.okteto.com/free-trial/)
+[Start with our Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 ## Why Platform Teams choose Okteto?
 
@@ -60,6 +60,6 @@ Okteto is flexible enough to meet your deployment and compliance needs.
 
 - 🚀 [Follow the installation guide](get-started/install/index.mdx)
 - 🗓️ [Book a demo with our team](https://okteto.com/schedule/)
-- 🎁 [Claim your free 30-day trial](https://www.okteto.com/free-trial/)
+- 🎁 [Get your Free Tier (5 seats, 1 year)](https://www.okteto.com/free-trial/)
 
 Need help deciding which deployment model or feature fits best? [Contact us](https://okteto.com/schedule/) and we’ll walk you through it.

--- a/versioned_docs/version-1.35/self-hosted/digitalocean/marketplace.md
+++ b/versioned_docs/version-1.35/self-hosted/digitalocean/marketplace.md
@@ -77,7 +77,7 @@ clusters:
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial. No credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year). No credit card required](https://www.okteto.com/free-trial/).
 
 ### Authentication
 

--- a/versioned_docs/version-1.35/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.35/self-hosted/helm-configuration.mdx
@@ -11,7 +11,7 @@ id: helm-configuration
 
 You'll receive a license key as part of your subscription to Okteto. If you haven't received it, [please open a support ticket](https://okteto.com/support).
 
-If you are interested in evaluating Okteto, [sign up for our free 30 days trial, no credit card required](https://www.okteto.com/free-trial/).
+If you are interested in evaluating Okteto, [sign up for our Free Tier (5 seats, 1 year), no credit card required](https://www.okteto.com/free-trial/).
 
 ```yaml
 license: XXXXX

--- a/versioned_docs/version-1.35/self-hosted/manage/okteto-license.mdx
+++ b/versioned_docs/version-1.35/self-hosted/manage/okteto-license.mdx
@@ -23,16 +23,16 @@ This requirement also helps us know who's using our product for typical product 
 
 There are two ways to obtain a license from Okteto.
 
-1. Fill out the self-hosted [free trial form](https://www.okteto.com/free-trial/) on our website
+1. Fill out the self-hosted [Free Tier form](https://www.okteto.com/free-trial/) on our website
 1. [Contact us](https://www.okteto.com/get-demo/) to schedule a demo
 
-When you fill out the self-hosted free trial form you will automatically receive an email containing a trial license key. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
+When you fill out the self-hosted Free Tier form you will automatically receive an email containing a license key for your Free Tier access. This option does not require any interaction with Okteto or our teams and gives you the control and independence to try Okteto self-hosted on your schedule and at your own pace. This process and license key only works and provides access to the self-hosted version of Okteto.
 
-The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in a free trial of Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
+The alternative option of contacting us for a demo will get you in touch with someone from our team to guide you through a personalized demo and gives you the opportunity to ask questions and explore our product side-by-side with our knowledgeable team. This process can result in Free Tier access to Okteto SaaS or Self-Hosted, which provides you with additional flexibility to use Okteto in the way that best suits your needs.
 
 ## How to use the license
 
-If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the trial license for your SaaS instance.
+If you have opted to use Okteto SaaS then there is no action required of you. We will handle the generation, assignment, and configuration of the license for your SaaS instance.
 
 If you have opted to use Okteto Self-Hosted then you will need to add your license key to your `config.yaml`. If you do not yet have a license, please choose one of the methods [above](#how-to-obtain-a-license).
 


### PR DESCRIPTION
## 🤖 Okteto AI Agent PR

## Summary
This PR implements a strategic messaging change from "30-day trial" to "Free Tier (5 seats, 1 year)" across all Okteto documentation. This psychological change is designed to increase new user signups and create a built-in renewal touchpoint for sales after 1 year.

### Key Changes Made:
- ✅ **Updated messaging terminology** across all documentation versions (current + 1.24-1.35)
- ✅ **Fixed broken anchor link** in cleanup.mdx to resolve build issues
- ✅ **Maintained existing URL structure** (https://www.okteto.com/free-trial/)


### Files Updated:
- **Index pages**: Main index.md and all versioned index.md files
- **Installation guides**: AWS EKS, Google GKE, Microsoft AKS, Civo, DigitalOcean DOKS
- **Configuration files**: helm-configuration.mdx across all versions  
- **Release documentation**: archived-release-notes.mdx and release-notes.mdx files
- **Marketplace docs**: DigitalOcean marketplace.md files

### Scope:
- **📊 126+ files modified**
- **📈 Multiple incremental improvements**
- **🔢 13 documentation versions updated** (current + versions 1.24-1.35)

## Test plan
- [x] ✅ **Deployed and validated** in Okteto namespace
- [x] ✅ **Build process successful** - all broken links resolved
- [x] ✅ **Documentation site accessible** at deployed endpoint
- [x] ✅ **Terminology consistently updated** across all affected files
- [x] ✅ **English phrasing sounds natural** and conversational
- [x] ✅ **No functional changes** - only messaging updates
- [x] ✅ **Call-to-action language improved** for better user experience

## Deployment Status
✅ **Deployed and validated in Okteto namespace**

## Commit History
1. **Initial comprehensive update**: "30-day trial" → "Free Tier (5 seats, 1 year)"
2. **Anchor link fix**: Resolved broken documentation links
3. **English phrasing improvements**: Natural language refinements

🤖 Generated with Okteto AI Powered by Claude Code