### PR TITLE
docs(cli): explain optional devContainer argument for okteto up

### DIFF
--- a/src/content/reference/okteto-cli.mdx
+++ b/src/content/reference/okteto-cli.mdx
@@ -755,7 +755,7 @@ If needed, `okteto up` builds the images and runs the deploy commands defined in
 $ okteto up [devContainer]
 ```
 
-The `devContainer` argument is the name of a Development Container defined in the [`dev`](reference/okteto-manifest.mdx#dev-object-optional) section of your Okteto Manifest, and it is optional. When you specify it, Okteto activates that Development Container directly, without scanning the available Development Containers or asking you to pick one from a list. If you omit it and your manifest defines more than one Development Container, Okteto prompts you to choose.
+The `devContainer` argument is optional and it's the name of a Development Container defined in the [`dev`](reference/okteto-manifest.mdx#dev-object-optional) section of your Okteto Manifest. If you omit it, `okteto up` activates the only Development Container in your Okteto Manifest, or presents a selector when there's more than one.
 
 When you run `okteto up`, okteto scales to zero the specified deployment and creates a mirror deployment. The mirror deployment is a copy of the original deployment manifest with the following development-time improvements:
 

--- a/src/content/reference/okteto-cli.mdx
+++ b/src/content/reference/okteto-cli.mdx
@@ -755,6 +755,8 @@ If needed, `okteto up` builds the images and runs the deploy commands defined in
 $ okteto up [devContainer]
 ```
 
+The `devContainer` argument is the name of a Development Container defined in the [`dev`](reference/okteto-manifest.mdx#dev-object-optional) section of your Okteto Manifest, and it is optional. When you specify it, Okteto activates that Development Container directly, without scanning the available Development Containers or asking you to pick one from a list. If you omit it and your manifest defines more than one Development Container, Okteto prompts you to choose.
+
 When you run `okteto up`, okteto scales to zero the specified deployment and creates a mirror deployment. The mirror deployment is a copy of the original deployment manifest with the following development-time improvements:
 
 - Okteto overrides the container-level configuration of the original deployment with the values defined in your [Okteto Manifest](reference/okteto-manifest.mdx). A typical example of this is to replace the production container image with one that contains your development runtime.


### PR DESCRIPTION
The `okteto up` CLI reference showed the `okteto up [devContainer]` syntax but never explained the optional argument. This adds a short note in the `up` section clarifying that:

- The `devContainer` argument names a Development Container from the `dev` section of the Okteto Manifest, and it is optional.
- Passing it activates that Development Container directly, without scanning the available Development Containers or showing an interactive selector.
- Omitting it prompts you to choose when the manifest defines more than one Development Container.

No restructuring, just the added note.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)