### PR TITLE
fix(styles): migrate Sass @import to @use and drop deprecated color functions

### DIFF
--- a/src/components/Feedback/styles.module.scss
+++ b/src/components/Feedback/styles.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/fonts.scss';
+@use '../../styles/fonts.scss' as *;
 
 .componentTitle {
   font-size: 1.1em;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,7 +1,7 @@
+@use 'circular-font.scss';
+@use 'colors.scss' as *;
+@use 'fonts.scss' as *;
 @import url('https://fonts.googleapis.com/css?family=Inconsolata:400,700&display=swap');
-@import 'circular-font.scss';
-@import 'colors.scss';
-@import 'fonts.scss';
 
 :root {
   --ifm-heading-color: #{$navy};
@@ -356,7 +356,7 @@ a.menu__link svg {
   // Override DocSearch v4 colors to match Okteto brand
   --docsearch-primary-color: #{$dark-green};
   --docsearch-highlight-color: #{$dark-green};
-  --docsearch-hit-highlight-color: rgba(#{red($dark-green)}, #{green($dark-green)}, #{blue($dark-green)}, 0.1);
+  --docsearch-hit-highlight-color: #{rgba($dark-green, 0.1)};
   --docsearch-focus-color: #{$green};
   --docsearch-logo-color: #{$dark-green};
 

--- a/src/theme/Button/styles.scss
+++ b/src/theme/Button/styles.scss
@@ -1,5 +1,5 @@
-@import '../../styles/colors.scss';
-@import '../../styles/fonts.scss';
+@use '../../styles/colors.scss' as *;
+@use '../../styles/fonts.scss' as *;
 
 a.Button,
 .Button {

--- a/src/theme/Card/styles.scss
+++ b/src/theme/Card/styles.scss
@@ -1,5 +1,5 @@
-@import '../../styles/colors.scss';
-@import '../../styles/fonts.scss';
+@use '../../styles/colors.scss' as *;
+@use '../../styles/fonts.scss' as *;
 
 .Card {
   position: relative;


### PR DESCRIPTION
## What

`yarn build` succeeded but printed a wall of Dart Sass deprecation warnings on every run, in two groups:

1. **`@import` rules are deprecated** (slated for removal in Dart Sass 3.0.0) — across five SCSS files that pulled in shared variable partials.
2. **Global color functions `red()`/`green()`/`blue()` are deprecated** — in `main.scss`, where a color was manually split into channels.

## Changes

| File | Change |
|------|--------|
| `src/styles/main.scss` | `@import` → `@use ... as *` for the partials; moved the Google Fonts `@import url(...)` (a plain CSS import, still valid) below the `@use` rules since `@use` must come first. Replaced `rgba(#{red(...)}, ...)` with `#{rgba($dark-green, 0.1)}` — matching the idiom already used elsewhere in the file. |
| `src/theme/Card/styles.scss` | `@import` → `@use ... as *` |
| `src/theme/Button/styles.scss` | `@import` → `@use ... as *` |
| `src/components/Feedback/styles.module.scss` | `@import` → `@use ... as *` |

The `as *` keeps the shared variables (`$navy`, `$dark-green`, `$normal-font`, etc.) in the global namespace, so no variable references elsewhere needed touching — the migration is behavior-preserving.

## Verification

`yarn build` now completes with zero SASS deprecation warnings and generates static files successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)