### PR TITLE
docs(manifest): document named commands form for destroy

### DIFF
--- a/src/content/reference/okteto-manifest.mdx
+++ b/src/content/reference/okteto-manifest.mdx
@@ -408,6 +408,14 @@ destroy:
   - helm uninstall movies
 ```
 
+You can name your commands with the following syntax:
+
+```yaml
+destroy:
+  - name: Uninstall Movies App
+    command: helm uninstall movies
+```
+
 Follow this document for a [list of variables](core/okteto-variables.mdx#runtime-environment-variables-injected-into-pods) available in your destroy commands.
 
 #### Destroy remotely (recommended) {#destroy-remotely}


### PR DESCRIPTION
## Summary
- The `deploy` section of the manifest reference documents both the bare-string list form and the `name:`/`command:` named form ([deploy with commands](https://www.okteto.com/docs/reference/okteto-manifest/#deploy-with-commands)).
- The `destroy` section only showed the bare-string form, even though `DestroyInfo.Commands` uses the same `DeployCommand` type and supports the named syntax identically.
- This PR adds a parity example to the destroy section, mirroring the deploy section's wording and YAML conventions, so users discover the named form without having to read the deploy docs to infer it.

## Test plan
- [ ] Verify the rendered destroy section shows the new "You can name your commands…" example directly after the basic `helm uninstall movies` snippet and before the `Destroy remotely` heading.
- [ ] Confirm anchors and surrounding links are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)