### PR TITLE
docs(#379): convertLoadBalancedServices also converts NodePort

### DIFF
--- a/src/content/self-hosted/helm-configuration.mdx
+++ b/src/content/self-hosted/helm-configuration.mdx
@@ -797,7 +797,7 @@ autowake:
 
 ### convertLoadBalancedServices
 
-Converts services with type LoadBalancer into ClusterIP and automatically creates an ingress. Enabled by default.
+Converts services with type `LoadBalancer` or `NodePort` into `ClusterIP` and automatically creates an ingress. Services with type `ExternalName` are not affected. Enabled by default.
 
 ```yaml
 convertLoadBalancedServices:


### PR DESCRIPTION
Closes #379

The `convertLoadBalancedServices` section documented only `LoadBalancer` services. When enabled, `NodePort` services are also converted to `ClusterIP` (an ingress is created automatically); `ExternalName` services are not affected. This updates the section to reflect both.

Context: the original report on #379 (that `ExternalName` services get converted) is outdated. `ExternalName` is not converted; the remaining documentation gap was the missing `NodePort` case, which this addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)