### PR TITLE
chore: update caniuse-lite (browserslist db)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3710,9 +3710,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001741:
-  version "1.0.30001760"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz"
-  integrity sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==
+  version "1.0.30001806"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz"
+  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
 
 ccount@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Problem

The production build logs a warning on every build:

```
Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:
  npx update-browserslist-db@latest
```

## Change

Bumps `caniuse-lite` from `1.0.30001760` to `1.0.30001806` (latest) in `yarn.lock`, clearing the warning. This is the exact change `npx update-browserslist-db@latest` produces for the `caniuse-lite` entry.

`package.json` is intentionally untouched: the tool's yarn v1 add/remove step tried to clobber the existing `baseline-browser-mapping` devDependency, so I reverted that side effect and kept only the `caniuse-lite` lockfile bump.

## Verification

- `git diff` is a single 3-line block change to the `caniuse-lite` entry in `yarn.lock`.
- The new integrity hash matches what the npm registry serves for `caniuse-lite@1.0.30001806`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)