### PR TITLE
docs: document the OKTETO_NAME environment variable

### DIFF
--- a/src/content/core/okteto-variables.mdx
+++ b/src/content/core/okteto-variables.mdx
@@ -233,6 +233,7 @@ The following environment variables are automatically injected by Okteto during 
 `OKTETO_DOMAIN` and `OKTETO_NAMESPACE` are available both at runtime in pods and during deployment operations.
 :::
 
+- **`OKTETO_NAME`**: The name of the Development Environment. It is also injected into the Development Container at runtime.
 - **`OKTETO_USERNAME`**: Your username in Okteto.
 - **`OKTETO_REGISTRY_URL`**: The URL of the Okteto Registry.
 - **`OKTETO_GIT_BRANCH`**: The name of the Git branch being deployed.


### PR DESCRIPTION
## What

Documents `OKTETO_NAME` in `src/content/core/okteto-variables.mdx`, adding it to the **Deployment Environment Variables** list.

Closes #449

## Why this placement

`OKTETO_NAME` is the name of the Development Environment (the `name` field of the Okteto Manifest, or the inferred name). It is:

- Available to the commands in the `deploy`, `destroy`, and `test` sections of the Okteto Manifest, including your scripts and tools. This matches the scope of the Deployment Environment Variables section.
- Also injected into the Development Container at runtime during `okteto up`, alongside `OKTETO_NAMESPACE`.

It is not part of the every-managed-pod set injected at runtime (`OKTETO_DOMAIN`, `OKTETO_NAMESPACE`, `OKTETO_MANAGED_POD`), so it does not belong in the "Runtime Environment Variables (Injected into Pods)" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
