### PR TITLE
docs: update plugins repo slug to okteto-agent-skills

### DIFF
--- a/src/content/agentic/index.mdx
+++ b/src/content/agentic/index.mdx
@@ -3,7 +3,7 @@ title: Agentic Workflows
 description: Install the Okteto plugin for Claude Code to give AI agents the knowledge to deploy, test, and debug code in Okteto environments
 ---
 
-AI agents are most effective when they can deploy code, run tests, and get feedback from real environments, not just read and write files locally. Okteto gives agents isolated, live environments driven by the same Okteto CLI and `okteto.yaml` that human developers use. The [Okteto plugin for Claude Code](https://github.com/okteto/okteto-claude-plugins) packages that knowledge as agent skills: install it once, and in any project your agent knows which commands to run, which to never run, and how to discover your services.
+AI agents are most effective when they can deploy code, run tests, and get feedback from real environments, not just read and write files locally. Okteto gives agents isolated, live environments driven by the same Okteto CLI and `okteto.yaml` that human developers use. The [Okteto plugin for Claude Code](https://github.com/okteto/okteto-agent-skills) packages that knowledge as agent skills: install it once, and in any project your agent knows which commands to run, which to never run, and how to discover your services.
 
 :::note
 Agentic Workflows are about bringing your own agent tooling to Okteto environments. To launch and manage agents from the Okteto Dashboard instead, see [Okteto AI](okteto-ai/index.mdx).
@@ -14,7 +14,7 @@ Agentic Workflows are about bringing your own agent tooling to Okteto environmen
 Run these commands in Claude Code:
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 
@@ -38,7 +38,7 @@ Platform teams can enable updates for an entire organization by adding the marke
     "okteto-plugins": {
       "source": {
         "source": "github",
-        "repo": "okteto/okteto-claude-plugins"
+        "repo": "okteto/okteto-agent-skills"
       },
       "autoUpdate": true
     }
@@ -56,10 +56,10 @@ This pre-installs the marketplace and the plugin for every developer and keeps b
 The skills are built on the open [Agent Skills](https://agentskills.io) format, so the same `okteto` and `okteto-onboarding` skills run in Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, and other compatible agents. Install them with the [`skills` CLI](https://github.com/vercel-labs/skills), which detects your agent and installs into it:
 
 ```bash
-npx skills add okteto/okteto-claude-plugins
+npx skills add okteto/okteto-agent-skills
 ```
 
-Agents that read a plain instruction file can use the tool-neutral `AGENTS.md` (or, for GitHub Copilot, `.github/copilot-instructions.md`) from the [plugin repository](https://github.com/okteto/okteto-claude-plugins) instead. These load the full guidance on every turn rather than on demand.
+Agents that read a plain instruction file can use the tool-neutral `AGENTS.md` (or, for GitHub Copilot, `.github/copilot-instructions.md`) from the [plugin repository](https://github.com/okteto/okteto-agent-skills) instead. These load the full guidance on every turn rather than on demand.
 
 The `/dev-setup` command ships only with the Claude Code plugin. Every other method carries the two skills.
 

--- a/versioned_docs/version-1.42/agentic/claude-code-plugin.mdx
+++ b/versioned_docs/version-1.42/agentic/claude-code-plugin.mdx
@@ -7,11 +7,11 @@ sidebar_label: Claude Code Plugin
 An agent that can only read and edit files locally is going to miss problems that only show up in a running environment. The Okteto plugin for Claude Code connects your agent to your Okteto environment so it can deploy services, run tests against real infrastructure, and iterate on failures using the same CLI and `okteto.yaml` that you already have.
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 
-Source: [okteto/okteto-claude-plugins](https://github.com/okteto/okteto-claude-plugins) on GitHub
+Source: [okteto/okteto-agent-skills](https://github.com/okteto/okteto-agent-skills) on GitHub
 
 Install the plugin once, and every project with an `okteto.yaml` just works. The agent learns which commands to use, which to avoid, and how to discover your project's services from the manifest. Without it, agents tend to build Docker images locally, run interactive commands that hang, or use kubectl directly. The plugin prevents all of that.
 
@@ -35,7 +35,7 @@ Before installing the plugin, make sure you have:
 Install the plugin from the Okteto marketplace:
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 

--- a/versioned_docs/version-1.42/agentic/index.mdx
+++ b/versioned_docs/version-1.42/agentic/index.mdx
@@ -49,7 +49,7 @@ Agents must never run `okteto up`.
 Install the [Claude Code Plugin for Okteto](agentic/claude-code-plugin.mdx):
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 

--- a/versioned_docs/version-1.43/agentic/claude-code-plugin.mdx
+++ b/versioned_docs/version-1.43/agentic/claude-code-plugin.mdx
@@ -7,11 +7,11 @@ sidebar_label: Claude Code Plugin
 An agent that can only read and edit files locally is going to miss problems that only show up in a running environment. The Okteto plugin for Claude Code connects your agent to your Okteto environment so it can deploy services, run tests against real infrastructure, and iterate on failures using the same CLI and `okteto.yaml` that you already have.
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 
-Source: [okteto/okteto-claude-plugins](https://github.com/okteto/okteto-claude-plugins) on GitHub
+Source: [okteto/okteto-agent-skills](https://github.com/okteto/okteto-agent-skills) on GitHub
 
 Install the plugin once, and every project with an `okteto.yaml` just works. The agent learns which commands to use, which to avoid, and how to discover your project's services from the manifest. Without it, agents tend to build Docker images locally, run interactive commands that hang, or use kubectl directly. The plugin prevents all of that.
 
@@ -35,7 +35,7 @@ Before installing the plugin, make sure you have:
 Install the plugin from the Okteto marketplace:
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 

--- a/versioned_docs/version-1.43/agentic/index.mdx
+++ b/versioned_docs/version-1.43/agentic/index.mdx
@@ -49,7 +49,7 @@ Agents must never run `okteto up`.
 Install the [Claude Code Plugin for Okteto](agentic/claude-code-plugin.mdx):
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 

--- a/versioned_docs/version-1.44/agentic/claude-code-plugin.mdx
+++ b/versioned_docs/version-1.44/agentic/claude-code-plugin.mdx
@@ -7,11 +7,11 @@ sidebar_label: Claude Code Plugin
 An agent that can only read and edit files locally is going to miss problems that only show up in a running environment. The Okteto plugin for Claude Code connects your agent to your Okteto environment so it can deploy services, run tests against real infrastructure, and iterate on failures using the same CLI and `okteto.yaml` that you already have.
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 
-Source: [okteto/okteto-claude-plugins](https://github.com/okteto/okteto-claude-plugins) on GitHub
+Source: [okteto/okteto-agent-skills](https://github.com/okteto/okteto-agent-skills) on GitHub
 
 Install the plugin once, and every project with an `okteto.yaml` just works. The agent learns which commands to use, which to avoid, and how to discover your project's services from the manifest. Without it, agents tend to build Docker images locally, run interactive commands that hang, or use kubectl directly. The plugin prevents all of that.
 
@@ -35,7 +35,7 @@ Before installing the plugin, make sure you have:
 Install the plugin from the Okteto marketplace:
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 

--- a/versioned_docs/version-1.44/agentic/index.mdx
+++ b/versioned_docs/version-1.44/agentic/index.mdx
@@ -49,7 +49,7 @@ Agents must never run `okteto up`.
 Install the [Claude Code Plugin for Okteto](agentic/claude-code-plugin.mdx):
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 

--- a/versioned_docs/version-1.45/agentic/index.mdx
+++ b/versioned_docs/version-1.45/agentic/index.mdx
@@ -3,7 +3,7 @@ title: Agentic Workflows
 description: Install the Okteto plugin for Claude Code to give AI agents the knowledge to deploy, test, and debug code in Okteto environments
 ---
 
-AI agents are most effective when they can deploy code, run tests, and get feedback from real environments, not just read and write files locally. Okteto gives agents isolated, live environments driven by the same Okteto CLI and `okteto.yaml` that human developers use. The [Okteto plugin for Claude Code](https://github.com/okteto/okteto-claude-plugins) packages that knowledge as agent skills: install it once, and in any project your agent knows which commands to run, which to never run, and how to discover your services.
+AI agents are most effective when they can deploy code, run tests, and get feedback from real environments, not just read and write files locally. Okteto gives agents isolated, live environments driven by the same Okteto CLI and `okteto.yaml` that human developers use. The [Okteto plugin for Claude Code](https://github.com/okteto/okteto-agent-skills) packages that knowledge as agent skills: install it once, and in any project your agent knows which commands to run, which to never run, and how to discover your services.
 
 :::note
 Agentic Workflows are about bringing your own agent tooling to Okteto environments. To launch and manage agents from the Okteto Dashboard instead, see [Okteto AI](okteto-ai/index.mdx).
@@ -14,7 +14,7 @@ Agentic Workflows are about bringing your own agent tooling to Okteto environmen
 Run these commands in Claude Code:
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 
@@ -38,7 +38,7 @@ Platform teams can enable updates for an entire organization by adding the marke
     "okteto-plugins": {
       "source": {
         "source": "github",
-        "repo": "okteto/okteto-claude-plugins"
+        "repo": "okteto/okteto-agent-skills"
       },
       "autoUpdate": true
     }

--- a/versioned_docs/version-1.46/agentic/index.mdx
+++ b/versioned_docs/version-1.46/agentic/index.mdx
@@ -3,7 +3,7 @@ title: Agentic Workflows
 description: Install the Okteto plugin for Claude Code to give AI agents the knowledge to deploy, test, and debug code in Okteto environments
 ---
 
-AI agents are most effective when they can deploy code, run tests, and get feedback from real environments, not just read and write files locally. Okteto gives agents isolated, live environments driven by the same Okteto CLI and `okteto.yaml` that human developers use. The [Okteto plugin for Claude Code](https://github.com/okteto/okteto-claude-plugins) packages that knowledge as agent skills: install it once, and in any project your agent knows which commands to run, which to never run, and how to discover your services.
+AI agents are most effective when they can deploy code, run tests, and get feedback from real environments, not just read and write files locally. Okteto gives agents isolated, live environments driven by the same Okteto CLI and `okteto.yaml` that human developers use. The [Okteto plugin for Claude Code](https://github.com/okteto/okteto-agent-skills) packages that knowledge as agent skills: install it once, and in any project your agent knows which commands to run, which to never run, and how to discover your services.
 
 :::note
 Agentic Workflows are about bringing your own agent tooling to Okteto environments. To launch and manage agents from the Okteto Dashboard instead, see [Okteto AI](okteto-ai/index.mdx).
@@ -14,7 +14,7 @@ Agentic Workflows are about bringing your own agent tooling to Okteto environmen
 Run these commands in Claude Code:
 
 ```bash
-/plugin marketplace add okteto/okteto-claude-plugins
+/plugin marketplace add okteto/okteto-agent-skills
 /plugin install okteto
 ```
 
@@ -38,7 +38,7 @@ Platform teams can enable updates for an entire organization by adding the marke
     "okteto-plugins": {
       "source": {
         "source": "github",
-        "repo": "okteto/okteto-claude-plugins"
+        "repo": "okteto/okteto-agent-skills"
       },
       "autoUpdate": true
     }
@@ -56,10 +56,10 @@ This pre-installs the marketplace and the plugin for every developer and keeps b
 The skills are built on the open [Agent Skills](https://agentskills.io) format, so the same `okteto` and `okteto-onboarding` skills run in Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, and other compatible agents. Install them with the [`skills` CLI](https://github.com/vercel-labs/skills), which detects your agent and installs into it:
 
 ```bash
-npx skills add okteto/okteto-claude-plugins
+npx skills add okteto/okteto-agent-skills
 ```
 
-Agents that read a plain instruction file can use the tool-neutral `AGENTS.md` (or, for GitHub Copilot, `.github/copilot-instructions.md`) from the [plugin repository](https://github.com/okteto/okteto-claude-plugins) instead. These load the full guidance on every turn rather than on demand.
+Agents that read a plain instruction file can use the tool-neutral `AGENTS.md` (or, for GitHub Copilot, `.github/copilot-instructions.md`) from the [plugin repository](https://github.com/okteto/okteto-agent-skills) instead. These load the full guidance on every turn rather than on demand.
 
 The `/dev-setup` command ships only with the Claude Code plugin. Every other method carries the two skills.
 


### PR DESCRIPTION
## What

Updates the Agentic Workflows docs page to the plugins repo's new name: **`okteto-claude-plugins` → `okteto-agent-skills`**.

## Why

The AI-agents plugins repo was renamed to a provider-neutral slug — its skills already run in Claude Code, Cursor, Codex, Copilot, and Gemini CLI via the open [Agent Skills](https://agentskills.io) format. GitHub's rename redirect keeps old links working, but the docs should show the canonical name.

## Scope

5 references on `src/content/agentic/index.mdx` (the current/next docs source): the `/plugin marketplace add` install command, the marketplace `repo` field, the `npx skills add` command, and two GitHub repo links.

## Intentionally NOT changed

- Frozen `versioned_docs/1.42–1.45` snapshots — published version history; the GitHub redirect keeps their commands working.
- The marketplace name `okteto-plugins`.
- The "Okteto plugin for Claude Code" wording in the intro/frontmatter — that's positioning copy, a separate editorial call.
