### PR TITLE
docs(release-notes): add ingress-nginx OCI Important Note to 1.44.0

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -7,23 +7,16 @@ id: release-notes
 
 import Image from '@theme/Image';
 
-## 1.45.0
-
-[DATE TBD]
-
-This version is compatible with Kubernetes versions 1.33 to 1.35 \
-Okteto Chart release 1.45 is designed to work with [Okteto CLI 3.20.x](https://github.com/okteto/okteto/releases/tag/3.20.0)
-
-### Improvements {#improvements-1.45}
-
-- **Ingress NGINX distribution**: The `ingress-nginx` Helm dependency in the Okteto Chart is now sourced from Okteto's OCI fork at `ghcr.io/okteto/ingress-nginx-chart` instead of the upstream Helm repository. Standard installs and upgrades are unaffected because the dependency is packaged with the Okteto Chart, so the OCI registry is not contacted at install time. Workflows that re-resolve chart dependencies from source (for example, running `helm dep update` against the chart source, or configuring ArgoCD against the chart source repo) require Helm 3.8.0+ or ArgoCD 2.3.0+ for OCI support <!-- PLAT-1441, app#10160 -->
-
 ## 1.44.0
 
 8 May 2026
 
 This version is compatible with Kubernetes versions 1.33 to 1.35 \
 Okteto Chart release 1.44 is designed to work with [Okteto CLI 3.19.x](https://github.com/okteto/okteto/releases/tag/3.19.0)
+
+### Important Notes {#important-notes-1.44}
+
+- **Ingress NGINX distribution**: The `ingress-nginx` Helm dependency in the Okteto Chart is now sourced from Okteto's OCI fork at `ghcr.io/okteto/ingress-nginx-chart` instead of the upstream Helm repository. Standard installs and upgrades are unaffected because the dependency is packaged with the Okteto Chart, so the OCI registry is not contacted at install time. Workflows that re-resolve chart dependencies from source (for example, running `helm dep update` against the chart source, or configuring ArgoCD against the chart source repo) require Helm 3.8.0+ or ArgoCD 2.3.0+ for OCI support <!-- PLAT-1441, app#10160 -->
 
 ### New Features {#new-features-1.44}
 

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -7,6 +7,17 @@ id: release-notes
 
 import Image from '@theme/Image';
 
+## 1.45.0
+
+[DATE TBD]
+
+This version is compatible with Kubernetes versions 1.33 to 1.35 \
+Okteto Chart release 1.45 is designed to work with [Okteto CLI 3.20.x](https://github.com/okteto/okteto/releases/tag/3.20.0)
+
+### Improvements {#improvements-1.45}
+
+- **Ingress NGINX distribution**: The `ingress-nginx` Helm dependency in the Okteto Chart is now sourced from Okteto's OCI fork at `ghcr.io/okteto/ingress-nginx-chart` instead of the upstream Helm repository. Standard installs and upgrades are unaffected because the dependency is packaged with the Okteto Chart, so the OCI registry is not contacted at install time. Workflows that re-resolve chart dependencies from source (for example, running `helm dep update` against the chart source, or configuring ArgoCD against the chart source repo) require Helm 3.8.0+ or ArgoCD 2.3.0+ for OCI support <!-- PLAT-1441, app#10160 -->
+
 ## 1.44.0
 
 8 May 2026


### PR DESCRIPTION
## Summary

Adds an advisory note under **1.44.0 → Important Notes** for the ingress-nginx Helm dependency move to Okteto's OCI fork ([app#10160](https://github.com/okteto/app/pull/10160), [PLAT-1441](https://okteto.atlassian.net/browse/PLAT-1441)). Per Slack thread with @ifbyol, this is a customer-visibility call-out — no behavior change for standard installs/upgrades, but worth flagging for customers running source-resolved dependency workflows.

Picked **Important Notes** over **Improvements** because the change is advisory rather than an enhancement customers benefit from, matching the precedent set in 1.38.

The bullet:

> **Ingress NGINX distribution**: The \`ingress-nginx\` Helm dependency in the Okteto Chart is now sourced from Okteto's OCI fork at \`ghcr.io/okteto/ingress-nginx-chart\` instead of the upstream Helm repository. Standard installs and upgrades are unaffected because the dependency is packaged with the Okteto Chart, so the OCI registry is not contacted at install time. Workflows that re-resolve chart dependencies from source (for example, running \`helm dep update\` against the chart source, or configuring ArgoCD against the chart source repo) require Helm 3.8.0+ or ArgoCD 2.3.0+ for OCI support.

## Open question for reviewers

**Public vs. private GHCR package.** app#10160's description says the chart is published as a *private* GHCR package, but @ifbyol's Slack writeup describes it as public so customers can verify/audit. Worth confirming \`ghcr.io/okteto/ingress-nginx-chart\` is publicly readable before this URL goes out — otherwise customers clicking through hit an auth wall. Once confirmed, this PR is ready to un-draft.

## Test plan

- [ ] Confirm \`ghcr.io/okteto/ingress-nginx-chart\` is publicly readable (anonymous \`docker pull\` or browser-accessible)
- [ ] Un-draft once confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLAT-1441]: https://okteto.atlassian.net/browse/PLAT-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ