### PR TITLE
docs: strip tier badges from llms.txt link titles

### DIFF
--- a/patches/@signalwire+docusaurus-plugin-llms-txt+1.2.2.patch
+++ b/patches/@signalwire+docusaurus-plugin-llms-txt+1.2.2.patch
@@ -1,3 +1,51 @@
+diff --git a/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/title-extractor.js b/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/title-extractor.js
+index 57fd4af..82776fa 100644
+--- a/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/title-extractor.js
++++ b/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/title-extractor.js
+@@ -2,15 +2,41 @@
+  * Title extraction strategies
+  * Multiple strategies for extracting document titles from HTML
+  */
++import { select } from 'hast-util-select';
++import { toString } from 'hast-util-to-string';
+ import { DEFAULT_DOCUMENT_TITLE, HTML_SELECTORS } from '../constants';
+ import { selectText } from '../utils/html';
++/**
++ * Okteto's TiersList tier badges (`<div class="TiersList">…`) render inside
++ * the page h1. Title extraction runs on the raw HTML AST before any rehype
++ * plugins can strip them, so without this filter the badge labels concatenate
++ * into the title (e.g. "CatalogScaleEnterpriseSelf-Hosted").
++ */
++const isTierBadge = (node) => node.type === 'element' &&
++    node.tagName === 'div' &&
++    Array.isArray(node.properties?.className) &&
++    node.properties.className.includes('TiersList');
++const withoutTierBadges = (node) => {
++    if (!node.children) {
++        return node;
++    }
++    return {
++        ...node,
++        children: node.children
++            .filter((child) => !isTierBadge(child))
++            .map(withoutTierBadges),
++    };
++};
+ /**
+  * Extract title from first h1 element found anywhere on the page
+  * @internal
+  */
+ const extractFirstH1 = (tree) => {
+-    const firstH1 = selectText(tree, HTML_SELECTORS.H1);
+-    return firstH1 || null;
++    const h1 = select(HTML_SELECTORS.H1, tree);
++    if (!h1) {
++        return null;
++    }
++    return toString(withoutTierBadges(h1)).trim() || null;
+ };
+ /**
+  * Extract title from document title tag
 diff --git a/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/utils/url.js b/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/utils/url.js
 index 0c3168c..a9d91a0 100644
 --- a/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/utils/url.js


### PR DESCRIPTION
## What

Link titles in the generated `build/docs/llms.txt` concatenated tier-badge text, e.g. `- [CatalogScaleEnterpriseSelf-Hosted](/docs/admin/catalog.md)`.

The llms-txt plugin extracts each page title from the first h1 of the raw HTML AST **before** the rehype pipeline runs, so the `TiersList` badge markup rendered inside the h1 leaks into the title — and rehype-based stripping (like `rehypeStripTierBadges`) can't reach it.

## How

Extends the existing patch-package patch for `@signalwire/docusaurus-plugin-llms-txt` so `extractFirstH1` drops `div.TiersList` elements before reading the h1 text, using the same matcher as the `rehypeStripTierBadges` rehype plugin. Fallback behavior (plain h1, `<title>` tag) is unchanged.

## Verification

- Unit-level check against the installed plugin: badge-laden h1 extracted as `CatalogScaleEnterpriseSelf-Hosted` before the patch, `Catalog` after; plain-h1 and title-tag-fallback cases unchanged.
- Full `yarn build`: all nine badge-bearing pages (`admin/catalog`, `admin/cleanup`, `admin/dashboard`, `admin/previews`, `admin/private-repositories/ssh-key`, `development/deploy/deploy-from-catalog`, `get-started/install/openshift`, `reference/okteto-cli`, `self-hosted/manage/air-gapped`) now render clean titles in `build/docs/llms.txt`, e.g. `- [Catalog](/docs/admin/catalog.md)`.

## Notes

- Complementary to the `rehypeStripTierBadges` fix (branch `claude/keen-chaum-b4a4e4`), which cleans badge text out of headings **inside** the generated Markdown twins / `llms-full.txt`. The two changes touch different files and merge independently; both are needed for fully clean output.
- The patch works around an upstream design limitation (title extraction runs before `content.beforeDefaultRehypePlugins`); worth an upstream issue proposing post-pipeline title extraction or a custom title extractor option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)