### PR TITLE
docs: add 1.46.0 release notes

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -16,13 +16,14 @@ Okteto Chart release 1.46 is designed to work with [Okteto CLI 3.21.x](https://g
 
 ### New Features {#new-features-1.46}
 
-- **Workload identity for Docker Compose services**: Docker Compose services now support a per-service `x-okteto-identity-token` directive. Okteto projects an audience-scoped, automatically refreshed Kubernetes ServiceAccount token into the running container, so a service can authenticate to a cloud provider through OIDC web-identity federation (for example, AWS STS) without static, manually rotated credentials. The directive is cloud-agnostic: Okteto manages only the token projection, and you set the provider variables such as `AWS_ROLE_ARN`, `AWS_REGION`, and `AWS_WEB_IDENTITY_TOKEN_FILE` per service. It applies only to services that declare it, and requires Okteto CLI 3.21.0 or later <!-- PROD-497, okteto/okteto#5064 -->
+- **Workload identity for Docker Compose services**: Docker Compose services now support a per-service [`x-okteto-identity-token`](reference/docker-compose.mdx#x-okteto-identity-token-object-optional) directive. Okteto projects an audience-scoped, automatically refreshed Kubernetes ServiceAccount token into the running container, so a service can authenticate to a cloud provider through OIDC web-identity federation (for example, AWS STS) without static, manually rotated credentials. The directive is cloud-agnostic: Okteto manages only the token projection, and you set the provider variables such as `AWS_ROLE_ARN`, `AWS_REGION`, and `AWS_WEB_IDENTITY_TOKEN_FILE` per service. It applies only to services that declare it, and requires Okteto CLI 3.21.0 or later <!-- PROD-497, okteto/okteto#5064 -->
 
 ### Improvements {#improvements-1.46}
 
 - **Linked pull request in the Preview Environment view**: The Preview Environment details view now shows the pull request associated with the environment. Previously this link appeared only in the Preview Environments list <!-- PROD-441, 10220 -->
 - **Chart version in the Help menu**: The Okteto Chart version is now shown in the Help menu for all users. This makes it easier to confirm the installed version when reporting an issue <!-- DEV-1388, 10192 -->
 - Upgraded the bundled ingress-nginx to address [CVE-2026-49975](https://github.com/okteto/app/pull/10229), a high-severity HTTP/2 vulnerability in the ingress-nginx controller <!-- PLAT-1500, 10229 -->
+- [Okteto CLI 3.21.0](https://github.com/okteto/okteto/releases/tag/3.21.0): The BuildKit readiness check timeout is now configurable through the [`OKTETO_BUILDKIT_READINESS_TIMEOUT`](reference/feature-flags.mdx) environment variable, with the default raised from 4 to 6 seconds. This prevents intermittent `context deadline exceeded` errors when building or deploying remotely over slow or high-latency connections <!-- DEV-1426, okteto/okteto#5057 -->
 
 ## 1.45.0
 

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -7,6 +7,23 @@ id: release-notes
 
 import Image from '@theme/Image';
 
+## 1.46.0
+
+3 July 2026
+
+This version is compatible with Kubernetes versions 1.33 to 1.35 \
+Okteto Chart release 1.46 is designed to work with [Okteto CLI 3.21.x](https://github.com/okteto/okteto/releases/tag/3.21.0)
+
+### New Features {#new-features-1.46}
+
+- **Workload identity for Docker Compose services**: Docker Compose services now support a per-service `x-okteto-identity-token` directive. Okteto projects an audience-scoped, automatically refreshed Kubernetes ServiceAccount token into the running container, so a service can authenticate to a cloud provider through OIDC web-identity federation (for example, AWS STS) without static, manually rotated credentials. The directive is cloud-agnostic: Okteto manages only the token projection, and you set the provider variables such as `AWS_ROLE_ARN`, `AWS_REGION`, and `AWS_WEB_IDENTITY_TOKEN_FILE` per service. It applies only to services that declare it, and requires Okteto CLI 3.21.0 or later <!-- PROD-497, okteto/okteto#5064 -->
+
+### Improvements {#improvements-1.46}
+
+- **Linked pull request in the Preview Environment view**: The Preview Environment details view now shows the pull request associated with the environment. Previously this link appeared only in the Preview Environments list <!-- PROD-441, 10220 -->
+- **Chart version in the Help menu**: The Okteto Chart version is now shown in the Help menu for all users. This makes it easier to confirm the installed version when reporting an issue <!-- DEV-1388, 10192 -->
+- Upgraded the bundled ingress-nginx to address [CVE-2026-49975](https://github.com/okteto/app/pull/10229), a high-severity HTTP/2 vulnerability in the ingress-nginx controller <!-- PLAT-1500, 10229 -->
+
 ## 1.45.0
 
 5 June 2026


### PR DESCRIPTION
## What

Adds the **Chart 1.46.0 / CLI 3.21.0** release notes (target release July 2026) to `src/content/release-notes.mdx`.

### New Features
- **Workload identity for Docker Compose services** — new per-service `x-okteto-identity-token` directive (PROD-497, okteto/okteto#5064)

### Improvements
- Linked pull request in the Preview Environment details view (PROD-441, app#10220)
- Chart version shown in the Help menu for all users (DEV-1388, app#10192)
- ingress-nginx upgraded to address CVE-2026-49975, high-severity HTTP/2 vulnerability (PLAT-1500, app#10229)

## Notes
- Generated from `okteto/release` (`relo`) comparing `chart/1.45.0…chart/1.46.0-rc.6` plus the CLI `3.21.0-beta.1` release, then curated to the same pattern as 1.45.
- **Gateway API and PostHog work is intentionally excluded** — those workstreams are tracked internally for now.
- `yarn build` passes (Node 22), so no broken links/anchors.
- The CLI `3.21.x` link resolves once 3.21.0 ships (currently `3.21.0-beta.1`).

## Follow-up
- Add a reference entry for `x-okteto-identity-token` in `reference/docker-compose.mdx` before GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
