### PR TITLE
Prepare variables for version 1.47 development

### DIFF
--- a/src/content/variables.json
+++ b/src/content/variables.json
@@ -1,7 +1,7 @@
 {
   "kubernetesMinVersion": "1.33",
   "kubernetesMaxVersion": "1.35",
-  "cliVersion": "3.21.0",
-  "chartVersion": "1.46.0",
+  "cliVersion": "3.22.0",
+  "chartVersion": "1.47.0",
   "syncthingVersion": "2.1.1"
 }


### PR DESCRIPTION
## What

Bumps `src/content/variables.json` for the 1.47 development cycle, per the post-release steps in the README:

- `cliVersion` → 3.22.0 (expected next CLI version)
- `chartVersion` → 1.47.0

`syncthingVersion` and the Kubernetes range are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)