### PR TITLE
docs(byoc/aws): remove stale CIDR filtering promise

### DIFF
--- a/src/content/byoc/aws/index.mdx
+++ b/src/content/byoc/aws/index.mdx
@@ -23,7 +23,7 @@ Before you start, ensure the following:
 AWS Account Requirements:
 - Use a **dedicated AWS account** exclusively for Okteto. No other workloads should run in this account.
 - Flexible Service Control Policies (SCPs): Okteto requires elevated permissions to provision and for our SRE team to operate infrastructure.
-- Disable VPC Block Public Access. Okteto uses internet-facing load balancers to expose applications. CIDR-based access controls will be available in a future release.
+- Disable VPC Block Public Access. Okteto uses internet-facing load balancers to expose applications. Okteto doesn't offer native CIDR-based ingress filtering; use AWS security groups or VPC network ACLs to restrict access by IP range.
 :::
 
 ## Step 1: Get the AWS IAM Role Assumption External ID


### PR DESCRIPTION
## Summary
- The BYOC-on-AWS installation requirements said "CIDR-based access controls will be available in a future release." That's no longer accurate — the original ingress-nginx-based implementation doesn't survive the move to Gateway API + dual load balancers, and there's no committed timeline for a replacement.
- Replaced the promise with the current, factual state and pointed customers at AWS-native alternatives (security groups / VPC network ACLs) for IP-based access restriction.

Context: came up in an internal thread re-evaluating IP-restriction support for a BYOC customer; confirmed with Provecho that the original approach is no longer valid.

## Test plan
- [x] `yarn build` not required (single-page content change, no links/anchors touched)
- [ ] Doc review for tone/terminology per STYLE_GUIDE.md