### PR TITLE
ignore .git , .claude, node_modules and build foldes when developing with Okteto

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-node_modules
-build
+.claude
 .docusaurus
+.git
 .github
-Dockerfile
+build
+node_modules

--- a/.oktetoignore
+++ b/.oktetoignore
@@ -1,4 +1,8 @@
-node_modules
-build
+.claude
 .docusaurus
+.git
 .github
+build
+node_modules
+
+


### PR DESCRIPTION
The .git folder on this repository is pretty large (133MB+), and that makes building the docker image take longer than necessary. 