### PR TITLE
docs: add late CLI 3.21 changes to 1.46 release notes (destroy --all, OKTETO_IS_REDEPLOY)

### DIFF
--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -24,7 +24,6 @@ Okteto Chart release 1.46 is designed to work with [Okteto CLI 3.21.x](https://g
 - **Chart version in the Help menu**: The Okteto Chart version is now shown in the Help menu for all users. This makes it easier to confirm the installed version when reporting an issue <!-- DEV-1388, 10192 -->
 - Upgraded the bundled ingress-nginx to address [CVE-2026-49975](https://github.com/okteto/app/pull/10229), a high-severity HTTP/2 vulnerability in the ingress-nginx controller <!-- PLAT-1500, 10229 -->
 - [Okteto CLI 3.21.0](https://github.com/okteto/okteto/releases/tag/3.21.0): The BuildKit readiness check timeout is now configurable through the [`OKTETO_BUILDKIT_READINESS_TIMEOUT`](reference/feature-flags.mdx) environment variable, with the default raised from 4 to 6 seconds. This prevents intermittent `context deadline exceeded` errors when building or deploying remotely over slow or high-latency connections <!-- DEV-1426, okteto/okteto#5057 -->
-- [Okteto CLI 3.21.0](https://github.com/okteto/okteto/releases/tag/3.21.0): Added the `OKTETO_IS_REDEPLOY` environment variable, which lets an installer explicitly signal whether an `okteto deploy` is a first-time deploy or a redeploy of an existing Development Environment, instead of inferring it from the pipeline state. When the variable is unset, detection behavior is unchanged <!-- okteto/okteto#5076 -->
 
 ### Bug Fixes {#bug-fixes-1.46}
 

--- a/src/content/release-notes.mdx
+++ b/src/content/release-notes.mdx
@@ -24,6 +24,11 @@ Okteto Chart release 1.46 is designed to work with [Okteto CLI 3.21.x](https://g
 - **Chart version in the Help menu**: The Okteto Chart version is now shown in the Help menu for all users. This makes it easier to confirm the installed version when reporting an issue <!-- DEV-1388, 10192 -->
 - Upgraded the bundled ingress-nginx to address [CVE-2026-49975](https://github.com/okteto/app/pull/10229), a high-severity HTTP/2 vulnerability in the ingress-nginx controller <!-- PLAT-1500, 10229 -->
 - [Okteto CLI 3.21.0](https://github.com/okteto/okteto/releases/tag/3.21.0): The BuildKit readiness check timeout is now configurable through the [`OKTETO_BUILDKIT_READINESS_TIMEOUT`](reference/feature-flags.mdx) environment variable, with the default raised from 4 to 6 seconds. This prevents intermittent `context deadline exceeded` errors when building or deploying remotely over slow or high-latency connections <!-- DEV-1426, okteto/okteto#5057 -->
+- [Okteto CLI 3.21.0](https://github.com/okteto/okteto/releases/tag/3.21.0): Added the `OKTETO_IS_REDEPLOY` environment variable, which lets an installer explicitly signal whether an `okteto deploy` is a first-time deploy or a redeploy of an existing Development Environment, instead of inferring it from the pipeline state. When the variable is unset, detection behavior is unchanged <!-- okteto/okteto#5076 -->
+
+### Bug Fixes {#bug-fixes-1.46}
+
+- [Okteto CLI 3.21.0](https://github.com/okteto/okteto/releases/tag/3.21.0): Fixed `okteto destroy --all` hanging until it timed out, and reporting a false error, when run against a Sleeping Namespace. The command now completes and leaves the Namespace in its previous status <!-- okteto/okteto#5072 -->
 
 ## 1.45.0
 


### PR DESCRIPTION
## What

Follow-up to #1280. Adds two **late CLI 3.21 changes** to the 1.46 release notes that our initial review missed — the CLI advanced from `3.21.0-beta.1` (what we reviewed) to `3.21.0` final, and these landed in between (both merged after beta.1; one is `release/internal`-labeled so it was filtered from the generated changelog).

### Bug Fixes
- `okteto destroy --all` no longer hangs until timeout (with a false "deploy didn't finish" error) when run against a **Sleeping** Namespace; it now completes and preserves the Namespace's previous status ([okteto/okteto#5072](https://github.com/okteto/okteto/pull/5072), backend [okteto/app#9902](https://github.com/okteto/app/pull/9902))

### Improvements
- New `OKTETO_IS_REDEPLOY` environment variable lets an installer explicitly signal first-deploy vs. redeploy instead of inferring it from pipeline state ([okteto/okteto#5076](https://github.com/okteto/okteto/pull/5076))

## Notes
- `yarn build` passes (Node 22).
- `OKTETO_IS_REDEPLOY` is not yet in the Feature Flags reference, so it's shown in backticks without a link — worth a follow-up reference entry.
- Verify the shipped Chart 1.46 bundles **CLI 3.21.0 final** (the RC pinned `3.21.0-beta.1`), otherwise these fixes won't be in the bundled CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
