### PR TITLE
chore: improve AI agent discoverability

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Link = "</docs>; rel=\"service-doc\""
+
 [[redirects]]
   from = "/*/index.html"
   to = "/:splat/"

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+# Content Signals (https://contentsignals.org/)
+Content-Signal: ai-train=yes, search=yes, ai-input=yes


### PR DESCRIPTION
Add robots.txt with Content Signals directives and Link response headers to help AI agents discover and correctly interact with the docs site.