### PR TITLE
Update Istio divert sample repo URL to okteto-community org

### DIFF
--- a/src/content/development/using-divert.mdx
+++ b/src/content/development/using-divert.mdx
@@ -403,4 +403,4 @@ Others can access your diverted environment using:
 
 - [Movies with Divert](https://github.com/okteto-community/movies-with-divert) - Multi-service example
 - [TacoShop with Divert Queues](https://github.com/okteto-community/tacoshop-with-divert-queues) - Queue routing patterns
-- [Divert with Istio Sample](https://github.com/okteto/divert-with-istio-sample) - Istio driver configuration
+- [Divert with Istio Sample](https://github.com/okteto-community/getting-started-with-divert-istio) - Istio driver configuration

--- a/src/tutorials/divert.mdx
+++ b/src/tutorials/divert.mdx
@@ -289,4 +289,4 @@ Congratulations! You've deployed your first diverted Development Environment ðŸš
 - Explore [Using Divert](/docs/development/using-divert/) for advanced configuration
 - Try [okteto up](/docs/development/containers/file-sync/) for live code synchronization
 - Check out the [TacoShop example](https://github.com/okteto-community/tacoshop-with-divert-queues) for queue-based architectures
-- Review the [Istio Divert sample](https://github.com/okteto/divert-with-istio-sample) if using Istio service mesh
+- Review the [Istio Divert sample](https://github.com/okteto-community/getting-started-with-divert-istio) if using Istio service mesh

--- a/versioned_docs/version-1.40/development/using-divert.mdx
+++ b/versioned_docs/version-1.40/development/using-divert.mdx
@@ -403,4 +403,4 @@ Others can access your diverted environment using:
 
 - [Movies with Divert](https://github.com/okteto-community/movies-with-divert) - Multi-service example
 - [TacoShop with Divert Queues](https://github.com/okteto-community/tacoshop-with-divert-queues) - Queue routing patterns
-- [Divert with Istio Sample](https://github.com/okteto/divert-with-istio-sample) - Istio driver configuration
+- [Divert with Istio Sample](https://github.com/okteto-community/getting-started-with-divert-istio) - Istio driver configuration

--- a/versioned_docs/version-1.40/self-hosted/install/divert/index.mdx
+++ b/versioned_docs/version-1.40/self-hosted/install/divert/index.mdx
@@ -96,7 +96,7 @@ namespace:
 
 ### Istio Installation
 
-See the [Istio Divert Sample](https://github.com/okteto/divert-with-istio-sample) for detailed installation instructions, including:
+See the [Istio Divert Sample](https://github.com/okteto-community/getting-started-with-divert-istio) for detailed installation instructions, including:
 
 - Installing Istio base, istiod, and ingress gateway
 - Configuring the Istio ingress for Okteto

--- a/versioned_docs/version-1.41/development/using-divert.mdx
+++ b/versioned_docs/version-1.41/development/using-divert.mdx
@@ -403,4 +403,4 @@ Others can access your diverted environment using:
 
 - [Movies with Divert](https://github.com/okteto-community/movies-with-divert) - Multi-service example
 - [TacoShop with Divert Queues](https://github.com/okteto-community/tacoshop-with-divert-queues) - Queue routing patterns
-- [Divert with Istio Sample](https://github.com/okteto/divert-with-istio-sample) - Istio driver configuration
+- [Divert with Istio Sample](https://github.com/okteto-community/getting-started-with-divert-istio) - Istio driver configuration

--- a/versioned_docs/version-1.41/self-hosted/install/divert/index.mdx
+++ b/versioned_docs/version-1.41/self-hosted/install/divert/index.mdx
@@ -96,7 +96,7 @@ namespace:
 
 ### Istio Installation
 
-See the [Istio Divert Sample](https://github.com/okteto/divert-with-istio-sample) for detailed installation instructions, including:
+See the [Istio Divert Sample](https://github.com/okteto-community/getting-started-with-divert-istio) for detailed installation instructions, including:
 
 - Installing Istio base, istiod, and ingress gateway
 - Configuring the Istio ingress for Okteto

--- a/versioned_docs/version-1.42/development/using-divert.mdx
+++ b/versioned_docs/version-1.42/development/using-divert.mdx
@@ -403,4 +403,4 @@ Others can access your diverted environment using:
 
 - [Movies with Divert](https://github.com/okteto-community/movies-with-divert) - Multi-service example
 - [TacoShop with Divert Queues](https://github.com/okteto-community/tacoshop-with-divert-queues) - Queue routing patterns
-- [Divert with Istio Sample](https://github.com/okteto/divert-with-istio-sample) - Istio driver configuration
+- [Divert with Istio Sample](https://github.com/okteto-community/getting-started-with-divert-istio) - Istio driver configuration

--- a/versioned_docs/version-1.43/development/using-divert.mdx
+++ b/versioned_docs/version-1.43/development/using-divert.mdx
@@ -403,4 +403,4 @@ Others can access your diverted environment using:
 
 - [Movies with Divert](https://github.com/okteto-community/movies-with-divert) - Multi-service example
 - [TacoShop with Divert Queues](https://github.com/okteto-community/tacoshop-with-divert-queues) - Queue routing patterns
-- [Divert with Istio Sample](https://github.com/okteto/divert-with-istio-sample) - Istio driver configuration
+- [Divert with Istio Sample](https://github.com/okteto-community/getting-started-with-divert-istio) - Istio driver configuration


### PR DESCRIPTION
## Summary
We currently link to a sample that hasn't been updated in two years. That sample also doesn't have 'okteto up' functionality. 

My suggestion is to replace with with https://github.com/okteto-community/getting-started-with-divert-istio. We could also use https://github.com/okteto-community/movies-with-divert-istio if we want something more complex. 


🤖 Generated with [Claude Code](https://claude.com/claude-code)