### PR TITLE
docs: strip tier badges from llms-txt Markdown twins

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,6 +21,26 @@ function rehypeStripHashLinks() {
   return (tree) => walk(tree);
 }
 
+// Strip tier badges (the TiersList component, rendered as
+// `<div class="TiersList"><span class="Tier">…</span></div>`) from the
+// Markdown twins. They sit inside heading HTML, so without this the badge
+// labels concatenate into the heading text (e.g.
+// `# CatalogScaleEnterpriseSelf-Hosted`).
+function rehypeStripTierBadges() {
+  const isTierBadge = (node) =>
+    node.tagName === 'div' &&
+    Array.isArray(node.properties && node.properties.className) &&
+    node.properties.className.includes('TiersList');
+
+  const walk = (node) => {
+    if (!node.children) return;
+    node.children = node.children.filter((child) => !isTierBadge(child));
+    node.children.forEach(walk);
+  };
+
+  return (tree) => walk(tree);
+}
+
 // Docs origin and base path (also used for url/baseUrl in module.exports below).
 const SITE_URL = 'https://www.okteto.com';
 const BASE_URL = '/docs/';
@@ -408,7 +428,7 @@ module.exports = {
           includeVersionedDocs: false,
           enableMarkdownFiles: true,
           enableLlmsFullTxt: true,
-          beforeDefaultRehypePlugins: [rehypeStripHashLinks],
+          beforeDefaultRehypePlugins: [rehypeStripHashLinks, rehypeStripTierBadges],
           remarkPlugins: [remarkLlmsIndexPointer],
         },
       },


### PR DESCRIPTION
## What changed

The Markdown twins generated by `@signalwire/docusaurus-plugin-llms-txt` concatenated tier badge labels into headings. For example, `build/docs/admin/catalog.md` opened with `# CatalogScaleEnterpriseSelf-Hosted`. The badges come from the `TiersList` component, which renders inside the heading HTML.

This PR adds a `rehypeStripTierBadges` plugin in `docusaurus.config.js`. It removes the badge elements (`div.TiersList`) from the page HTML before it is converted to Markdown. It follows the same dependency-free pattern as the existing `rehypeStripHashLinks` plugin and is registered next to it in the llms-txt plugin's `beforeDefaultRehypePlugins`.

## Verification

I ran `yarn build` and compared the headings of all nine affected pages against the previous build output:

- Page-level headings are clean. `# CatalogScaleEnterpriseSelf-Hosted` is now `# Catalog`.
- Section-level badges are clean too. In `reference/okteto-cli.md`, `### analyticsPlatformOpen-Source` is now `### analytics`, and the same applies to `self-hosted/manage/air-gapped.md`.
- A grep across all generated twins and `llms-full.txt` finds no remaining concatenated badge text.
- Badges only ever appear inside headings, so no page body content was removed.

## Known limitation

Link titles in `llms.txt` itself still contain the badge text, for example `- [Catalog ScaleEnterpriseSelf-Hosted](/admin/catalog.md)`. The plugin extracts each page title from the first `h1` of the raw HTML before the configurable rehype pipeline runs, so no config-level plugin can clean it. That fix needs a patch to the plugin (or an upstream change) and is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
