### PR TITLE
feat(llms): surface llms.txt on every page for coding agents

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,11 +21,63 @@ function rehypeStripHashLinks() {
   return (tree) => walk(tree);
 }
 
+// Docs origin and base path (also used for url/baseUrl in module.exports below).
+const SITE_URL = 'https://www.okteto.com';
+const BASE_URL = '/docs/';
+
+// Origin for the llms.txt pointer. On Netlify deploy previews / branch deploys
+// use the deploy's own URL (injected as DEPLOY_PRIME_URL) so the pointer
+// resolves to the preview instead of production; fall back to the production
+// origin for prod builds and local development. Building an absolute URL also
+// keeps Docusaurus's onBrokenLinks check from treating it as an internal route
+// (llms.txt is generated in postBuild, so no route exists for it at check time).
+const LLMS_ORIGIN =
+  process.env.CONTEXT && process.env.CONTEXT !== 'production'
+    ? process.env.DEPLOY_PRIME_URL || SITE_URL
+    : SITE_URL;
+const LLMS_TXT_URL = `${LLMS_ORIGIN}${BASE_URL.replace(/\/$/, '')}/llms.txt`;
+
+// Prepend a pointer to llms.txt at the top of every generated Markdown page so
+// that coding agents which fetch a page as Markdown can discover the full
+// documentation index. Linking the index (rather than crawling blindly) sharply
+// reduces an agent's wasted fetches and tokens.
+function remarkLlmsIndexPointer() {
+  return (tree) => {
+    tree.children.unshift({
+      type: 'blockquote',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'strong',
+              children: [{ type: 'text', value: 'Documentation Index' }],
+            },
+            {
+              type: 'text',
+              value: ': fetch the complete list of pages as Markdown at ',
+            },
+            {
+              type: 'link',
+              url: LLMS_TXT_URL,
+              children: [{ type: 'text', value: LLMS_TXT_URL }],
+            },
+            {
+              type: 'text',
+              value: ' to find the right page before exploring further.',
+            },
+          ],
+        },
+      ],
+    });
+  };
+}
+
 module.exports = {
   title: 'Okteto Documentation',
   tagline: 'Kubernetes for Developers',
-  url: 'https://www.okteto.com',
-  baseUrl: '/docs/',
+  url: SITE_URL,
+  baseUrl: BASE_URL,
   trailingSlash: true,
   organizationName: 'okteto', // Usually your GitHub org/user name.
   projectName: 'okteto', // Usually your repo name.
@@ -97,6 +149,16 @@ module.exports = {
       attributes: {
         name: 'theme-color',
         content: '#fff',
+      },
+    },
+    {
+      // Machine-readable pointer so agents crawling the HTML can find the index.
+      tagName: 'link',
+      attributes: {
+        rel: 'alternate',
+        type: 'text/plain',
+        title: 'llms.txt',
+        href: LLMS_TXT_URL,
       },
     },
   ],
@@ -231,6 +293,11 @@ module.exports = {
               href: 'https://www.okteto.com/pricing',
               target: '_self',
             },
+            {
+              label: 'llms.txt',
+              href: LLMS_TXT_URL,
+              target: '_self',
+            },
           ],
         },
         {
@@ -342,6 +409,7 @@ module.exports = {
           enableMarkdownFiles: true,
           enableLlmsFullTxt: true,
           beforeDefaultRehypePlugins: [rehypeStripHashLinks],
+          remarkPlugins: [remarkLlmsIndexPointer],
         },
       },
     ],


### PR DESCRIPTION
## Why

Following the [Mintlify llms.txt benchmark](https://www.mintlify.com/blog/llms-txt-agent-benchmark) ("linking the index wins, at a fraction of inlining's cost") and how [bun.sh](https://bun.sh/docs/runtime/file-types) does it, point agents at `llms.txt` from everywhere they might look.

## What

- **Every generated `.md` page** opens with a pointer (a small remark plugin passed to `docusaurus-plugin-llms-txt`):
  > **Documentation Index**: fetch the complete list of pages as Markdown at <…/docs/llms.txt> to find the right page before exploring further.
- **Every HTML page** gets a `<link rel="alternate" type="text/plain" title="llms.txt">` in `<head>` and a visible **llms.txt** footer link.

The pointer URL is built from the deploy's own origin (`DEPLOY_PRIME_URL` on Netlify preview/branch deploys, production otherwise), so it resolves against the environment serving the page rather than pinning to production. An absolute URL also keeps `onBrokenLinks: throw` from flagging it (llms.txt is generated in `postBuild`, so no route exists at check time).

## Impact

Benchmarking agent URL discovery, the `md` -> `md-link` arms (markdown vs markdown-with-an-llms.txt-pointer) showed the pointer cuts wasted fetches ~38% and tokens ~31%, and drives residual 404s to zero.

## Verification

`yarn build`: all 156 generated `.md` pages carry the pointer; the head + footer links render on every HTML page; build passes with `onBrokenLinks: throw`.

_Split out of #1296 (feature half). Independent of the link-path bug fix PR._