### PR TITLE
Fix installer CodeBlock: runner indented under installer

### DIFF
--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -517,7 +517,7 @@ The jobs that deploy your [development environments from Git](development/deploy
 - `extraInitContainers`: List of init containers to add to the installer job pods.
 
 <CodeBlock language="yaml">
-  {`installer:
+{`installer:
   runner:
     repository: okteto/pipeline-runner
     tag: ${variables.chartVersion}

--- a/versioned_docs/version-1.39/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.39/self-hosted/helm-configuration.mdx
@@ -517,7 +517,7 @@ The jobs that deploy your [development environments from Git](development/deploy
 - `extraInitContainers`: List of init containers to add to the installer job pods.
 
 <CodeBlock language="yaml">
-  {`installer:
+{`installer:
   runner:
     repository: okteto/pipeline-runner
     tag: ${variables.chartVersion}

--- a/versioned_docs/version-1.40/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.40/self-hosted/helm-configuration.mdx
@@ -517,7 +517,7 @@ The jobs that deploy your [development environments from Git](development/deploy
 - `extraInitContainers`: List of init containers to add to the installer job pods.
 
 <CodeBlock language="yaml">
-  {`installer:
+{`installer:
   runner:
     repository: okteto/pipeline-runner
     tag: ${variables.chartVersion}

--- a/versioned_docs/version-1.41/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.41/self-hosted/helm-configuration.mdx
@@ -517,7 +517,7 @@ The jobs that deploy your [development environments from Git](development/deploy
 - `extraInitContainers`: List of init containers to add to the installer job pods.
 
 <CodeBlock language="yaml">
-  {`installer:
+{`installer:
   runner:
     repository: okteto/pipeline-runner
     tag: ${variables.chartVersion}

--- a/versioned_docs/version-1.42/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.42/self-hosted/helm-configuration.mdx
@@ -517,7 +517,7 @@ The jobs that deploy your [development environments from Git](development/deploy
 - `extraInitContainers`: List of init containers to add to the installer job pods.
 
 <CodeBlock language="yaml">
-  {`installer:
+{`installer:
   runner:
     repository: okteto/pipeline-runner
     tag: ${variables.chartVersion}

--- a/versioned_docs/version-1.43/self-hosted/helm-configuration.mdx
+++ b/versioned_docs/version-1.43/self-hosted/helm-configuration.mdx
@@ -517,7 +517,7 @@ The jobs that deploy your [development environments from Git](development/deploy
 - `extraInitContainers`: List of init containers to add to the installer job pods.
 
 <CodeBlock language="yaml">
-  {`installer:
+{`installer:
   runner:
     repository: okteto/pipeline-runner
     tag: ${variables.chartVersion}


### PR DESCRIPTION
## Summary

- The `installer` code block example was incorrectly rendering `runner` at the same indentation level as `installer`
- Root cause: a 2-space text node before the JSX template expression (`` {`...`} ``) was prepended to the rendered content, giving `installer:` 2 spaces of indentation — matching `runner:`'s 2 spaces from the template literal
- Fix: remove the leading 2 spaces before `` {` `` so `installer:` renders at column 0 and `runner:` is visually indented beneath it

## Affected versions

`src/content` (next release) and versioned docs 1.39, 1.40, 1.41, 1.42.

## Test plan

- [ ] Verify the `installer` code block on the helm configuration page shows `runner` indented under `installer`
- [ ] Spot-check the same section in versioned docs (1.39–1.42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)