### PR TITLE
Add CLAUDE.md and AGENTS.md agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# Agent instructions for the Okteto docs
+
+This file is loaded automatically by Claude Code (and other agents that read `CLAUDE.md` / `AGENTS.md`) for every session in this repo. Read it before doing anything in this codebase.
+
+## Mandatory: read the style guide first
+
+Before editing **any** file under `src/content/`, `src/pages/`, `versioned_docs/`, or any `.mdx`/`.md` doc page, you must read [`STYLE_GUIDE.md`](STYLE_GUIDE.md) in full. It is the source of truth for voice, tone, page structure, formatting, and terminology. The rules below are a quick-reference subset — when in doubt, defer to `STYLE_GUIDE.md`.
+
+If `STYLE_GUIDE.md` is not present in the working tree (e.g. on an old branch), stop and tell the user before continuing.
+
+## Tone of voice — the rules agents miss most
+
+These patterns are the most common drift in agent-authored docs. Treat each as a hard "don't" and apply the substitution.
+
+**Banned words and phrases.** Do not use any of these unless quoting product copy verbatim:
+
+- `powerful`, `seamless`, `intelligent`, `foundational`, `comprehensive`, `robust`, `cutting-edge`, `enterprise-grade`
+- `Learn more →`, `Click here`, `Read more about`
+- `In this guide, you will learn...`, `In this section we will...`
+- `Before you start, it helps to understand...`, `Before diving in...`
+- `Useful for [X]` (describe what the feature does instead)
+- Stacked synonyms like `consistent, reproducible, and reliable` — pick one
+- Marketing phrases describing what the docs *contain* (e.g. `Guides, references, and tutorials.`)
+
+**Required patterns:**
+
+- Open every page with the subject (feature name or "Okteto") followed by what it does. No preamble.
+- Section headings are noun phrases (`Configuring the Garbage Collector`), not questions or imperatives.
+- Embed links inline. Never use standalone "Learn more" lines or arrow links.
+- Frontmatter `description` is one functional sentence. No marketing language.
+
+If you find yourself reaching for an adjective, ask whether it adds technical meaning. If not, cut it.
+
+## Capitalization canon — non-negotiable
+
+Use these exact spellings and capitalizations. The full table is in [`STYLE_GUIDE.md`](STYLE_GUIDE.md#terminology); the cases agents most often get wrong:
+
+| Term | Correct form | Notes |
+|------|--------------|-------|
+| Okteto product names | `Okteto CLI`, `Okteto Manifest`, `Okteto Registry`, `Okteto Build Service`, `Garbage Collector`, `Admin Dashboard`, `Okteto Test`, `Okteto AI`, `Okteto API` | Always capitalized. "the CLI" is OK after first reference. |
+| Manifest filename | `okteto.yaml` | Lowercase, code-formatted (backticks). The product name is `Okteto Manifest`. |
+| CLI commands | `okteto up`, `okteto deploy`, `okteto test`, `okteto build` | Lowercase, in backticks. |
+| Deployment models | `Self-Hosted`, `BYOC`, `SaaS` | All capitalized exactly as shown. `BYOC` is always uppercase. First reference: `Bring Your Own Cloud (BYOC)`. |
+| Environments | `Development Environment`, `Preview Environment`, `Development Container` | Capitalized when referring to the Okteto feature. Lowercase when generic. |
+| Namespaces | `Namespace` (Okteto) vs. `namespace` (generic Kubernetes) | Capitalization signals which one you mean. |
+| Roles | `Admin`, `Developer`, `Personal Access Token` | Capitalized when referring to the Okteto role. |
+| Features | `Divert`, `Remote Execution`, `File Sync`, `Volume Snapshot`, `Agentic Workflows` | Capitalized as feature names. |
+| Third-party | `Kubernetes`, `BuildKit`, `GitHub Actions`, `Docker Compose`, `Helm` | Match upstream casing. Never `k8s` in prose. |
+
+## Where docs live
+
+- `src/content/` — the **current** unreleased version. **All new content goes here.**
+- `versioned_docs/version-X.Y/` — frozen snapshots of past versions. Don't edit unless backporting an explicit fix.
+- `src/pages/` — top-level pages (archives, etc.).
+- `static/` — images and assets. Use the `+X.Y` filename suffix when an image only applies to specific versions (see [`README.md`](README.md#image)).
+- `src/content/variables.json` — version variables (`cliVersion`, `chartVersion`, etc.) used in MDX via the variables plugin.
+
+File extension is `.mdx` for content pages. Frontmatter requires a `description` field — write it per [`STYLE_GUIDE.md`](STYLE_GUIDE.md#frontmatter-description).
+
+## Pre-submit checklist
+
+Run through this before declaring any docs change complete:
+
+1. **Read the diff aloud.** Does any sentence start with preamble (`Before you start...`, `In this guide...`)? Cut it.
+2. **Grep your additions for banned words:** `powerful`, `seamless`, `intelligent`, `foundational`, `comprehensive`, `Learn more`, `Useful for`. None should appear.
+3. **Check every Okteto noun you introduced** against the capitalization canon above. `Self-Hosted` (not `self-hosted`), `BYOC` (not `byoc`), `okteto.yaml` in backticks, `Okteto CLI` (not `Okteto cli` or `okteto CLI`).
+4. **Verify links are inline**, not standalone "Learn more →" lines.
+5. **Confirm the frontmatter `description`** is a single functional sentence — no marketing copy.
+6. **Run `yarn build`** if you touched more than a single page. The build catches broken anchors and version mismatches.
+7. **For new feature docs:** confirm you opened with the subject + what it does, and that section headings are noun phrases.
+
+## Special workflows
+
+### Cutting a new docs version
+
+If the user asks you to release a new version of the docs, follow the [Quick Reference for Automation](README.md#quick-reference-for-automation) section in `README.md`. It lists every file to modify and the parameters involved. Do not improvise — the file count and order matter (versions.json, docusaurus.config.js, netlify.toml, archives.md, release-notes.mdx all need coordinated edits).
+
+### Building locally
+
+```
+yarn install
+yarn start    # dev server
+yarn build    # production build, used to catch broken links
+```
+
+### Commits
+
+Per `CONTRIBUTING.md`, commits must be signed off (`git commit -s`). Do not skip this — it's a DCO requirement.
+
+## When you're unsure
+
+Read [`STYLE_GUIDE.md`](STYLE_GUIDE.md) and grep existing docs for examples. The correct pattern almost always exists somewhere in `src/content/`. If a canonical pattern isn't clear, ask the user before inventing one — terminology and tone consistency are more important than speed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,21 @@ Reporting issues is a great way to help us improve the documentation! This isn't
 When adding new documentation, it'll be helpful to keep the following things in mind:
 
 - Communicating your changes before you start working
+- Following the [Documentation Style Guide](STYLE_GUIDE.md) for voice, tone, formatting, and terminology
 - [Signing off](#commit-and-push-your-changes) on all your git commits by running `git commit -s'
 
 Discussing your changes with the maintainers before you start writing is one of the most important steps, as this sets you in the right direction before you begin. The best way to communicate this is through a detailed GitHub issue. Another way to discuss changes with maintainers is using the [#okteto](https://kubernetes.slack.com/messages/CM1QMQGS0/) channel on the Kubernetes slack.
+
+#### Style and terminology
+
+All contributions — human or agent-authored — must follow the [Documentation Style Guide](STYLE_GUIDE.md). It covers:
+
+- Voice and tone (direct, factual, concise — no marketing language)
+- Page structure and frontmatter conventions
+- Capitalization for Okteto product names, environments, roles, and deployment models
+- Formatting for links, CLI commands, admonitions, and images
+
+Agents and automated tools working in this repository should also read [`CLAUDE.md`](CLAUDE.md) (also exposed as [`AGENTS.md`](AGENTS.md) for tools that follow that convention), which contains a quick-reference subset of the style guide and the pre-submit checklist.
 
 :::note
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,224 @@
+# Okteto Documentation Style Guide
+
+This guide covers voice, tone, formatting, and terminology for the Okteto docs. It applies to all content in `src/content/` and is the reference for both human contributors and automated tools.
+
+---
+
+## Voice and tone
+
+**Direct.** State what a thing is or does. Don't set it up first.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Before you start, it helps to understand... | _Start with what the feature is._ |
+| In this guide, you will learn how to... | _Start with what the feature does._ |
+| Understand what each role can do across the platform. | Okteto uses RBAC with two roles: Admin and Developer. |
+
+**Factual.** Describe behavior, not value. Reserve adjectives for cases where they add technical meaning.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Intelligent traffic routing | Routes traffic across microservice environments |
+| Powerful configuration | Central configuration for building and deploying |
+| Foundational building blocks | Core concepts |
+| Seamless development experience | _Describe the actual behavior instead._ |
+
+**Concise.** Don't pad descriptions with what every docs site contains.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Guides, references, and tutorials. | _Remove. It adds nothing._ |
+| Power your Okteto development experience. | _Remove or replace with specific capability._ |
+
+---
+
+## Page structure
+
+### Opening sentence
+
+Open with the subject — either the feature name or "Okteto" — followed by what it does. No preamble.
+
+**Pattern:** `[Feature] is/does/allows [what it does].`
+
+**Examples from the docs:**
+- *"Preview Environments automatically create a live, production-like instance of your application for every pull request."*
+- *"Every time you build your images with Okteto, your build is executed in a remote BuildKit server running in your cluster."*
+- *"The Okteto Garbage Collector (GC) allows Admins to optimize infrastructure usage by automatically scaling down or deleting inactive Namespaces."*
+
+### Frontmatter `description`
+
+Write a single functional sentence that describes what the page covers. Avoid marketing language.
+
+```yaml
+# Good
+description: The Okteto Build Service allows you to build your container images remotely.
+description: Manage Preview Environments from the Admin Dashboard.
+
+# Avoid
+description: Understand the foundational concepts that power your Okteto development experience.
+description: A comprehensive guide to getting the most out of Okteto.
+```
+
+### Section headings
+
+Use noun phrases, not imperative verbs or questions.
+
+| Avoid | Use instead |
+|-------|-------------|
+| How to configure the Garbage Collector | Configuring the Garbage Collector |
+| Why use Preview Environments? | (just write the section) |
+| Understanding namespaces | Namespaces |
+
+---
+
+## Formatting
+
+### Links
+
+Embed links in the flow of the sentence. Don't use standalone "Learn more" lines or arrows.
+
+```mdx
+# Good
+[Namespaces](core/namespaces.mdx) are isolated workspaces where development environments run.
+Okteto uses [role-based access control (RBAC)](core/user-roles-and-permissions.mdx) with two roles.
+
+# Avoid
+[Learn more about Namespaces →](core/namespaces.mdx)
+[Learn more about roles and permissions →](core/user-roles-and-permissions.mdx)
+```
+
+### Code and CLI
+
+Wrap all CLI commands, flags, file names, and code values in backticks.
+
+```mdx
+Run `okteto deploy` to deploy your application.
+The `okteto.yaml` file defines your development environment.
+Set the `--wait` flag to block until the deployment completes.
+```
+
+CLI commands are always lowercase: `okteto up`, `okteto deploy`, `okteto test`, `okteto build`.
+
+### Admonitions
+
+Use sparingly — each one interrupts reading flow.
+
+| Type | When to use |
+|------|-------------|
+| `:::note` | Extra context that doesn't fit inline. Most common. |
+| `:::tip` | Optional shortcut or best practice. |
+| `:::info` | Important distinction or clarification. |
+| `:::warning` | Action that could cause data loss, breakage, or unexpected behavior. |
+| `:::caution` | Destructive or irreversible action. |
+| `:::danger` | Reserved for security-critical warnings. |
+
+Don't use admonitions for content that reads naturally inline.
+
+### UI elements
+
+Bold UI labels exactly as they appear in the product.
+
+```mdx
+Navigate to **Admin → Garbage Collector** and click **Enable**.
+```
+
+### Images
+
+Always include descriptive `alt` text.
+
+```mdx
+<Image src={...} alt="BuildKit architecture diagram showing remote build flow" />
+```
+
+---
+
+## Terminology
+
+Use these terms exactly as written. Capitalization matters.
+
+### Okteto product names
+
+| Term | Notes |
+|------|-------|
+| **Okteto CLI** | Always "Okteto CLI", never "okteto CLI" or "the CLI" on first reference. "the CLI" is fine on subsequent references. |
+| **Okteto Manifest** | Capitalized as a product name. The file itself is `okteto.yaml` (lowercase, code-formatted). |
+| **Okteto Registry** | Capitalized. Never "the registry" on first reference. |
+| **Okteto Catalog** | Capitalized. |
+| **Okteto Insights** | Capitalized. |
+| **Okteto Test** | Capitalized as a product feature. The CLI command is `okteto test` (lowercase, code-formatted). |
+| **Okteto AI** | Capitalized. |
+| **Okteto API** | Capitalized. |
+| **Okteto Platform** | Capitalized when referring to the product as a whole. |
+| **Build Service** | Capitalized. Full form "Okteto Build Service" on first reference per page. |
+| **Garbage Collector** | Capitalized. Abbreviation "GC" is acceptable after first use. |
+| **Resource Manager** | Capitalized. |
+| **Admin Dashboard** | Capitalized. |
+
+### Environments
+
+| Term | When to use |
+|------|-------------|
+| **Development Environment** | Capitalized when referring to an Okteto Development Environment specifically. Lowercase "development environment" when referring to the concept generically. |
+| **Preview Environment** | Capitalized when referring to the Okteto feature. Lowercase when generic. |
+| **Namespace** | Capitalize when referring to an Okteto Namespace. Lowercase for generic Kubernetes namespace references. |
+| **Development Container** | Capitalized. |
+| **dev environment** | Lowercase. Informal shorthand — acceptable in tutorials and quickstarts, avoid in reference docs. |
+
+### Access and roles
+
+| Term | Notes |
+|------|-------|
+| **Admin** | Capitalized when referring to the Okteto role. |
+| **Developer** | Capitalized when referring to the Okteto role. Lowercase when referring to engineers in general. |
+| **Personal Access Token** | Capitalized. |
+
+### Platform concepts
+
+| Term | Notes |
+|------|-------|
+| **Divert** | Capitalized as an Okteto feature name. |
+| **Remote Execution** | Capitalized. |
+| **File Sync** | Capitalized. The underlying behavior is "file sync" (lowercase) when used as a verb phrase. |
+| **Volume Snapshot** | Capitalized when referring to the Okteto feature. |
+| **Agentic Workflows** | Capitalized as a section/feature name. |
+
+### Deployment models
+
+| Term | Notes |
+|------|-------|
+| **BYOC** | Always uppercase. Full form "Bring Your Own Cloud (BYOC)" on first reference per page. |
+| **Self-Hosted** | Always capitalized, hyphenated. |
+| **SaaS** | Always uppercase. |
+
+### Third-party terms
+
+| Term | Notes |
+|------|-------|
+| Kubernetes | Always capitalized. Never "k8s" in prose (acceptable in code/config). |
+| BuildKit | Capitalized per upstream project name. |
+| GitHub Actions | Capitalized per upstream. |
+| Docker Compose | Capitalized per upstream. |
+| Helm | Capitalized per upstream. |
+
+---
+
+## Common mistakes to avoid
+
+**Don't editorialize about what to do before using a feature:**
+> ~~Before you start building with Okteto, it helps to understand...~~
+
+**Don't use "learn more" as link text:**
+> ~~[Learn more about Namespaces →](core/namespaces.mdx)~~
+
+**Don't use "useful for" to describe a feature:**
+> ~~Useful for seeding development databases with realistic data.~~  
+> Volume snapshots let you initialize a persistent volume from a previous snapshot.
+
+**Don't stack synonyms to sound thorough:**
+> ~~consistent, reproducible, and reliable operations~~  
+> consistent, reproducible operations
+
+**Don't describe what documentation is:**
+> ~~Guides, references, and tutorials for Okteto.~~
+
+**Don't use "powerful" or "seamless"** unless quoting a specific technical property.


### PR DESCRIPTION
## Summary

Adds agent-facing instructions so Claude Code, Cursor, Codex, Aider, and other AI tools writing in this repo follow the same voice, tone, and terminology rules as human contributors.

- **`CLAUDE.md`** — entry point loaded automatically by Claude Code. Mandates reading [`STYLE_GUIDE.md`](https://github.com/okteto/docs/pull/1209) before any docs edit, then inlines a quick-reference subset of the rules agents most often miss: banned tone-of-voice phrases, capitalization canon for Okteto product names, and a pre-submit checklist. Also points at the [Quick Reference for Automation](README.md#quick-reference-for-automation) for version cuts.
- **`AGENTS.md`** — symlink to `CLAUDE.md` so tools following the `AGENTS.md` convention read identical content. One source, no drift.
- **`CONTRIBUTING.md`** — adds a "Style and terminology" section pointing both human and agent contributors at the style guide.

## Why this shape

Pure pointers ("see `STYLE_GUIDE.md`") work in theory but agents skim. Inlining the highest-impact subset (banned words, capitalization table, checklist) catches half-attention edits while keeping `STYLE_GUIDE.md` as the single canonical source humans also read. Avoids duplication of the full guide to prevent drift.

## Depends on

[#1209](https://github.com/okteto/docs/pull/1209) — `CLAUDE.md` references `STYLE_GUIDE.md`. Branched off `docs/style-guide` so this can merge cleanly after #1209.

## Test plan

- [ ] Skim `CLAUDE.md` and confirm the banned-word list and capitalization table match the conventions you actually want enforced
- [ ] Verify the symlink works (`cat AGENTS.md` should show the same content as `CLAUDE.md`)
- [ ] On a fresh Claude Code session in this repo, confirm `CLAUDE.md` loads and the agent references it before editing
- [ ] Optional follow-up (separate PR): add a CI grep linter that fails on banned words in changed `.mdx` files