### PR TITLE
docs: replace hardcoded okteto.com/docs URLs with internal links

### DIFF
--- a/src/content/admin/okteto-insights.mdx
+++ b/src/content/admin/okteto-insights.mdx
@@ -233,4 +233,4 @@ Only successful tests are tracked with `okteto_usage_test_duration_seconds`.
 
 ## Troubleshooting and Support
 ### Metric Server Availability
-Okteto Insights relies on the Kubernetes Metric Server. If the Metric Server is unavailable, requests to the `/metrics` endpoint, like requests from a [configured scraper](https://www.okteto.com/docs/admin/okteto-insights/#set-up-the-dashboards), will fail. You can troubleshoot the Metric Server or refer to the [documentation](https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-server) for further guidance.
+Okteto Insights relies on the Kubernetes Metric Server. If the Metric Server is unavailable, requests to the `/metrics` endpoint, like requests from a [configured scraper](admin/okteto-insights.mdx#set-up-the-dashboards), will fail. You can troubleshoot the Metric Server or refer to the [documentation](https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/#metrics-server) for further guidance.

--- a/src/content/admin/ssh-known-hosts.mdx
+++ b/src/content/admin/ssh-known-hosts.mdx
@@ -38,7 +38,7 @@ When a Git clone operation fails using one protocol, Okteto automatically attemp
 This fallback ensures public repositories remain accessible and doesn't compromise security, as HTTPS clones are secured through certificate authorities (CA) rather than known hosts.
 
 **Important:** For private repositories, authentication is required through at least one protocol. Configure either:
-- **SSH authentication:** Add known hosts entries and configure the [Okteto-generated SSH key](https://www.okteto.com/docs/admin/private-repositories/ssh-key/) in your Git provider
+- **SSH authentication:** Add known hosts entries and configure the [Okteto-generated SSH key](admin/private-repositories/ssh-key.mdx) in your Git provider
 - **HTTPS authentication:** Use our [GitHub App integration](admin/private-repositories/github.mdx)
 
 The fallback mechanism ensures deployment succeeds if either protocol is properly configured.

--- a/src/content/get-started/advanced-commands-and-concepts.mdx
+++ b/src/content/get-started/advanced-commands-and-concepts.mdx
@@ -100,4 +100,4 @@ Okteto's Preview Environments automatically generate a unique, shareable version
 
 - Follow this [tutorial to write your first Okteto Manifest](/get-started/deploy-your-app/index.mdx)
 - Join the [Okteto Community](https://community.okteto.com/) for additional help and updates
-- Check out our [Release Notes](https://www.okteto.com/docs/release-notes/) for monthly updates to Okteto
+- Check out our [Release Notes](release-notes.mdx) for monthly updates to Okteto

--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -57,7 +57,7 @@ Use this property to override the Public URL where Okteto is available. This opt
 publicOverride: "example.com"
 ```
 
-Once you set this in your Helm configuration file, make sure to point the Okteto Ingress Controller's IP address to this domain using your DNS provider. The IP address can be found by running the following command (like we did during the [install phase](https://www.okteto.com/docs/get-started/install/amazon-eks/#retrieve-the-ingress-controller-ip-address)):
+Once you set this in your Helm configuration file, make sure to point the Okteto Ingress Controller's IP address to this domain using your DNS provider. The IP address can be found by running the following command (like we did during the [install phase](get-started/install/amazon-eks.mdx#retrieve-the-ingress-controller-ip-address)):
 
 ```bash
 kubectl get service -l=app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller --namespace=okteto

--- a/src/content/self-hosted/install/volume-snapshots.mdx
+++ b/src/content/self-hosted/install/volume-snapshots.mdx
@@ -155,7 +155,7 @@ kubectl apply -f okteto-snapshot-sc.yaml
 
 ## Enabling Volume Snapshots
 
-To enable Volume Snapshots on your Okteto instance, update your `config.yaml` file with the following values, and run a [helm upgrade](https://okteto.com/docs/self-hosted/install/upgrade/#upgrade-your-okteto-enterprise-instance) to apply the new configuration.
+To enable Volume Snapshots on your Okteto instance, update your `config.yaml` file with the following values, and run a [helm upgrade](self-hosted/manage/upgrade.mdx#upgrade-your-okteto-instance) to apply the new configuration.
 
 See the [Volume Snapshots Helm configuration](self-hosted/helm-configuration.mdx#volumesnapshots) for all available settings.
 

--- a/src/content/self-hosted/manage/buildkit-high-performance.mdx
+++ b/src/content/self-hosted/manage/buildkit-high-performance.mdx
@@ -134,4 +134,4 @@ To make the most of your BuildKit configuration, we have the following recommend
 - Adhere to [Dockerfile best practices](https://docs.docker.com/build/building/best-practices/).
 - Reduce file transfer times to BuildKit by using [.dockerignore](https://docs.docker.com/reference/dockerfile/#dockerignore-file) and [.oktetoignore](core/remote-execution.mdx#ignoring-files) files.
 - Use [BuildKit cache mounts](https://docs.docker.com/build/cache/optimize/) to persist cache folders between image builds. This can significantly speed up build times by caching dependencies and build artifacts.
-- Use [Test Container caches](https://www.okteto.com/docs/reference/okteto-manifest/#caches-string-optional) to persist cache folders between test executions. This ensures that test dependencies are cached, reducing the time taken for subsequent test runs.
+- Use [Test Container caches](reference/okteto-manifest.mdx#caches-string-optional) to persist cache folders between test executions. This ensures that test dependencies are cached, reducing the time taken for subsequent test runs.


### PR DESCRIPTION
## What

Six pages in the current v1.47 docs (`src/content/`) linked to other documentation pages using absolute `https://www.okteto.com/docs/...` URLs instead of root-relative internal links. This converts all six to the internal `.mdx` link convention codified in `STYLE_GUIDE.md`.

## Why

Absolute self-referential URLs:
- **Bypass the `onBrokenLinks: 'throw'` build check** — they're treated as external, so a stale target isn't caught (as happened here, see below).
- **Break on Netlify preview deploys** — they send readers to production instead of the preview being reviewed.
- **Ignore the reader's version** — a reader on 1.47 gets bounced to the latest published version.

## Changes

| Page | Before (absolute) | After (internal) |
|------|-------------------|------------------|
| `admin/okteto-insights.mdx` | `.../admin/okteto-insights/#set-up-the-dashboards` | `admin/okteto-insights.mdx#set-up-the-dashboards` |
| `admin/ssh-known-hosts.mdx` | `.../admin/private-repositories/ssh-key/` | `admin/private-repositories/ssh-key.mdx` |
| `get-started/advanced-commands-and-concepts.mdx` | `.../release-notes/` | `release-notes.mdx` |
| `self-hosted/helm-configuration.mdx` | `.../get-started/install/amazon-eks/#retrieve-...` | `get-started/install/amazon-eks.mdx#retrieve-the-ingress-controller-ip-address` |
| `self-hosted/install/volume-snapshots.mdx` | `.../self-hosted/install/upgrade/#upgrade-your-okteto-enterprise-instance` | `self-hosted/manage/upgrade.mdx#upgrade-your-okteto-instance` |
| `self-hosted/manage/buildkit-high-performance.mdx` | `.../reference/okteto-manifest/#caches-string-optional` | `reference/okteto-manifest.mdx#caches-string-optional` |

**Note:** `self-hosted/install/volume-snapshots.mdx` was doubly broken — the page had moved (`self-hosted/install/upgrade` → `self-hosted/manage/upgrade`) *and* the anchor was stale (`#upgrade-your-okteto-enterprise-instance`; the heading is now "Upgrade your Okteto Instance"). Because the link was absolute, the build never flagged either.

## Validation

Every target page and `#anchor` was verified to resolve against the current `src/content/` tree. Scoped to v1.47 only; the same patterns exist in `versioned_docs/` snapshots but those are frozen and out of scope here.

Part of a broader docs cross-referencing review; this PR covers only the broken/hardcoded-link hygiene fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)