### PR TITLE
docs(agentic): document skill activation and repository instructions

### DIFF
--- a/src/content/agentic/autonomous-workflows.mdx
+++ b/src/content/agentic/autonomous-workflows.mdx
@@ -43,6 +43,22 @@ okteto context use https://okteto.example.com --token $OKTETO_TOKEN
 
 Store the token as a secret in your CI system (e.g., a GitHub Actions secret or GitLab CI variable). The agent then has the same CLI access as the token's owner.
 
+## Repository instructions
+
+The [plugin](agentic/index.mdx#installing-the-plugin) teaches the agent how to run this workflow, but the agent still decides when to reach for it by matching skill descriptions against the prompt (see [Skill activation](agentic/index.mdx#skill-activation)). A ticket that says "add a `/health` endpoint" carries no signal that the project deploys to Okteto, so the agent may implement the change and validate it locally without deploying anything.
+
+Add the expectation to the repository's agent instructions file (`CLAUDE.md` for Claude Code, `AGENTS.md` for most other agents), and the agent runs the deploy-test loop on every task:
+
+```markdown
+## Verifying changes
+
+This project deploys to Okteto. After implementing any change, verify it in an
+Okteto environment: deploy with `okteto deploy --wait` and run the test
+containers defined in `okteto.yaml` with `okteto test`.
+```
+
+For one-off runs, the prompt works too: "implement PROJ-123 and test the change in Okteto" activates the skill directly. The instructions file is what removes the need to say it every time.
+
 ## Workflow example: ticket to PR
 
 A CI pipeline or webhook triggers the agent with a ticket:

--- a/src/content/agentic/index.mdx
+++ b/src/content/agentic/index.mdx
@@ -73,6 +73,23 @@ The plugin installs two skills and one slash command:
 | `okteto-onboarding` skill | Discovers your services from Docker Compose files, Helm charts, Kubernetes manifests, or Dockerfiles; drafts an `okteto.yaml`; and validates it with `okteto validate`, `okteto build`, and `okteto deploy`. | The project has no `okteto.yaml` and you ask to set it up for Okteto. |
 | `/dev-setup` command | Validates the manifest, runs `okteto deploy --wait`, prints the environment URLs, and guides you into a dev session on the service you pick. | You run it. |
 
+## Skill activation
+
+Skills load on demand: the agent matches each skill's description against your prompt and against what it has already seen of the project. A prompt that mentions Okteto, or a session where the agent has already read `okteto.yaml`, activates the `okteto` skill. A generic prompt like "implement this feature" gives the agent no signal to look for Okteto, so it may write the code and validate it locally without ever deploying.
+
+To make Okteto verification part of every task instead of only Okteto-specific ones, add the expectation to your repository's agent instructions file — `CLAUDE.md` for Claude Code, `AGENTS.md` for most other agents:
+
+```markdown
+## Verifying changes
+
+This project deploys to Okteto. After implementing any change, verify it in an
+Okteto environment: deploy with `okteto deploy --wait` and run the test
+containers defined in `okteto.yaml` with `okteto test`. Use the okteto skill
+for all environment work.
+```
+
+The instructions file loads on every session, so the agent treats Okteto verification as part of the definition of done even when the prompt never mentions Okteto.
+
 ## Example prompts
 
 What you say to the agent determines what happens:

--- a/versioned_docs/version-1.46/agentic/autonomous-workflows.mdx
+++ b/versioned_docs/version-1.46/agentic/autonomous-workflows.mdx
@@ -43,6 +43,22 @@ okteto context use https://okteto.example.com --token $OKTETO_TOKEN
 
 Store the token as a secret in your CI system (e.g., a GitHub Actions secret or GitLab CI variable). The agent then has the same CLI access as the token's owner.
 
+## Repository instructions
+
+The [plugin](agentic/index.mdx#installing-the-plugin) teaches the agent how to run this workflow, but the agent still decides when to reach for it by matching skill descriptions against the prompt (see [Skill activation](agentic/index.mdx#skill-activation)). A ticket that says "add a `/health` endpoint" carries no signal that the project deploys to Okteto, so the agent may implement the change and validate it locally without deploying anything.
+
+Add the expectation to the repository's agent instructions file (`CLAUDE.md` for Claude Code, `AGENTS.md` for most other agents), and the agent runs the deploy-test loop on every task:
+
+```markdown
+## Verifying changes
+
+This project deploys to Okteto. After implementing any change, verify it in an
+Okteto environment: deploy with `okteto deploy --wait` and run the test
+containers defined in `okteto.yaml` with `okteto test`.
+```
+
+For one-off runs, the prompt works too: "implement PROJ-123 and test the change in Okteto" activates the skill directly. The instructions file is what removes the need to say it every time.
+
 ## Workflow example: ticket to PR
 
 A CI pipeline or webhook triggers the agent with a ticket:

--- a/versioned_docs/version-1.46/agentic/index.mdx
+++ b/versioned_docs/version-1.46/agentic/index.mdx
@@ -73,6 +73,23 @@ The plugin installs two skills and one slash command:
 | `okteto-onboarding` skill | Discovers your services from Docker Compose files, Helm charts, Kubernetes manifests, or Dockerfiles; drafts an `okteto.yaml`; and validates it with `okteto validate`, `okteto build`, and `okteto deploy`. | The project has no `okteto.yaml` and you ask to set it up for Okteto. |
 | `/dev-setup` command | Validates the manifest, runs `okteto deploy --wait`, prints the environment URLs, and guides you into a dev session on the service you pick. | You run it. |
 
+## Skill activation
+
+Skills load on demand: the agent matches each skill's description against your prompt and against what it has already seen of the project. A prompt that mentions Okteto, or a session where the agent has already read `okteto.yaml`, activates the `okteto` skill. A generic prompt like "implement this feature" gives the agent no signal to look for Okteto, so it may write the code and validate it locally without ever deploying.
+
+To make Okteto verification part of every task instead of only Okteto-specific ones, add the expectation to your repository's agent instructions file — `CLAUDE.md` for Claude Code, `AGENTS.md` for most other agents:
+
+```markdown
+## Verifying changes
+
+This project deploys to Okteto. After implementing any change, verify it in an
+Okteto environment: deploy with `okteto deploy --wait` and run the test
+containers defined in `okteto.yaml` with `okteto test`. Use the okteto skill
+for all environment work.
+```
+
+The instructions file loads on every session, so the agent treats Okteto verification as part of the definition of done even when the prompt never mentions Okteto.
+
 ## Example prompts
 
 What you say to the agent determines what happens:


### PR DESCRIPTION
## Why

Field report from Ramiro: he cloned [okteto/oktetodo](https://github.com/okteto/oktetodo), opened Claude Code, and asked it to implement a feature. The agent never used the okteto skill until told explicitly to test in Okteto. He then checked the [autonomous workflows page](https://www.okteto.com/docs/agentic/autonomous-workflows/) and found no guidance on making the agent pick up the skill — which is correct, there was none.

Skill activation is description-matching against the prompt, so a generic feature request carries no Okteto signal. The reliable pattern is a repo-level `CLAUDE.md`/`AGENTS.md` instruction that makes Okteto verification part of the definition of done. Our docs never said this.

## What

- **`agentic/index.mdx`**: new **Skill activation** section after the skills table — explains the activation mechanism, why generic prompts miss, and gives a copy-pasteable `CLAUDE.md`/`AGENTS.md` snippet.
- **`agentic/autonomous-workflows.mdx`**: new **Repository instructions** section — same pattern framed for ticket-driven runs, linking back to the index section.

`yarn build` passes (no broken links/anchors).

Related: okteto/okteto-claude-plugins#13 strengthens the plugin's SessionStart hook so sessions in Okteto projects get this nudge injected automatically — once that ships, a follow-up can document the hook here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)