### PR TITLE
docs: drop banned word from BYOC vs. Self-Hosted page

### DIFF
--- a/src/content/byoc-vs-self-hosted.mdx
+++ b/src/content/byoc-vs-self-hosted.mdx
@@ -13,7 +13,7 @@ In addition to Okteto's [CLI](get-started/install-okteto-cli.mdx) we optionally 
 
 Additionally, you can use the Okteto CLI without using the Okteto Platform, but there are important considerations with that use case.
 
-Some examples of what the Okteto Platform manages are: [configuring variables](core/okteto-variables.mdx), adding [external resources](/docs/tutorials/external-resources) into your development environment, and build and push container images to the [Okteto Registry](core/container-registry.mdx). For a more comprehensive list of features, check out our [docs](self-hosted/index.mdx).
+Some examples of what the Okteto Platform manages are: [configuring variables](core/okteto-variables.mdx), adding [external resources](/docs/tutorials/external-resources) into your development environment, and build and push container images to the [Okteto Registry](core/container-registry.mdx). For the full list of features, see the [Self-Hosted documentation](self-hosted/index.mdx).
 
 # Important things to know
 


### PR DESCRIPTION
The SaaS deprecation cleanup in #1292 rewrote `saas-vs-self-hosted.mdx` into [`byoc-vs-self-hosted.mdx`](../blob/main/src/content/byoc-vs-self-hosted.mdx), but one line carried over a word `STYLE_GUIDE.md` bans:

```diff
- For a more comprehensive list of features, check out our [docs](self-hosted/index.mdx).
+ For the full list of features, see the [Self-Hosted documentation](self-hosted/index.mdx).
```

The new link text also names its target instead of using a generic "our docs".

Two pre-existing issues on the same page are intentionally left for a separate PR:

- The page is in no sidebar (`sidebars.js`, `sidebarTutorials.js`, `docusaurus.config.js`). Its only entry point is the inline link from `self-hosted/manage/okteto-license.mdx`.
- Its two section headings use `#` rather than `##`, so the page renders three H1s including the title.

No `yarn build` run — single-line prose change, no anchors or link targets altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)