### PR TITLE
chore(seo): noindex archived docs versions (/docs/1.XX)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,18 @@
   [headers.values]
     Link = "</docs>; rel=\"service-doc\""
 
+# Keep archived documentation versions out of search engines.
+# The current docs live at /docs/... (no version segment) and stay indexed;
+# every numbered snapshot at /docs/1.XX/ is de-indexed. The trailing splat means
+# new versions are covered automatically, with no per-release change needed.
+# Note: we intentionally do NOT Disallow these in robots.txt. A crawler must be
+# allowed to fetch the page to see this header, and "follow" lets link equity
+# still flow to the current docs.
+[[headers]]
+  for = "/docs/1.*"
+  [headers.values]
+    X-Robots-Tag = "noindex, follow"
+
 [[redirects]]
   from = "/*/index.html"
   to = "/:splat/"


### PR DESCRIPTION
## What

Adds an `X-Robots-Tag: noindex, follow` response header (via `netlify.toml`) for every archived documentation version under `/docs/1.XX/`, so old versions stop showing up in search results.

## Why

Old versioned docs currently rank and appear in search alongside the current docs, sending people to outdated pages and diluting the canonical docs. Confirmed against production today: `/docs/1.42/` returns `200` with **no** `X-Robots-Tag`, i.e. fully indexable.

## How it behaves

- `okteto.com/docs/...` (current, unversioned) → **indexed** (untouched)
- `okteto.com/docs/1.XX/...` (any archived version) → **`noindex, follow`**

The rule is a single trailing-splat path (`for = "/docs/1.*"`), so every future monthly version is covered automatically, with no per-release edit.

## Notes / rationale

- `noindex` (not a `robots.txt Disallow`) is what actually removes pages from the index. We deliberately keep these pages **crawlable** so crawlers can see the header; a `Disallow` would hide the header and leave stale entries in the index.
- `follow` lets link equity still flow through to the current docs.
- The `/docs/`-prefixed path matches the way Netlify sees requests (verified: the existing `/docs/...` redirects fire in production).
- Once merged, worth requesting recrawl of the `/docs/1.*` prefix in Search Console to speed de-indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)