### PR TITLE
chore: granular COPY layers in Dockerfile for better build caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM node:22 as dev
+FROM node:22 AS dev
 
 WORKDIR /app
 
 COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install
 
-COPY --exclude=nginx . .
+FROM dev AS build
+COPY versioned_sidebars versioned_sidebars
+COPY versioned_docs versioned_docs
+COPY sidebarTutorials.js sidebars.js versions.json docusaurus.config.js ./
+COPY static static
+COPY src src
+
 RUN --mount=type=cache,target=./node_modules/.cache/webpack yarn build
 
-FROM bitnami/nginx as prod
+FROM bitnami/nginx AS prod
 COPY nginx/index.html  /app
-COPY --from=dev /app/build/docs /app/docs
+COPY --from=build /app/build/docs /app/docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,27 @@ COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install
 
 FROM dev AS build
+# Stable and large — cache early
+COPY static static
+# Changes on version releases
 COPY versioned_sidebars versioned_sidebars
 COPY versioned_docs versioned_docs
+# Config files — occasional changes
 COPY sidebarTutorials.js sidebars.js versions.json docusaurus.config.js ./
-COPY static static
-COPY src src
+# Theme/component code — changes less often than content
+COPY src/components src/components
+COPY src/icons src/icons
+COPY src/pages src/pages
+COPY src/styles src/styles
+COPY src/theme src/theme
+COPY src/tutorials src/tutorials
+# Content changes most frequently — last so all layers above stay cached
+COPY src/content src/content
 
-RUN --mount=type=cache,target=./node_modules/.cache/webpack yarn build
+RUN --mount=type=cache,target=/app/node_modules/.cache/webpack \
+    --mount=type=cache,target=/app/.docusaurus \
+    yarn build
 
 FROM bitnami/nginx AS prod
-COPY nginx/index.html  /app
+COPY nginx/index.html /app
 COPY --from=build /app/build/docs /app/docs


### PR DESCRIPTION
## Summary

- Replaces the single `COPY --exclude=nginx . .` with separate `COPY` instructions per directory
- Introduces an explicit `build` stage (split from the `dev` stage) to keep concerns separate
- Fixes the final `COPY --from=dev` to correctly reference `--from=build`

## Why

With a single monolithic `COPY`, any file change invalidates the entire layer and all subsequent ones. With granular `COPY` layers, Docker can cache each independently — a change to `src/` no longer busts the `versioned_docs/` or `static/` cache layers, which can be large and slow to transfer.

## Test plan

- [x] Dockerfile builds cleanly (validated via `okteto deploy` on the dependency upgrade branch)
- [x] Verify local `docker build` uses cached layers when only `src/` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)