### PR TITLE
docs(auth): document GitHub App org install requirement (#33)

### DIFF
--- a/src/content/self-hosted/install/auth/github.mdx
+++ b/src/content/self-hosted/install/auth/github.mdx
@@ -57,7 +57,7 @@ auth:
 [Upgrade your Okteto instance](self-hosted/manage/upgrade.mdx) for the new configuration to be applied.
 We recommend that you upgrade to the same version that you already have to minimize the changes and help you troubleshoot any issues.
 
-The `organization` field is optional. Only members of the organization will be allowed to log in into your Okteto instance. An empty `organization` field permits any user to log in.
+The `organization` field is optional but recommended. Setting it restricts login to members of the given GitHub organization, giving you finer control over who can access your Okteto instance. An empty `organization` field permits any user with a GitHub account to log in.
 
 :::warning
 If your Okteto instance is publicly reachable, we highly recommend that you set up access restrictions. Leaving the organization field blank lets anyone with a GitHub account log in to your Okteto instance.
@@ -77,7 +77,21 @@ auth:
     allowList: ["acct1","acct2","acct3"]
 ```
 
-We also have a video walking you through the steps on configuring GitHub as an authentication provider for your Okteto installation:
+## Installing the GitHub App in your organization
+
+When you set the `organization` field, Okteto verifies each user's GitHub organization membership at login and only admits members of that organization. To read that membership, the [Okteto GitHub App](self-hosted/install/github.mdx) must be installed in the organization you configured.
+
+GitHub only exposes a user's organization membership to an installed GitHub App that has the `Members` organization permission set to `Read-only`. The OAuth login flow does not require the App to be installed, so a login can complete while the membership check still fails. When the App is not installed in the configured organization, Okteto cannot confirm that a user belongs to it and rejects the login as unauthorized, even for members of the organization.
+
+To install the App, open `https://github.com/apps/YOUR_GITHUB_APP_NAME/installations/new` and select the organization you set in the `organization` field. This is the same GitHub App you configure for private repository access, so a single App covers both authentication and repository access.
+
+:::info
+The `organization` filter and the App installation must point to the same GitHub organization. If you change the `organization` value, install the App in the new organization as well.
+:::
+
+## Video walkthrough
+
+The following video walks you through configuring GitHub as an authentication provider for your Okteto instance:
 
 <iframe
   width="560"


### PR DESCRIPTION
## What

Documents the requirement, in the GitHub authentication provider guide, to install the Okteto GitHub App in the organization set in the `organization` filter. Also adds a recommendation to define `organization` for finer control over who can access the Okteto instance.

Fixes [#33](https://github.com/okteto/docs/issues/33).

## Why

When the `organization` filter is configured, Okteto only admits members of that GitHub organization at login. GitHub only exposes a user's org membership to an installed GitHub App that has the `Members` organization permission set to `Read-only`. The OAuth login flow does not require the App to be installed, so a login can complete while the membership check fails, rejecting legitimate org members as unauthorized. This was undocumented (context in the original support thread referenced by the issue).

## Changes

`src/content/self-hosted/install/auth/github.mdx`:
- Reframed the `organization` field as optional but recommended, noting it gives finer control over instance access.
- Added an **Installing the GitHub App in your organization** section explaining the requirement, why it is needed, and how to install the App (same App used for private repository access).
- Grouped the existing walkthrough video under a **Video walkthrough** heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)